### PR TITLE
fix: change skill symlink separator from colon to hyphen

### DIFF
--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -292,8 +292,9 @@ symlink_pack_skills() {
         local skill_name
         skill_name=$(basename "$skill")
 
-        # Use pack:skill format for namespacing (e.g., observer:observing-users)
-        local namespaced_name="${pack_slug}:${skill_name}"
+        # Use pack-skill format for namespacing (e.g., observer-observing-users)
+        # Note: Colons break Claude Code's trigger registration, must use hyphens
+        local namespaced_name="${pack_slug}-${skill_name}"
         # Use absolute path for symlink target (handles custom LOA_CONSTRUCTS_DIR)
         local abs_skill_path="$abs_skills_source/$skill_name"
         local target_link="$claude_skills_dir/$namespaced_name"
@@ -321,8 +322,10 @@ unlink_pack_skills() {
     local pack_slug="$1"
     local claude_skills_dir=".claude/skills"
 
-    # Remove symlinks matching this pack's prefix
+    # Remove symlinks matching this pack's prefix (hyphen separator)
     if [[ -d "$claude_skills_dir" ]]; then
+        find "$claude_skills_dir" -maxdepth 1 -type l -name "${pack_slug}-*" -delete 2>/dev/null || true
+        # Also clean up old colon-separated symlinks from previous versions
         find "$claude_skills_dir" -maxdepth 1 -type l -name "${pack_slug}:*" -delete 2>/dev/null || true
     fi
 }


### PR DESCRIPTION
## Summary

- Changes skill symlink separator from colon (`:`) to hyphen (`-`) in `constructs-install.sh`
- Example: `observer:observing-users` → `observer-observing-users`
- Adds cleanup for both old colon-separated and new hyphen-separated symlinks during unlink

## Problem

Claude Code's skill schema requires names to match `^[a-z][a-z0-9-]+` - colons are not allowed. Skills installed with colon separators were not being recognized by Claude Code's trigger registration system, making commands like `/observe` unavailable.

## Root Cause

The original implementation used colons for namespacing pack skills (e.g., `observer:observing-users`), but this breaks Claude Code's skill discovery since colons are not valid in skill names.

## Solution

Changed the separator from `:` to `-` so symlinks like `observer-observing-users` are created instead. This complies with Claude Code's naming requirements.

## Test plan

- [ ] Reinstall a pack with `constructs-install.sh install <pack>`
- [ ] Verify symlinks use hyphen separator (e.g., `observer-observing-users`)
- [ ] Restart Claude Code
- [ ] Verify skill triggers (e.g., `/observe`) appear in available commands

## Related

- Closes #61 (pack skills not loading)
- Follow-up from PR #62 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)