### PR TITLE
fix: Add missing GetObjectCommand import

### DIFF
--- a/apps/api/src/services/storage.ts
+++ b/apps/api/src/services/storage.ts
@@ -4,7 +4,7 @@
  * @see sdd.md §1.6 External Integrations - Cloudflare R2
  */
 
-import { S3Client, PutObjectCommand, HeadObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, GetObjectCommand, HeadObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { env } from '../config/env.js';
 import { logger } from '../lib/logger.js';


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation error - `GetObjectCommand` was being used but not imported.

## Changes

```diff
-import { S3Client, PutObjectCommand, HeadObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, GetObjectCommand, HeadObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
```

## Context

This was causing the deploy-production workflow to fail at the typecheck step.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)