### PR TITLE
feat(auth): add /v1/auth/validate endpoint for API key validation

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -444,4 +444,29 @@ auth.get('/me', requireAuth(), async (c) => {
   });
 });
 
+/**
+ * GET /v1/auth/validate
+ * Validate API key or JWT token
+ * Used by Loa CLI constructs-auth.sh to verify credentials
+ * @see https://github.com/0xHoneyJar/loa/issues/77
+ */
+auth.get('/validate', requireAuth(), async (c) => {
+  const user = c.get('user');
+  const authMethod = c.get('authMethod');
+
+  // Note: API key lastUsedAt is already updated by requireAuth middleware
+  // No additional audit logging needed for validation checks
+
+  return c.json({
+    valid: true,
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      tier: user.tier,
+    },
+    auth_method: authMethod,
+  });
+});
+
 export { auth };


### PR DESCRIPTION
## Summary

Add `GET /v1/auth/validate` endpoint for validating API keys and JWT tokens. This endpoint is used by the Loa CLI's `constructs-auth.sh validate` command to verify credentials.

## Changes

- Added `/v1/auth/validate` endpoint to auth routes
- Uses existing `requireAuth()` middleware for authentication
- Returns validation status, user info, and authentication method

## Response Format

```json
{
  "valid": true,
  "user": {
    "id": "uuid",
    "email": "user@example.com",
    "name": "User Name",
    "tier": "free" | "pro" | "team" | "enterprise"
  },
  "auth_method": "jwt" | "api_key"
}
```

## Client Usage

```bash
# From Loa CLI (constructs-auth.sh)
curl -s -o /dev/null -w "%{http_code}" \
  -H "Authorization: Bearer sk_your_api_key" \
  "https://loa-constructs-api.fly.dev/v1/auth/validate"

# 200/204 = valid
# 401/403 = invalid/expired
```

## Related

- Closes 0xHoneyJar/loa#77 (Constructs multi-select UI)
- Related PR: 0xHoneyJar/loa#88 (Constructs CLI implementation)

## Test Plan

- [x] All existing tests pass (202 tests)
- [ ] Manual test with valid API key → returns 200 with user info
- [ ] Manual test with invalid API key → returns 401
- [ ] Manual test with expired API key → returns 401

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)