### PR TITLE
feat(cycle-036): Constructs Network Distribution Layer — Phase 1

### DIFF
--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -1939,6 +1939,8 @@ do_sync_pack() {
 # =============================================================================
 
 # Show sync status for installed constructs
+# Makes O(2n) HTTP calls where n = installed packs (registry + hash per pack).
+# Acceptable for typical install counts (1-10 packs).
 # Args:
 #   $1 - Pack slug (optional — if empty, show all installed packs)
 do_status_pack() {
@@ -2154,7 +2156,9 @@ main() {
             do_link_commands "$2"
             ;;
         register)
-            # Delegate to standalone register script
+            # Delegate to standalone register script.
+            # exec replaces the current process (no fork overhead, no cleanup needed
+            # since dispatch has no active traps at this point).
             local register_script="$SCRIPT_DIR/constructs-register.sh"
             if [[ ! -x "$register_script" ]]; then
                 print_error "ERROR: constructs-register.sh not found or not executable"

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -903,6 +903,22 @@ do_install_pack_git() {
     return 0
 }
 
+# Compute Merkle-root content hash for an installed pack directory.
+# Uses compute_merkle_hash from constructs-lib.sh (same algorithm as API).
+# Excludes license and meta files from hash computation.
+# Args:
+#   $1 - Pack directory
+# Returns: sha256:... hash string
+compute_pack_hash() {
+    local pack_dir="$1"
+
+    if type compute_merkle_hash &>/dev/null; then
+        compute_merkle_hash "$pack_dir"
+    else
+        echo ""
+    fi
+}
+
 # Update pack metadata in .constructs-meta.json
 # Args:
 #   $1 - Pack slug
@@ -953,6 +969,10 @@ except: print('unknown')
         skills_json=$(find "$pack_dir/skills" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | jq -R -s 'split("\n") | map(select(length > 0))')
     fi
 
+    # Compute content hash for staleness detection
+    local content_hash=""
+    content_hash=$(compute_pack_hash "$pack_dir")
+
     # Ensure meta file exists
     init_registry_meta
 
@@ -966,6 +986,7 @@ except: print('unknown')
            --arg source_type "$source_type" \
            --arg git_url "$git_url" \
            --arg git_commit "$git_commit" \
+           --arg content_hash "$content_hash" \
            --argjson skills "$skills_json" \
            '.installed_packs[$slug] = {
                "version": $version,
@@ -975,6 +996,7 @@ except: print('unknown')
                "source_type": $source_type,
                "git_url": $git_url,
                "git_commit": $git_commit,
+               "content_hash": $content_hash,
                "skills": $skills
            }' "$meta_path" > "$tmp_file" && mv "$tmp_file" "$meta_path"
     else
@@ -982,12 +1004,14 @@ except: print('unknown')
            --arg version "$version" \
            --arg installed_at "$now" \
            --arg license_expires "$license_expires" \
+           --arg content_hash "$content_hash" \
            --argjson skills "$skills_json" \
            '.installed_packs[$slug] = {
                "version": $version,
                "installed_at": $installed_at,
                "registry": "default",
                "license_expires": $license_expires,
+               "content_hash": $content_hash,
                "skills": $skills
            }' "$meta_path" > "$tmp_file" && mv "$tmp_file" "$meta_path"
     fi
@@ -1992,11 +2016,12 @@ show_pack_status() {
     local registry_url="$3"
 
     # Read local data
-    local local_version local_installed_at local_source_type local_git_url
+    local local_version local_installed_at local_source_type local_git_url local_content_hash
     local_version=$(jq -r ".installed_packs[\"$slug\"].version // \"unknown\"" "$meta_path" 2>/dev/null)
     local_installed_at=$(jq -r ".installed_packs[\"$slug\"].installed_at // \"unknown\"" "$meta_path" 2>/dev/null)
     local_source_type=$(jq -r ".installed_packs[\"$slug\"].source_type // \"registry\"" "$meta_path" 2>/dev/null)
     local_git_url=$(jq -r ".installed_packs[\"$slug\"].git_url // \"\"" "$meta_path" 2>/dev/null)
+    local_content_hash=$(jq -r ".installed_packs[\"$slug\"].content_hash // \"\"" "$meta_path" 2>/dev/null)
 
     echo "Pack: $slug"
     echo "  Installed: $local_version ($local_installed_at)"
@@ -2032,6 +2057,9 @@ show_pack_status() {
     fi
 
     # Fetch content hash for divergence detection
+    # NOTE: O(2n) HTTP calls per pack — registry metadata + hash endpoint.
+    # Acceptable for CLI status; optimize if used in CI or batch contexts.
+    local registry_hash_value=""
     local hash_file
     hash_file=$(mktemp)
     chmod 600 "$hash_file"
@@ -2043,23 +2071,38 @@ show_pack_status() {
         -o "$hash_file" 2>/dev/null) || hash_code="000"
 
     if [[ "$hash_code" == "200" ]]; then
-        local registry_hash_value
         registry_hash_value=$(jq -r '.data.hash // ""' "$hash_file" 2>/dev/null)
-        if [[ -n "$registry_hash_value" ]]; then
-            echo "  Hash:      ${registry_hash_value:0:20}..."
-        fi
     fi
     rm -f "$hash_file"
 
-    # Version comparison
-    if [[ "$registry_version" != "unknown" && "$local_version" != "unknown" ]]; then
-        if [[ "$local_version" == "$registry_version" ]]; then
-            echo "  Status:    [SYNCED]"
+    # Combined version + content-hash status
+    if [[ -z "$local_content_hash" ]]; then
+        # No local hash — installed before hash tracking was added
+        if [[ "$registry_version" != "unknown" && "$local_version" != "unknown" ]]; then
+            if [[ "$local_version" == "$registry_version" ]]; then
+                echo "  Status:    [UNKNOWN] — reinstall to compute hash"
+            else
+                echo "  Status:    [BEHIND] — registry has $registry_version"
+            fi
         else
-            echo "  Status:    [BEHIND] — run /constructs sync $slug"
+            echo "  Status:    [UNKNOWN]"
+        fi
+    elif [[ -n "$registry_hash_value" ]]; then
+        # Both hashes available — compare
+        if [[ "$local_content_hash" == "$registry_hash_value" ]]; then
+            echo "  Status:    [SYNCED]"
+        elif [[ "$local_version" != "$registry_version" && "$registry_version" != "unknown" ]]; then
+            echo "  Status:    [BEHIND] — registry has $registry_version"
+        else
+            echo "  Status:    [DIVERGED] — local files modified"
         fi
     else
-        echo "  Status:    [UNKNOWN]"
+        # No registry hash — can't compare
+        if [[ "$local_version" == "$registry_version" && "$registry_version" != "unknown" ]]; then
+            echo "  Status:    [SYNCED] (version match, hash unavailable)"
+        else
+            echo "  Status:    [UNKNOWN]"
+        fi
     fi
 }
 

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -1833,6 +1833,235 @@ remove_construct_claude_md() {
 }
 
 # =============================================================================
+# Sync Subcommand
+# =============================================================================
+
+# Trigger server-side sync for a git-sourced construct
+# Args:
+#   $1 - Pack slug
+do_sync_pack() {
+    local pack_slug="$1"
+
+    print_status "$icon_valid" "Syncing construct: $pack_slug"
+
+    # Get authentication
+    local api_key
+    api_key=$(get_api_key)
+    if [[ -z "$api_key" ]]; then
+        print_error "ERROR: No API key found. Run /constructs auth setup"
+        return $EXIT_AUTH_ERROR
+    fi
+
+    local registry_url
+    registry_url=$(get_registry_url)
+
+    # SHELL-002: Use curl config file to avoid exposing API key in process list
+    local curl_config
+    curl_config=$(mktemp)
+    chmod 600 "$curl_config"
+    echo "header = \"Authorization: Bearer ${api_key}\"" > "$curl_config"
+
+    echo "  POST ${registry_url}/packs/${pack_slug}/sync"
+
+    local tmp_file
+    tmp_file=$(mktemp)
+    chmod 600 "$tmp_file"
+
+    local http_code
+    http_code=$(curl -s -w "%{http_code}" \
+        --config "$curl_config" \
+        --proto =https --tlsv1.2 --max-time 120 \
+        -X POST \
+        "${registry_url}/packs/${pack_slug}/sync" \
+        -o "$tmp_file" 2>/dev/null) || {
+        rm -f "$curl_config" "$tmp_file"
+        print_error "ERROR: Network error — could not reach registry"
+        return $EXIT_NETWORK_ERROR
+    }
+
+    rm -f "$curl_config"
+
+    case "$http_code" in
+        200)
+            local version commit files_synced
+            version=$(jq -r '.data.version // "unknown"' "$tmp_file" 2>/dev/null)
+            commit=$(jq -r '.data.commit // "unknown"' "$tmp_file" 2>/dev/null)
+            files_synced=$(jq -r '.data.files_synced // 0' "$tmp_file" 2>/dev/null)
+
+            echo ""
+            print_success "Sync complete: $pack_slug"
+            echo "  Version: $version"
+            echo "  Commit:  $commit"
+            echo "  Files:   $files_synced synced"
+
+            # Check if installed locally — suggest reinstall if version changed
+            local meta_path
+            meta_path=$(get_registry_meta_path)
+            if [[ -f "$meta_path" ]]; then
+                local local_version
+                local_version=$(jq -r ".installed_packs[\"$pack_slug\"].version // \"\"" "$meta_path" 2>/dev/null)
+                if [[ -n "$local_version" && "$local_version" != "$version" ]]; then
+                    echo ""
+                    echo "  Local install is at $local_version — run /constructs install $pack_slug to update"
+                fi
+            fi
+
+            rm -f "$tmp_file"
+            return $EXIT_SUCCESS
+            ;;
+        401|403)
+            print_error "ERROR: Authentication failed. Check your API key."
+            rm -f "$tmp_file"
+            return $EXIT_AUTH_ERROR
+            ;;
+        404)
+            print_error "ERROR: Pack '$pack_slug' not found or not git-sourced"
+            rm -f "$tmp_file"
+            return $EXIT_NOT_FOUND
+            ;;
+        429)
+            print_error "ERROR: Rate limited. Maximum 10 syncs per hour."
+            rm -f "$tmp_file"
+            return $EXIT_ERROR
+            ;;
+        *)
+            local error_msg
+            error_msg=$(jq -r '.error.message // "Unknown error"' "$tmp_file" 2>/dev/null)
+            print_error "ERROR: Sync failed (HTTP $http_code): $error_msg"
+            rm -f "$tmp_file"
+            return $EXIT_ERROR
+            ;;
+    esac
+}
+
+# =============================================================================
+# Status Subcommand
+# =============================================================================
+
+# Show sync status for installed constructs
+# Args:
+#   $1 - Pack slug (optional — if empty, show all installed packs)
+do_status_pack() {
+    local pack_slug="${1:-}"
+    local meta_path
+    meta_path=$(get_registry_meta_path)
+
+    if [[ ! -f "$meta_path" ]]; then
+        print_warning "No constructs installed. Run /constructs install <pack> first."
+        return $EXIT_SUCCESS
+    fi
+
+    local registry_url
+    registry_url=$(get_registry_url)
+
+    if [[ -n "$pack_slug" ]]; then
+        # Single pack status
+        show_pack_status "$pack_slug" "$meta_path" "$registry_url"
+    else
+        # All installed packs
+        local slugs
+        slugs=$(jq -r '.installed_packs | keys[]' "$meta_path" 2>/dev/null)
+        if [[ -z "$slugs" ]]; then
+            echo "No packs installed."
+            return $EXIT_SUCCESS
+        fi
+
+        echo "Construct Status"
+        echo "════════════════════════════════════════"
+        echo ""
+
+        while IFS= read -r slug; do
+            show_pack_status "$slug" "$meta_path" "$registry_url"
+            echo ""
+        done <<< "$slugs"
+    fi
+
+    return $EXIT_SUCCESS
+}
+
+# Show status for a single pack
+# Args:
+#   $1 - Pack slug
+#   $2 - Meta file path
+#   $3 - Registry URL
+show_pack_status() {
+    local slug="$1"
+    local meta_path="$2"
+    local registry_url="$3"
+
+    # Read local data
+    local local_version local_installed_at local_source_type local_git_url
+    local_version=$(jq -r ".installed_packs[\"$slug\"].version // \"unknown\"" "$meta_path" 2>/dev/null)
+    local_installed_at=$(jq -r ".installed_packs[\"$slug\"].installed_at // \"unknown\"" "$meta_path" 2>/dev/null)
+    local_source_type=$(jq -r ".installed_packs[\"$slug\"].source_type // \"registry\"" "$meta_path" 2>/dev/null)
+    local_git_url=$(jq -r ".installed_packs[\"$slug\"].git_url // \"\"" "$meta_path" 2>/dev/null)
+
+    echo "Pack: $slug"
+    echo "  Installed: $local_version ($local_installed_at)"
+
+    # Fetch registry data (non-blocking — graceful on failure)
+    local registry_version="unknown"
+    local registry_hash=""
+    local tmp_file
+    tmp_file=$(mktemp)
+    chmod 600 "$tmp_file"
+
+    local http_code
+    http_code=$(curl -s -w "%{http_code}" \
+        --proto =https --tlsv1.2 --max-time 10 \
+        "${registry_url}/constructs/${slug}" \
+        -o "$tmp_file" 2>/dev/null) || http_code="000"
+
+    if [[ "$http_code" == "200" ]]; then
+        registry_version=$(jq -r '.data.version // .data.latest_version.version // "unknown"' "$tmp_file" 2>/dev/null)
+        local registry_updated
+        registry_updated=$(jq -r '.data.updated_at // "unknown"' "$tmp_file" 2>/dev/null)
+        echo "  Registry:  $registry_version ($registry_updated)"
+    else
+        echo "  Registry:  [unavailable]"
+    fi
+    rm -f "$tmp_file"
+
+    # Source info
+    if [[ "$local_source_type" == "git" && -n "$local_git_url" ]]; then
+        echo "  Source:    git ($local_git_url)"
+    else
+        echo "  Source:    registry"
+    fi
+
+    # Fetch content hash for divergence detection
+    local hash_file
+    hash_file=$(mktemp)
+    chmod 600 "$hash_file"
+
+    local hash_code
+    hash_code=$(curl -s -w "%{http_code}" \
+        --proto =https --tlsv1.2 --max-time 10 \
+        "${registry_url}/packs/${slug}/hash" \
+        -o "$hash_file" 2>/dev/null) || hash_code="000"
+
+    if [[ "$hash_code" == "200" ]]; then
+        local registry_hash_value
+        registry_hash_value=$(jq -r '.data.hash // ""' "$hash_file" 2>/dev/null)
+        if [[ -n "$registry_hash_value" ]]; then
+            echo "  Hash:      ${registry_hash_value:0:20}..."
+        fi
+    fi
+    rm -f "$hash_file"
+
+    # Version comparison
+    if [[ "$registry_version" != "unknown" && "$local_version" != "unknown" ]]; then
+        if [[ "$local_version" == "$registry_version" ]]; then
+            echo "  Status:    [SYNCED]"
+        else
+            echo "  Status:    [BEHIND] — run /constructs sync $slug"
+        fi
+    else
+        echo "  Status:    [UNKNOWN]"
+    fi
+}
+
+# =============================================================================
 # Command Line Interface
 # =============================================================================
 
@@ -1845,7 +2074,11 @@ Commands:
     skill <vendor/slug>      Install a skill from the registry
     uninstall pack <slug>    Uninstall a pack
     uninstall skill <slug>   Uninstall a skill
+    upgrade <slug> [version] Upgrade a pack to latest or specified version
     link-commands <slug>     Re-link pack commands (use "all" for all packs)
+    register <slug> [opts]   Register a new construct (delegates to constructs-register.sh)
+    sync <slug>              Sync a git-sourced construct from registry
+    status [slug]            Show sync status for installed constructs
 
 Exit Codes:
     0 = success
@@ -1919,6 +2152,23 @@ main() {
         link-commands)
             [[ -n "${2:-}" ]] || { print_error "ERROR: Missing pack slug (or 'all')"; exit $EXIT_ERROR; }
             do_link_commands "$2"
+            ;;
+        register)
+            # Delegate to standalone register script
+            local register_script="$SCRIPT_DIR/constructs-register.sh"
+            if [[ ! -x "$register_script" ]]; then
+                print_error "ERROR: constructs-register.sh not found or not executable"
+                exit $EXIT_ERROR
+            fi
+            shift  # Remove 'register' from args
+            exec "$register_script" "$@"
+            ;;
+        sync)
+            [[ -n "${2:-}" ]] || { print_error "ERROR: Missing pack slug"; exit $EXIT_ERROR; }
+            do_sync_pack "$2"
+            ;;
+        status)
+            do_status_pack "${2:-}"
             ;;
         -h|--help|help)
             show_usage

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -378,6 +378,45 @@ unlink_pack_skills() {
 }
 
 # =============================================================================
+# Post-Install Hooks
+# =============================================================================
+
+# Execute post-install hook if declared in manifest.
+# Security: path traversal prevention via realpath comparison.
+# Non-blocking: hook failure emits warning, does not fail installation.
+# Args:
+#   $1 - Pack directory path
+execute_post_install_hook() {
+    local pack_dir="$1"
+    local manifest="${pack_dir}/construct.yaml"
+    [[ -f "$manifest" ]] || return 0
+
+    if ! type safe_yq &>/dev/null 2>&1; then return 0; fi
+
+    local hook_script
+    hook_script=$(safe_yq '.hooks.post_install' "$manifest" 2>/dev/null) || return 0
+    [[ -z "$hook_script" || "$hook_script" == "null" ]] && return 0
+
+    local script_path="${pack_dir}/${hook_script}"
+
+    # Security: validate script is within pack directory (path traversal prevention)
+    local real_script real_pack
+    real_script=$(realpath "$script_path" 2>/dev/null) || return 0
+    real_pack=$(realpath "$pack_dir" 2>/dev/null) || return 0
+    if [[ "$real_script" != "$real_pack"* ]]; then
+        echo "  ⚠ Post-install hook path traversal blocked: $hook_script" >&2
+        return 0
+    fi
+
+    if [[ -f "$script_path" && -x "$script_path" ]]; then
+        echo "  Running post-install hook..."
+        if ! (cd "$pack_dir" && timeout 30 "$script_path" 2>&1); then
+            echo "  ⚠ Post-install hook failed (non-blocking)" >&2
+        fi
+    fi
+}
+
+# =============================================================================
 # Pack Installation
 # =============================================================================
 
@@ -514,6 +553,9 @@ do_install_pack() {
                 local skills_linked
                 skills_linked=$(symlink_pack_skills "$pack_slug")
                 echo "  Created $skills_linked skill symlinks"
+
+                # Execute post-install hook if declared
+                execute_post_install_hook "$pack_dir"
 
                 echo "  Validating license..."
                 local validator="$SCRIPT_DIR/constructs-loader.sh"
@@ -691,6 +733,9 @@ PYEOF
     local skills_linked
     skills_linked=$(symlink_pack_skills "$pack_slug")
     echo "  Created $skills_linked skill symlinks"
+
+    # Execute post-install hook if declared
+    execute_post_install_hook "$pack_dir"
 
     # Validate pack license
     echo "  Validating license..."

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -391,7 +391,7 @@ execute_post_install_hook() {
     local manifest="${pack_dir}/construct.yaml"
     [[ -f "$manifest" ]] || return 0
 
-    if ! type safe_yq &>/dev/null 2>&1; then return 0; fi
+    if ! type safe_yq &>/dev/null; then return 0; fi
 
     local hook_script
     hook_script=$(safe_yq '.hooks.post_install' "$manifest" 2>/dev/null) || return 0

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -912,7 +912,7 @@ do_install_pack_git() {
 compute_pack_hash() {
     local pack_dir="$1"
 
-    if type compute_merkle_hash &>/dev/null; then
+    if command -v compute_merkle_hash &>/dev/null; then
         compute_merkle_hash "$pack_dir"
     else
         echo ""
@@ -970,8 +970,13 @@ except: print('unknown')
     fi
 
     # Compute content hash for staleness detection
-    local content_hash=""
-    content_hash=$(compute_pack_hash "$pack_dir")
+    # Convention: null = not computed, string = computed hash
+    local content_hash_raw=""
+    content_hash_raw=$(compute_pack_hash "$pack_dir")
+    local content_hash_json="null"
+    if [[ -n "$content_hash_raw" ]]; then
+        content_hash_json="\"$content_hash_raw\""
+    fi
 
     # Ensure meta file exists
     init_registry_meta
@@ -986,7 +991,7 @@ except: print('unknown')
            --arg source_type "$source_type" \
            --arg git_url "$git_url" \
            --arg git_commit "$git_commit" \
-           --arg content_hash "$content_hash" \
+           --argjson content_hash "$content_hash_json" \
            --argjson skills "$skills_json" \
            '.installed_packs[$slug] = {
                "version": $version,
@@ -1004,7 +1009,7 @@ except: print('unknown')
            --arg version "$version" \
            --arg installed_at "$now" \
            --arg license_expires "$license_expires" \
-           --arg content_hash "$content_hash" \
+           --argjson content_hash "$content_hash_json" \
            --argjson skills "$skills_json" \
            '.installed_packs[$slug] = {
                "version": $version,

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -400,18 +400,40 @@ execute_post_install_hook() {
     local script_path="${pack_dir}/${hook_script}"
 
     # Security: validate script is within pack directory (path traversal prevention)
+    # Trailing slash prevents sibling-path bypass (e.g., /packs/foo matching /packs/foobar)
     local real_script real_pack
-    real_script=$(realpath "$script_path" 2>/dev/null) || return 0
-    real_pack=$(realpath "$pack_dir" 2>/dev/null) || return 0
+    if command -v realpath &>/dev/null; then
+        real_script=$(realpath "$script_path" 2>/dev/null) || return 0
+        real_pack=$(realpath "$pack_dir" 2>/dev/null) || return 0
+    elif command -v python3 &>/dev/null; then
+        real_script=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$script_path" 2>/dev/null) || return 0
+        real_pack=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$pack_dir" 2>/dev/null) || return 0
+    else
+        return 0
+    fi
+    real_pack="${real_pack%/}/"
     if [[ "$real_script" != "$real_pack"* ]]; then
         echo "  ⚠ Post-install hook path traversal blocked: $hook_script" >&2
         return 0
     fi
 
+    # Portable timeout: prefer timeout, fall back to gtimeout (macOS), then direct exec
+    local timeout_cmd=""
+    if command -v timeout &>/dev/null; then
+        timeout_cmd="timeout"
+    elif command -v gtimeout &>/dev/null; then
+        timeout_cmd="gtimeout"
+    fi
+
     if [[ -f "$script_path" && -x "$script_path" ]]; then
-        echo "  Running post-install hook..."
-        if ! (cd "$pack_dir" && timeout 30 "$script_path" 2>&1); then
-            echo "  ⚠ Post-install hook failed (non-blocking)" >&2
+        if [[ -n "$timeout_cmd" ]]; then
+            echo "  Running post-install hook..."
+            if ! (cd "$pack_dir" && "$timeout_cmd" 30 "$script_path" 2>&1); then
+                echo "  ⚠ Post-install hook failed (non-blocking)" >&2
+            fi
+        else
+            # No timeout utility → skip execution (untrusted hooks must be bounded)
+            echo "  ⚠ Post-install hook skipped: timeout utility not available (requires timeout or gtimeout)" >&2
         fi
     fi
 }
@@ -1888,7 +1910,14 @@ do_sync_pack() {
     local curl_config
     curl_config=$(mktemp)
     chmod 600 "$curl_config"
-    echo "header = \"Authorization: Bearer ${api_key}\"" > "$curl_config"
+
+    # Prevent curl config injection via CR/LF or quote characters in API key
+    if [[ "$api_key" == *$'\n'* || "$api_key" == *$'\r'* || "$api_key" == *'"'* ]]; then
+        print_error "Invalid API key format"
+        rm -f "$curl_config"
+        return $EXIT_AUTH_ERROR
+    fi
+    printf 'header = "Authorization: Bearer %s"\n' "$api_key" > "$curl_config"
 
     echo "  POST ${registry_url}/packs/${pack_slug}/sync"
 

--- a/.claude/scripts/constructs-register.sh
+++ b/.claude/scripts/constructs-register.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Loa Constructs - Registration Script
+# =============================================================================
+# Register a new construct on the Loa Constructs Registry.
+#
+# Usage:
+#   constructs-register.sh <slug> --git-url <url> [--name "Name"] [--git-ref <ref>]
+#
+# Exit Codes:
+#   0 = success
+#   1 = authentication error
+#   2 = network error
+#   3 = not found
+#   5 = validation error
+#   6 = general error
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared library
+if [[ -f "$SCRIPT_DIR/constructs-lib.sh" ]]; then
+    source "$SCRIPT_DIR/constructs-lib.sh"
+else
+    echo "ERROR: constructs-lib.sh not found" >&2
+    exit 6
+fi
+
+# Exit codes
+EXIT_SUCCESS=0
+EXIT_AUTH_ERROR=1
+EXIT_NETWORK_ERROR=2
+EXIT_VALIDATION_ERROR=5
+EXIT_ERROR=6
+
+# =============================================================================
+# Argument Parsing
+# =============================================================================
+
+show_usage() {
+    cat << 'EOF'
+Usage: constructs-register.sh <slug> --git-url <url> [options]
+
+Register a new construct from a git repository.
+
+Arguments:
+    <slug>                  Construct slug (lowercase, hyphens, 3-100 chars)
+
+Options:
+    --git-url <url>         Git repository URL (required, HTTPS only)
+    --name "Display Name"   Display name (defaults to slug)
+    --git-ref <ref>         Git branch/tag (default: main)
+    -h, --help              Show this help
+
+Examples:
+    constructs-register.sh my-construct --git-url https://github.com/org/construct-my-construct.git
+    constructs-register.sh my-pack --git-url https://github.com/org/construct-my-pack.git --name "My Pack"
+EOF
+}
+
+parse_args() {
+    SLUG=""
+    GIT_URL=""
+    NAME=""
+    GIT_REF="main"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --git-url)
+                [[ -n "${2:-}" ]] || { echo "ERROR: --git-url requires a value" >&2; exit $EXIT_VALIDATION_ERROR; }
+                GIT_URL="$2"
+                shift 2
+                ;;
+            --name)
+                [[ -n "${2:-}" ]] || { echo "ERROR: --name requires a value" >&2; exit $EXIT_VALIDATION_ERROR; }
+                NAME="$2"
+                shift 2
+                ;;
+            --git-ref)
+                [[ -n "${2:-}" ]] || { echo "ERROR: --git-ref requires a value" >&2; exit $EXIT_VALIDATION_ERROR; }
+                GIT_REF="$2"
+                shift 2
+                ;;
+            -h|--help)
+                show_usage
+                exit $EXIT_SUCCESS
+                ;;
+            -*)
+                echo "ERROR: Unknown option: $1" >&2
+                show_usage
+                exit $EXIT_VALIDATION_ERROR
+                ;;
+            *)
+                if [[ -z "$SLUG" ]]; then
+                    SLUG="$1"
+                else
+                    echo "ERROR: Unexpected argument: $1" >&2
+                    exit $EXIT_VALIDATION_ERROR
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    # Validate required args
+    if [[ -z "$SLUG" ]]; then
+        echo "ERROR: Missing construct slug" >&2
+        show_usage
+        exit $EXIT_VALIDATION_ERROR
+    fi
+
+    if [[ -z "$GIT_URL" ]]; then
+        echo "ERROR: --git-url is required" >&2
+        show_usage
+        exit $EXIT_VALIDATION_ERROR
+    fi
+
+    # Default name to slug
+    [[ -z "$NAME" ]] && NAME="$SLUG"
+}
+
+# =============================================================================
+# Registration
+# =============================================================================
+
+register_construct() {
+    local slug="$SLUG"
+    local git_url="$GIT_URL"
+    local name="$NAME"
+    local git_ref="$GIT_REF"
+
+    # Validate slug format
+    if type validate_safe_identifier &>/dev/null; then
+        validate_safe_identifier "$slug" || {
+            echo "ERROR: Invalid slug format. Must be lowercase alphanumeric with hyphens." >&2
+            exit $EXIT_VALIDATION_ERROR
+        }
+    fi
+
+    # Validate URL format
+    if type validate_url &>/dev/null; then
+        validate_url "$git_url" || {
+            echo "ERROR: Invalid URL format. Must be HTTPS." >&2
+            exit $EXIT_VALIDATION_ERROR
+        }
+    fi
+
+    # Resolve API key
+    local api_key
+    api_key=$(get_api_key 2>/dev/null) || true
+    if [[ -z "$api_key" ]]; then
+        echo "ERROR: No API key found. Run /constructs auth setup" >&2
+        exit $EXIT_AUTH_ERROR
+    fi
+
+    # Build request body
+    local body
+    body=$(jq -n \
+        --arg slug "$slug" \
+        --arg name "$name" \
+        --arg git_url "$git_url" \
+        --arg git_ref "$git_ref" \
+        '{slug: $slug, name: $name, git_url: $git_url, git_ref: $git_ref}')
+
+    # Resolve registry URL
+    local registry_url
+    registry_url=$(get_registry_url)
+
+    # SHELL-002: Use curl config file to avoid exposing API key in process list
+    local curl_config
+    curl_config=$(mktemp)
+    chmod 600 "$curl_config"
+    echo "header = \"Authorization: Bearer ${api_key}\"" > "$curl_config"
+
+    echo "Registering construct: $slug"
+    echo "  Repository: $git_url ($git_ref)"
+    echo ""
+
+    local tmp_file
+    tmp_file=$(mktemp)
+    chmod 600 "$tmp_file"
+
+    local http_code
+    http_code=$(curl -s -w "%{http_code}" \
+        --config "$curl_config" \
+        --proto =https --tlsv1.2 --max-time 120 \
+        -H "Content-Type: application/json" \
+        -d "$body" \
+        "${registry_url}/constructs/register" \
+        -o "$tmp_file" 2>/dev/null) || {
+        rm -f "$curl_config" "$tmp_file"
+        echo "ERROR: Network error — could not reach registry" >&2
+        exit $EXIT_NETWORK_ERROR
+    }
+
+    rm -f "$curl_config"
+
+    # Handle response
+    case "$http_code" in
+        201)
+            local status source_type next_step
+            status=$(jq -r '.data.status // "unknown"' "$tmp_file" 2>/dev/null)
+            source_type=$(jq -r '.data.source_type // empty' "$tmp_file" 2>/dev/null)
+            next_step=$(jq -r '.data.next_step // empty' "$tmp_file" 2>/dev/null)
+
+            echo "  Registered: $slug (status: $status)"
+            [[ -n "$source_type" ]] && echo "  Source: $source_type ($git_url)"
+            echo ""
+            if [[ -n "$next_step" ]]; then
+                echo "  Next: $next_step"
+            fi
+            echo "  To populate initial version: /constructs sync $slug"
+
+            rm -f "$tmp_file"
+            return $EXIT_SUCCESS
+            ;;
+        401|403)
+            echo "ERROR: Authentication failed. Check your API key." >&2
+            rm -f "$tmp_file"
+            exit $EXIT_AUTH_ERROR
+            ;;
+        409)
+            local error_msg
+            error_msg=$(jq -r '.error.message // "Slug already taken"' "$tmp_file" 2>/dev/null)
+            echo "ERROR: $error_msg" >&2
+            rm -f "$tmp_file"
+            exit $EXIT_VALIDATION_ERROR
+            ;;
+        422)
+            local error_msg
+            error_msg=$(jq -r '.error.message // "Validation failed"' "$tmp_file" 2>/dev/null)
+            echo "ERROR: $error_msg" >&2
+            rm -f "$tmp_file"
+            exit $EXIT_VALIDATION_ERROR
+            ;;
+        429)
+            echo "ERROR: Rate limited. Maximum 5 registrations per 24 hours." >&2
+            rm -f "$tmp_file"
+            exit $EXIT_ERROR
+            ;;
+        *)
+            local error_msg
+            error_msg=$(jq -r '.error.message // "Unknown error"' "$tmp_file" 2>/dev/null)
+            echo "ERROR: Registration failed (HTTP $http_code): $error_msg" >&2
+            rm -f "$tmp_file"
+            exit $EXIT_ERROR
+            ;;
+    esac
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+parse_args "$@"
+register_construct

--- a/.claude/scripts/constructs-register.sh
+++ b/.claude/scripts/constructs-register.sh
@@ -172,7 +172,14 @@ register_construct() {
     local curl_config
     curl_config=$(mktemp)
     chmod 600 "$curl_config"
-    echo "header = \"Authorization: Bearer ${api_key}\"" > "$curl_config"
+
+    # Prevent curl config injection via CR/LF or quote characters in API key
+    if [[ "$api_key" == *$'\n'* || "$api_key" == *$'\r'* || "$api_key" == *'"'* ]]; then
+        print_error "Invalid API key format"
+        rm -f "$curl_config"
+        exit $EXIT_AUTH_ERROR
+    fi
+    printf 'header = "Authorization: Bearer %s"\n' "$api_key" > "$curl_config"
 
     echo "Registering construct: $slug"
     echo "  Repository: $git_url ($git_ref)"

--- a/.claude/scripts/golden-path.sh
+++ b/.claude/scripts/golden-path.sh
@@ -359,10 +359,12 @@ golden_detect_construct_journeys() {
         while IFS= read -r cmd_name; do
             [[ -z "$cmd_name" ]] && continue
 
-            # Check truename_map for current state match
+            # Check if this command's truename_map has an entry for the current state.
+            # If so, this command represents the user's current position in the journey.
             local is_current=false
             if [[ -n "$current_state" ]]; then
                 local mapped
+                # Look up truename for current state in this command's truename_map
                 mapped=$(echo "$commands_json" | jq -r \
                     --arg name "$cmd_name" --arg state "$current_state" \
                     '.[] | select(.name == $name) | .truename_map[$state] // empty' \

--- a/.claude/scripts/golden-path.sh
+++ b/.claude/scripts/golden-path.sh
@@ -318,6 +318,7 @@ golden_format_journey() {
 }
 
 # Detect installed construct packs with golden_path declarations.
+# Executes detect_state scripts (5s timeout) and shows ● position markers.
 # Returns formatted journey bars or empty string.
 golden_detect_construct_journeys() {
     local packs_dir="${PROJECT_ROOT}/.claude/constructs/packs"
@@ -328,9 +329,10 @@ golden_detect_construct_journeys() {
         return 0
     fi
 
-    local manifest pack_name commands_json bar output=""
+    local manifest pack_dir pack_name commands_json bar output=""
     for manifest in "$packs_dir"/*/construct.yaml "$packs_dir"/*/construct.yml; do
         [[ -f "$manifest" ]] || continue
+        pack_dir="$(dirname "$manifest")"
 
         # Extract golden_path.commands via yq→jq pipeline
         commands_json=$(safe_yq_to_json "$manifest" 2>/dev/null | jq -c '.golden_path.commands // empty' 2>/dev/null) || continue
@@ -340,16 +342,42 @@ golden_detect_construct_journeys() {
         pack_name=$(safe_yq '.name' "$manifest" 2>/dev/null) || continue
         [[ -z "$pack_name" ]] && continue
 
-        # Build journey bar from command names
+        # Execute detect_state script if declared (5s timeout, silent fallback)
+        local current_state=""
+        local detect_script
+        detect_script=$(safe_yq '.golden_path.detect_state' "$manifest" 2>/dev/null) || true
+        if [[ -n "$detect_script" && "$detect_script" != "null" ]]; then
+            local script_path="${pack_dir}/${detect_script}"
+            if [[ -f "$script_path" && -x "$script_path" ]]; then
+                current_state=$(cd "$pack_dir" && timeout 5 "$script_path" 2>/dev/null) || true
+            fi
+        fi
+
+        # Build journey bar from command names with position detection
         bar=""
         local first=true
         while IFS= read -r cmd_name; do
             [[ -z "$cmd_name" ]] && continue
+
+            # Check truename_map for current state match
+            local is_current=false
+            if [[ -n "$current_state" ]]; then
+                local mapped
+                mapped=$(echo "$commands_json" | jq -r \
+                    --arg name "$cmd_name" --arg state "$current_state" \
+                    '.[] | select(.name == $name) | .truename_map[$state] // empty' \
+                    2>/dev/null) || true
+                [[ -n "$mapped" ]] && is_current=true
+            fi
+
+            local segment="/$cmd_name"
+            $is_current && segment="/$cmd_name ●"
+
             if $first; then
-                bar="/$cmd_name"
+                bar="$segment"
                 first=false
             else
-                bar="$bar ━━━━━ /$cmd_name"
+                bar="$bar ━━━ $segment"
             fi
         done < <(echo "$commands_json" | jq -r '.[].name' 2>/dev/null)
 

--- a/.claude/scripts/golden-path.sh
+++ b/.claude/scripts/golden-path.sh
@@ -348,8 +348,29 @@ golden_detect_construct_journeys() {
         detect_script=$(safe_yq '.golden_path.detect_state' "$manifest" 2>/dev/null) || true
         if [[ -n "$detect_script" && "$detect_script" != "null" ]]; then
             local script_path="${pack_dir}/${detect_script}"
-            if [[ -f "$script_path" && -x "$script_path" ]]; then
-                current_state=$(cd "$pack_dir" && timeout 5 "$script_path" 2>/dev/null) || true
+
+            # Path traversal containment — resolve and enforce within pack_dir
+            local real_script="" real_pack_dir=""
+            if command -v realpath &>/dev/null; then
+                real_script=$(realpath "$script_path" 2>/dev/null) || real_script=""
+                real_pack_dir=$(realpath "$pack_dir" 2>/dev/null) || real_pack_dir=""
+            elif command -v python3 &>/dev/null; then
+                real_script=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$script_path" 2>/dev/null) || real_script=""
+                real_pack_dir=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$pack_dir" 2>/dev/null) || real_pack_dir=""
+            fi
+            real_pack_dir="${real_pack_dir%/}/"
+
+            if [[ -n "$real_script" && -n "$real_pack_dir" && "$real_script" == "$real_pack_dir"* && -f "$real_script" && -x "$real_script" ]]; then
+                local timeout_cmd=""
+                if command -v timeout &>/dev/null; then
+                    timeout_cmd="timeout"
+                elif command -v gtimeout &>/dev/null; then
+                    timeout_cmd="gtimeout"
+                fi
+                if [[ -n "$timeout_cmd" ]]; then
+                    current_state=$(cd "$pack_dir" && "$timeout_cmd" 5 "$real_script" 2>/dev/null) || true
+                fi
+                # No timeout utility → skip execution (untrusted scripts must be bounded)
             fi
         fi
 

--- a/.claude/scripts/validate-skills.sh
+++ b/.claude/scripts/validate-skills.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 SKILLS_DIR="$PROJECT_ROOT/.claude/skills"
+PACKS_DIR="$PROJECT_ROOT/.claude/constructs/packs"
 SCHEMA_FILE="$PROJECT_ROOT/.claude/schemas/skill-index.schema.json"
 
 # Source safe yq library
@@ -20,6 +21,130 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
+
+# Parse flags
+STANDALONE_MODE=false
+for arg in "$@"; do
+    case "$arg" in
+        --standalone) STANDALONE_MODE=true ;;
+    esac
+done
+
+# --- Standalone Audit Mode ---
+if [[ "$STANDALONE_MODE" == "true" ]]; then
+    echo "STANDALONE AUDIT"
+    echo "================"
+    echo ""
+
+    sa_total=0
+    sa_pass=0
+    sa_warn=0
+    sa_fail=0
+    context_warnings=()
+    grimoire_warnings=()
+
+    # Scan all pack skills
+    for pack_dir in "$PACKS_DIR"/*/; do
+        [[ -d "$pack_dir" ]] || continue
+        pack_name=$(basename "$pack_dir")
+
+        for skill_dir in "$pack_dir"/skills/*/; do
+            [[ -d "$skill_dir" ]] || continue
+            skill_name=$(basename "$skill_dir")
+            skill_md="$skill_dir/SKILL.md"
+
+            [[ -f "$skill_md" ]] || continue
+            ((sa_total++))
+
+            skill_label="$pack_name/$skill_name"
+            issues=()
+
+            # Check 1: {context:...} slots without "Required context" header
+            if grep -q '{context:' "$skill_md" 2>/dev/null; then
+                if ! grep -qi 'required context' "$skill_md" 2>/dev/null; then
+                    issues+=("context slot without Required Context header")
+                    context_warnings+=("  - $skill_label: has {context:} slots but no Required Context documentation")
+                fi
+            fi
+
+            # Check 2: Hard reads from grimoires/ without guards
+            if grep -q 'grimoires/' "$skill_md" 2>/dev/null; then
+                # Check if references are in optional/output context (acceptable) vs hard deps
+                grimoire_refs=$(grep -c 'grimoires/' "$skill_md" 2>/dev/null || echo "0")
+                has_guard=$(grep -ci 'if.*exist\|optional\|when available\|if present' "$skill_md" 2>/dev/null || echo "0")
+                if [[ "$grimoire_refs" -gt 0 && "$has_guard" -eq 0 ]]; then
+                    grimoire_warnings+=("  - $skill_label: $grimoire_refs grimoire ref(s) without guards")
+                fi
+            fi
+
+            # Check 3: Pack-level file references as runtime deps
+            if grep -qE '(persona\.yaml|construct\.yaml)' "$skill_md" 2>/dev/null; then
+                if grep -qE 'read|load|parse|require.*\.(persona|construct)\.yaml' "$skill_md" 2>/dev/null; then
+                    issues+=("runtime dependency on pack-level manifest")
+                fi
+            fi
+
+            if [[ ${#issues[@]} -eq 0 ]]; then
+                ((sa_pass++))
+            else
+                ((sa_warn++))
+                echo -e "${YELLOW}WARN${NC}: $skill_label"
+                for issue in "${issues[@]}"; do
+                    echo "       - $issue"
+                done
+            fi
+        done
+    done
+
+    # Also scan framework skills
+    for skill_dir in "$SKILLS_DIR"/*/; do
+        [[ -d "$skill_dir" ]] || continue
+        skill_name=$(basename "$skill_dir")
+        skill_md="$skill_dir/SKILL.md"
+
+        [[ -f "$skill_md" ]] || continue
+        ((sa_total++))
+
+        # Framework skills are expected to be standalone — just count
+        if grep -q '{context:' "$skill_md" 2>/dev/null; then
+            if ! grep -qi 'required context' "$skill_md" 2>/dev/null; then
+                ((sa_warn++))
+                context_warnings+=("  - (framework) $skill_name: has {context:} slots but no Required Context documentation")
+                continue
+            fi
+        fi
+        ((sa_pass++))
+    done
+
+    echo ""
+    echo "PASS: $sa_pass/$sa_total skills are fully standalone"
+
+    if [[ ${#context_warnings[@]} -gt 0 ]]; then
+        echo -e "${YELLOW}WARN${NC}: ${#context_warnings[@]} skill(s) have context slots needing defaults"
+        for w in "${context_warnings[@]}"; do
+            echo "$w"
+        done
+    fi
+
+    if [[ ${#grimoire_warnings[@]} -gt 0 ]]; then
+        echo ""
+        echo "INFO: ${#grimoire_warnings[@]} skill(s) reference grimoires/ (typically acceptable)"
+        for w in "${grimoire_warnings[@]}"; do
+            echo "$w"
+        done
+    fi
+
+    echo ""
+    if [[ $sa_warn -eq 0 ]]; then
+        echo -e "${GREEN}All skills are standalone-compatible!${NC}"
+        exit 0
+    else
+        echo -e "${YELLOW}$sa_warn skill(s) need attention for standalone compatibility${NC}"
+        exit 0  # Warnings don't fail the audit
+    fi
+fi
+
+# --- Standard Validation Mode ---
 
 # Counters
 total=0

--- a/.claude/skills/browsing-constructs/SKILL.md
+++ b/.claude/skills/browsing-constructs/SKILL.md
@@ -15,6 +15,9 @@ Provide a multi-select UI for browsing and installing packs from the Loa Constru
 - `/constructs uninstall <pack>` - Remove a pack
 - `/constructs auth` - Check authentication status
 - `/constructs auth setup` - Set up API key for premium packs
+- `/constructs register <slug> --git-url <url>` - Register a new construct from a git repo
+- `/constructs sync <slug>` - Sync a git-sourced construct from registry
+- `/constructs status [slug]` - Show sync status for installed constructs
 
 ## Workflow
 
@@ -337,6 +340,42 @@ Remove installed pack:
 2. Run: `.claude/scripts/constructs-install.sh uninstall pack <pack>`
 3. Report result
 
+### Action: register <slug> --git-url <url>
+
+Register a new construct on the registry from a git repository.
+
+```bash
+.claude/scripts/constructs-install.sh register <slug> --git-url <url> [--name "Name"] [--git-ref <ref>]
+```
+
+Delegates to `constructs-register.sh`. Requires authentication.
+
+After registration, run `/constructs sync <slug>` to populate the initial version.
+
+### Action: sync <slug>
+
+Trigger a server-side sync for a git-sourced construct. Pulls latest from the linked git repository.
+
+```bash
+.claude/scripts/constructs-install.sh sync <slug>
+```
+
+Requires authentication (must be the construct owner).
+
+### Action: status [slug]
+
+Show sync status and version comparison for installed constructs.
+
+```bash
+# Single pack
+.claude/scripts/constructs-install.sh status <slug>
+
+# All installed packs
+.claude/scripts/constructs-install.sh status
+```
+
+Displays: installed version, registry version, source type, content hash, and sync status ([SYNCED], [BEHIND], [UNKNOWN]).
+
 ## Error Handling
 
 | Error | Handling |
@@ -405,7 +444,8 @@ Installation metadata tracked in `.constructs-meta.json`:
 
 - `.claude/scripts/constructs-auth.sh` - Authentication management
 - `.claude/scripts/constructs-browse.sh` - Pack discovery
-- `.claude/scripts/constructs-install.sh` - Installation
+- `.claude/scripts/constructs-install.sh` - Installation, sync, status dispatch
+- `.claude/scripts/constructs-register.sh` - Construct registration
 - `.claude/scripts/constructs-loader.sh` - Skill loading
 - `.claude/scripts/constructs-lib.sh` - Shared utilities
 

--- a/.claude/skills/browsing-constructs/index.yaml
+++ b/.claude/skills/browsing-constructs/index.yaml
@@ -14,13 +14,19 @@ triggers:
     description: "Browse available packs"
   - pattern: "/constructs install"
     description: "Install specific pack"
+  - pattern: "/constructs register"
+    description: "Register a new construct from a git repo"
+  - pattern: "/constructs sync"
+    description: "Sync a git-sourced construct from registry"
+  - pattern: "/constructs status"
+    description: "Show sync status for installed constructs"
 
 dependencies: []
 
 inputs:
   - name: action
     type: string
-    description: "Action to perform: browse, install, list, update, uninstall"
+    description: "Action to perform: browse, install, list, update, uninstall, register, sync, status"
     required: false
     default: "browse"
   - name: pack

--- a/.loa.config.yaml
+++ b/.loa.config.yaml
@@ -806,10 +806,9 @@ gpt_review:
   # Model selection
   models:
     # Model for document reviews (PRD, SDD, Sprint)
-    documents: "gpt-5.2"
+    documents: "gpt-5.3-codex"
     # Model for code reviews (uses Responses API)
-    # gpt-5.3-codex registered in model-adapter but not yet available via API
-    code: "gpt-5.2-codex"
+    code: "gpt-5.3-codex"
   # Per-phase toggles (only used when enabled: true)
   phases:
     prd: true

--- a/BUTTERFREEZONE.md
+++ b/BUTTERFREEZONE.md
@@ -1,24 +1,12 @@
 <!-- AGENT-CONTEXT
-name: loa
+name: loa-constructs
 type: framework
-purpose: Loa is an agent-driven development framework for [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) (Anthropic's official CLI).
-key_files: [CLAUDE.md, .claude/loa/CLAUDE.loa.md, .loa.config.yaml, .claude/scripts/, .claude/skills/]
+purpose: SaaS platform for distributing, licensing, and monetizing AI agent constructs
+key_files: [CLAUDE.md, .claude/loa/CLAUDE.loa.md, .loa.config.yaml, .claude/scripts/, .claude/skills/, package.json]
 interfaces:
   core: [/auditing-security, /autonomous-agent, /bridgebuilder-review, /browsing-constructs, /bug-triaging]
-dependencies: [git, jq, yq]
-ecosystem:
-  - repo: 0xHoneyJar/loa-finn
-    role: runtime
-    interface: hounfour-router
-    protocol: loa-hounfour@5.0.0
-  - repo: 0xHoneyJar/loa-hounfour
-    role: protocol
-    interface: npm-package
-    protocol: loa-hounfour@7.0.0
-  - repo: 0xHoneyJar/arrakis
-    role: distribution
-    interface: jwt-auth
-    protocol: loa-hounfour@7.0.0
+  project: [/creating-constructs, /finding-constructs, /linking-constructs, /publishing-constructs, /syncing-constructs]
+dependencies: [git, jq, yq, node]
 capability_requirements:
   - filesystem: read
   - filesystem: write (scope: state)
@@ -26,65 +14,60 @@ capability_requirements:
   - git: read_write
   - shell: execute
   - github_api: read_write (scope: external)
-version: v1.49.0
+version: v2.7.1
 installation_mode: unknown
 trust_level: L2-verified
 -->
 
-# loa
+# loa-constructs
 
 <!-- provenance: DERIVED -->
-Loa is an agent-driven development framework for [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) (Anthropic's official CLI).
+SaaS platform for distributing, licensing, and monetizing AI agent constructs
 
-The framework provides 29 specialized skills, built with TypeScript/JavaScript, Python, Shell.
-
-## Key Capabilities
-<!-- provenance: DERIVED -->
-The project exposes 15 key entry points across its public API surface.
-
-### .claude/adapters
-
-- **_build_provider_config** — Build ProviderConfig from merged hounfour config. (`.claude/adapters/cheval.py:152`)
-- **_check_feature_flags** — Check feature flags. (`.claude/adapters/cheval.py:192`)
-- **_error_json** — Format error as JSON for stderr (SDD §4.2.2 Error Taxonomy). (`.claude/adapters/cheval.py:77`)
-- **_load_persona** — Load persona.md for the given agent with optional system merge (SDD §4.3.2). (`.claude/adapters/cheval.py:96`)
-- **cmd_cancel** — Cancel a Deep Research interaction. (`.claude/adapters/cheval.py:511`)
-- **cmd_invoke** — Main invocation: resolve agent → call provider → return response. (`.claude/adapters/cheval.py:211`)
-- **cmd_poll** — Poll a Deep Research interaction. (`.claude/adapters/cheval.py:467`)
-- **cmd_print_config** — Print effective merged config with source annotations. (`.claude/adapters/cheval.py:442`)
-- **cmd_validate_bindings** — Validate all agent bindings. (`.claude/adapters/cheval.py:453`)
-- **main** — CLI entry point. (`.claude/adapters/cheval.py:547`)
-
-### .claude/adapters/loa_cheval/config
-
-- **LazyValue** — Deferred interpolation token. (`.claude/adapters/loa_cheval/config/interpolation.py:41`)
-- **_check_env_allowed** — Check if env var name is in the allowlist. (`.claude/adapters/loa_cheval/config/interpolation.py:122`)
-- **_check_file_allowed** — Validate and resolve a file path for secret reading. (`.claude/adapters/loa_cheval/config/interpolation.py:133`)
-- **_get_credential_provider** — Get the credential provider chain (lazily initialized, thread-safe). (`.claude/adapters/loa_cheval/config/interpolation.py:192`)
-- **_matches_lazy_path** — Check if a dotted config key path matches any lazy path pattern. (`.claude/adapters/loa_cheval/config/interpolation.py:275`)
+The framework provides 35 specialized skills, built with TypeScript/JavaScript, Python, Shell.
 
 ## Architecture
 <!-- provenance: DERIVED -->
-The architecture follows a three-zone model: System (`.claude/`) contains framework-managed scripts and skills, State (`grimoires/`, `.beads/`) holds project-specific artifacts and memory, and App (`src/`, `lib/`) contains developer-owned application code. The framework orchestrates 29 specialized skills through slash commands.
+The architecture follows a three-zone model: System (`.claude/`) contains framework-managed scripts and skills, State (`grimoires/`, `.beads/`) holds project-specific artifacts and memory, and App (`src/`, `lib/`) contains developer-owned application code. The framework orchestrates       35 specialized skills through slash commands.
 ```mermaid
 graph TD
+    api[api]
+    apps[apps]
+    audits[audits]
     docs[docs]
     evals[evals]
     grimoires[grimoires]
-    skills[skills]
-    tests[tests]
+    packages[packages]
+    packs[packs]
     Root[Project Root]
+    Root --> api
+    Root --> apps
+    Root --> audits
     Root --> docs
     Root --> evals
     Root --> grimoires
-    Root --> skills
-    Root --> tests
+    Root --> packages
+    Root --> packs
 ```
 Directory structure:
 ```
+./api
+./api/checkout
+./api/subscription
+./api/webhook
+./apps
+./apps/api
+./apps/explorer
+./audits
 ./docs
 ./docs/architecture
+./docs/archive
+./docs/guides
 ./docs/integration
+./docs/mockups
+./docs/schemas
+./docs/screenshots
+./docs/tutorials
 ./evals
 ./evals/baselines
 ./evals/fixtures
@@ -95,19 +78,9 @@ Directory structure:
 ./evals/tasks
 ./evals/tests
 ./grimoires
+./grimoires/artisan
+./grimoires/bridgebuilder
 ./grimoires/loa
-./grimoires/pub
-./skills
-./skills/legba
-./tests
-./tests/__pycache__
-./tests/e2e
-./tests/edge-cases
-./tests/fixtures
-./tests/helpers
-./tests/integration
-./tests/performance
-./tests/unit
 ```
 
 ## Interfaces
@@ -117,22 +90,22 @@ Directory structure:
 #### Loa Core
 
 - **/auditing-security** — Paranoid Cypherpunk Auditor
-- **/autonomous-agent** — Autonomous agent
+- **/autonomous-agent** — Uautonomous agent
 - **/bridgebuilder-review** — Bridgebuilder — Autonomous PR Review
 - **/browsing-constructs** — Provide a multi-select UI for browsing and installing packs from the Loa Constructs Registry. Enables composable skill installation per-repo.
 - **/bug-triaging** — Bug Triage Skill
 - **/butterfreezone-gen** — BUTTERFREEZONE Generation Skill
 - **/continuous-learning** — Continuous Learning Skill
-- **/deploying-infrastructure** — Deploying infrastructure
+- **/deploying-infrastructure** — Udeploying infrastructure
 - **/designing-architecture** — Architecture Designer
 - **/discovering-requirements** — Discovering Requirements
-- **/enhancing-prompts** — Enhancing prompts
-- **/eval-running** — Eval running
+- **/enhancing-prompts** — Uenhancing prompts
+- **/eval-running** — Ueval running
 - **/flatline-knowledge** — Provides optional NotebookLM integration for the Flatline Protocol, enabling external knowledge retrieval from curated AI-powered notebooks.
-- **/flatline-reviewer** — Flatline reviewer
-- **/flatline-scorer** — Flatline scorer
-- **/flatline-skeptic** — Flatline skeptic
-- **/gpt-reviewer** — Gpt reviewer
+- **/flatline-reviewer** — Uflatline reviewer
+- **/flatline-scorer** — Uflatline scorer
+- **/flatline-skeptic** — Uflatline skeptic
+- **/gpt-reviewer** — Ugpt reviewer
 - **/implementing-tasks** — Sprint Task Implementer
 - **/managing-credentials** — /loa-credentials — Credential Management
 - **/mounting-framework** — Create structure (preserve if exists)
@@ -142,25 +115,39 @@ Directory structure:
 - **/riding-codebase** — Riding Through the Codebase
 - **/rtfm-testing** — RTFM Testing Skill
 - **/run-bridge** — Run Bridge — Autonomous Excellence Loop
-- **/run-mode** — Run mode
+- **/run-mode** — Urun mode
 - **/simstim-workflow** — Check post-PR state
-- **/translating-for-executives** — Translating for executives
+- **/translating-for-executives** — Utranslating for executives
+#### Project-Specific
+
+- **/creating-constructs** — Scaffold new construct projects from templates. Supports three construct
+- **/finding-constructs** — Ufinding constructs
+- **/linking-constructs** — Link local construct repositories for live development. When a construct is linked,
+- **/publishing-constructs** — Publish constructs to the Loa Constructs Registry. Runs a 10-point validation
+- **/syncing-constructs** — Detect divergence between local constructs and their upstream registry versions.
+- **/upgrading-constructs** — Upgrade installed constructs to newer versions using 3-way merge. Uses the
 
 ## Module Map
 <!-- provenance: DERIVED -->
 | Module | Files | Purpose | Documentation |
 |--------|-------|---------|---------------|
-| `docs/` | 6 | Documentation | \u2014 |
-| `evals/` | 5818 | Benchmarking and regression framework for the Loa agent development system. Ensures framework changes don't degrade agent behavior through | [evals/README.md](evals/README.md) |
-| `grimoires/` | 1264 | Home to all grimoire directories for the Loa | [grimoires/README.md](grimoires/README.md) |
-| `skills/` | 5112 | Specialized agent skills | \u2014 |
-| `tests/` | 184 | Test suites | \u2014 |
+| `api/` | 3 | API endpoints | \u2014 |
+| `apps/` | 15967 | Uapps | \u2014 |
+| `audits/` | 1 | Uaudits | \u2014 |
+| `docs/` | 41 | Documentation | \u2014 |
+| `evals/` | 122 | Benchmarking and regression framework for the Loa agent development system. Ensures framework changes don't degrade agent behavior through | [evals/README.md](evals/README.md) |
+| `grimoires/` | 509 | Home to all grimoire directories for the Loa | [grimoires/README.md](grimoires/README.md) |
+| `packages/` | 90 | Upackages | \u2014 |
+| `packs/` | 1 | Upacks | \u2014 |
+| `scripts/` | 27 | Utility scripts | \u2014 |
+| `tests/` | 196 | Test suites | \u2014 |
 
 ## Verification
 <!-- provenance: CODE-FACTUAL -->
 - Trust Level: **L2 — CI Verified**
-- 184 test files across 1 suite
-- CI/CD: GitHub Actions (11 workflows)
+- 196 test files across 1 suite
+- CI/CD: GitHub Actions (10 workflows)
+- Linting: ESLint configured
 - Security: SECURITY.md present
 
 ## Agents
@@ -171,53 +158,37 @@ The project defines 1 specialized agent persona.
 |-------|----------|-------|
 | Bridgebuilder | You are the Bridgebuilder — a senior engineering mentor who has spent decades building systems at scale. | Your voice is warm, precise, and rich with analogy. |
 
-## Culture
+## Ecosystem
 <!-- provenance: OPERATIONAL -->
-**Naming**: Vodou terminology via Gibson's Sprawl trilogy (Loa, Grimoire, Hounfour, Cheval, Beauvoir) and direct cyberpunk concepts (Simstim, ICE, Flatline, Freeside, Finn) as narrative architecture — coherent memetic frameworks that help humans and agents form consistent mental models. Gibson adapted Vodou from anthropological sources (Tallant 1946, likely Deren 1953).
-
-**Principles**: Think Before Coding — plan and analyze before implementing, Simplicity First — minimum complexity for the current task, Surgical Changes — minimal diff, maximum impact, Goal-Driven — every action traces to acceptance criteria.
-
-**Methodology**: Agent-driven development with iterative excellence loops (Simstim, Run Bridge, Flatline Protocol).
-**Creative Methodology**: Creative methodology drawing from cyberpunk fiction, free jazz improvisation, and temporary autonomous zones.
-
-**Influences**: Neuromancer (Gibson) — Simstim as shared consciousness metaphor, Flatline Protocol — adversarial multi-model review as creative tension, TAZ (Hakim Bey) — temporary spaces for autonomous agent exploration.
-
-**Knowledge Production**: Knowledge production through collective inquiry — Flatline as multi-model study group.
+### Dependencies
+- `@types/node`
+- `next`
+- `prettier`
+- `react`
+- `react-dom`
+- `tsx`
+- `turbo`
+- `typescript`
 
 ## Quick Start
 <!-- provenance: OPERATIONAL -->
+Available commands:
 
-**Prerequisites**: [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) (Anthropic's CLI for Claude), Git, jq, [yq v4+](https://github.com/mikefarah/yq). See **[INSTALLATION.md](INSTALLATION.md)** for full details.
-
-```bash
-# Install (one command, any existing repo — adds Loa as git submodule)
-curl -fsSL https://raw.githubusercontent.com/0xHoneyJar/loa/main/.claude/scripts/mount-loa.sh | bash
-
-# Or pin to a specific version
-curl -fsSL https://raw.githubusercontent.com/0xHoneyJar/loa/main/.claude/scripts/mount-loa.sh | bash -s -- --tag v1.39.0
-
-# Start Claude Code
-claude
-
-# These are slash commands typed inside Claude Code, not your terminal.
-# 5 commands. Full development cycle.
-/plan      # Requirements -> Architecture -> Sprints
-/build     # Implement the current sprint
-/review    # Code review + security audit
-/ship      # Deploy and archive
-```
+- `npm run dev` — turbo
+- `npm run build` — turbo
+- `npm run test` — turbo
+- `npm run test:coverage` — turbo
 <!-- ground-truth-meta
-head_sha: 63b3f9661f969b40cc0fc53769abf01633381d0a
-generated_at: 2026-02-26T03:15:02Z
+head_sha: c50b8fc9342c33b862c5f96c694e6023cc30a320
+generated_at: 2026-02-27T22:09:38Z
 generator: butterfreezone-gen v1.0.0
 sections:
-  agent_context: 2181e030ad7c26375787c2779116509418c11f8dd4cd51c7cbd38d655dbcdf96
-  capabilities: ab2576b1f2e7e8141f0e93e807d26ed2b7b155e21c96d787507a3ba933bb9795
-  architecture: 970c0549aa208f3f8e0063176776b3fd52798e8d19011897a6a22e6542c2e772
-  interfaces: 120e3b3a6d65d4939b251dd049f213e32254a91510d48457be2e4f1b3f7399d3
-  module_map: bbd9aa487c3d9bc25f0ea9be3edc8608bd8c6b8f8925986118a2466f7fcfa91d
-  verification: e8f0acae1d298517bc6fde815119665738f3a60699984a9fa922a01004a89fdf
+  agent_context: 216200d644d33e7b245db3474bafbe79b45d3e06bfd0265b7cc6cb3ea082b87b
+  architecture: ffdfd8f14e40bdad179aae5c8587b22dc82e36eee2f0d0d1448a561cc5978b35
+  interfaces: 96a525cab8e1628033128a8048f8fa8814ca169f193b38c9364b6d71c6ea3180
+  module_map: 5d2857ede090eab63b7fe34ec2d49af27315d81f6e65bc288efe1f3ba05d6af5
+  verification: 6badfc40824e9dffb00087fff8fab9498900bf799490353bf7df676dc813cc41
   agents: ca263d1e05fd123434a21ef574fc8d76b559d22060719640a1f060527ef6a0b6
-  culture: f73380f93bb4fadf36ccc10d60fc57555914363fc90e4f15b4dc4eb92bd1640f
-  quick_start: cfc39883247017c36dd2e9c3f44459a761d8b9e278b85a54584164db643a95ab
+  ecosystem: 0d998700d4489ca2aec077a69004279a3c45c117b9fb5b37c9f85ad511187c7c
+  quick_start: 15f176d9343ca15a6b32f5134ba0eda33e96f69620f6495734a1f150548e337b
 -->

--- a/apps/api/src/routes/constructs.ts
+++ b/apps/api/src/routes/constructs.ts
@@ -341,7 +341,8 @@ constructsRouter.post(
       }
 
       // Shallow clone test — verify repo is accessible and has a manifest
-      const tmpDir = `/tmp/register-test-${randomUUID()}`;
+      const { tmpdir } = await import('node:os');
+      const tmpDir = `${tmpdir()}/register-test-${randomUUID()}`;
       try {
         await cloneRepo(body.git_url, body.git_ref, tmpDir);
         await readManifest(tmpDir);

--- a/apps/api/src/routes/constructs.ts
+++ b/apps/api/src/routes/constructs.ts
@@ -269,14 +269,22 @@ constructsRouter.post(
         .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/, 'Slug must be lowercase alphanumeric with hyphens'),
       name: z.string().min(1).max(255),
       type: z.enum(['skill-pack', 'tool-pack', 'codex', 'template']).optional(),
-      git_url: z.string().url().optional(),
+      git_url: z
+        .string()
+        .url()
+        .refine((u) => u.startsWith('https://'), 'Git URL must be HTTPS')
+        .optional(),
       git_ref: z.string().max(100).optional().default('main'),
     })
   ),
   async (c) => {
-    const userId = c.get('userId');
     const user = c.get('user');
+    const userId = user?.id ?? c.get('userId');
     const requestId = randomUUID();
+
+    if (!userId) {
+      throw Errors.Unauthorized('Authentication required to register constructs');
+    }
 
     // Require email verification (fix: use AuthUser from context, not cast hack)
     if (!user?.emailVerified) {
@@ -310,24 +318,7 @@ constructsRouter.post(
       throw new AppError('SLUG_TAKEN', `Slug '${body.slug}' is already taken`, 409);
     }
 
-    // Create the construct entry — DB unique constraint on slug prevents TOCTOU race
-    try {
-      await createPack({
-        name: body.name,
-        slug: body.slug,
-        description: body.type ? `A ${body.type} construct` : undefined,
-        constructType: body.type || 'skill-pack',
-        ownerId: userId,
-        ownerType: 'user',
-      });
-    } catch (err: unknown) {
-      if (err instanceof Error && err.message?.includes('unique')) {
-        throw new AppError('SLUG_TAKEN', `Slug '${body.slug}' is already taken`, 409);
-      }
-      throw err;
-    }
-
-    // If git_url provided, validate and link the repo (same pattern as register-repo endpoint)
+    // Preflight git repo BEFORE reserving slug to avoid orphaned registrations on 422
     if (body.git_url) {
       const { validateGitUrl, cloneRepo, readManifest, GitSyncError } = await import('../services/git-sync.js');
 
@@ -355,8 +346,27 @@ constructsRouter.post(
         const fs = await import('node:fs/promises');
         await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
       }
+    }
 
-      // Fetch pack to get the DB-assigned ID
+    // Create the construct entry — DB unique constraint on slug prevents TOCTOU race
+    try {
+      await createPack({
+        name: body.name,
+        slug: body.slug,
+        description: body.type ? `A ${body.type} construct` : undefined,
+        constructType: body.type || 'skill-pack',
+        ownerId: userId,
+        ownerType: 'user',
+      });
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message?.includes('unique')) {
+        throw new AppError('SLUG_TAKEN', `Slug '${body.slug}' is already taken`, 409);
+      }
+      throw err;
+    }
+
+    // Link git source after successful pack creation
+    if (body.git_url) {
       const pack = await getPackBySlug(body.slug);
       if (!pack) {
         throw Errors.NotFound('Pack creation failed');

--- a/apps/api/src/routes/constructs.ts
+++ b/apps/api/src/routes/constructs.ts
@@ -19,7 +19,9 @@ import {
   type Construct,
   type ConstructManifest,
 } from '../services/constructs.js';
-import { isSlugAvailable, createPack } from '../services/packs.js';
+import { isSlugAvailable, createPack, getPackBySlug } from '../services/packs.js';
+import { db, packs } from '../db/index.js';
+import { eq } from 'drizzle-orm';
 import { Errors, AppError } from '../lib/errors.js';
 import { logger } from '../lib/logger.js';
 import { getRedis, isRedisConfigured } from '../services/redis.js';
@@ -267,19 +269,21 @@ constructsRouter.post(
         .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/, 'Slug must be lowercase alphanumeric with hyphens'),
       name: z.string().min(1).max(255),
       type: z.enum(['skill-pack', 'tool-pack', 'codex', 'template']).optional(),
+      git_url: z.string().url().optional(),
+      git_ref: z.string().max(100).optional().default('main'),
     })
   ),
   async (c) => {
-    const userId = c.get('userId' as never) as string;
-    const userEmail = c.get('userEmail' as never) as string;
+    const userId = c.get('userId');
+    const user = c.get('user');
     const requestId = randomUUID();
 
-    // Require email verification
-    if (!userEmail) {
+    // Require email verification (fix: use AuthUser from context, not cast hack)
+    if (!user?.emailVerified) {
       throw Errors.Forbidden('Email verification required to register constructs');
     }
 
-    const body = c.req.valid('json' as never) as { slug: string; name: string; type?: string };
+    const body = c.req.valid('json');
 
     // Rate limit: 5 registrations per 24h
     if (isRedisConfigured()) {
@@ -323,13 +327,87 @@ constructsRouter.post(
       throw err;
     }
 
-    logger.info({ slug: body.slug, name: body.name, type: body.type, userId, requestId }, 'Construct registered');
+    // If git_url provided, validate and link the repo (same pattern as register-repo endpoint)
+    if (body.git_url) {
+      const { validateGitUrl, cloneRepo, readManifest, GitSyncError } = await import('../services/git-sync.js');
+
+      try {
+        await validateGitUrl(body.git_url);
+      } catch (err) {
+        if (err instanceof GitSyncError) {
+          throw Errors.BadRequest(`Invalid git URL: ${err.message}`);
+        }
+        throw err;
+      }
+
+      // Shallow clone test — verify repo is accessible and has a manifest
+      const tmpDir = `/tmp/register-test-${randomUUID()}`;
+      try {
+        await cloneRepo(body.git_url, body.git_ref, tmpDir);
+        await readManifest(tmpDir);
+      } catch (err) {
+        if (err instanceof GitSyncError) {
+          throw new AppError('UNPROCESSABLE_ENTITY', err.message, 422);
+        }
+        throw new AppError('UNPROCESSABLE_ENTITY', 'Repository unreachable or missing manifest', 422);
+      } finally {
+        const fs = await import('node:fs/promises');
+        await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      }
+
+      // Fetch pack to get the DB-assigned ID
+      const pack = await getPackBySlug(body.slug);
+      if (!pack) {
+        throw Errors.NotFound('Pack creation failed');
+      }
+
+      // Fetch github_repo_id (non-fatal)
+      let githubRepoId: number | null = null;
+      try {
+        const urlParts = new URL(body.git_url);
+        const pathParts = urlParts.pathname.replace(/\.git$/, '').split('/').filter(Boolean);
+        if (pathParts.length >= 2) {
+          const resp = await fetch(`https://api.github.com/repos/${pathParts[0]}/${pathParts[1]}`, {
+            headers: {
+              'Accept': 'application/vnd.github.v3+json',
+              'User-Agent': 'constructs-network/1.0',
+            },
+          });
+          if (resp.ok) {
+            const data = await resp.json() as { id: number };
+            githubRepoId = data.id;
+          }
+        }
+      } catch {
+        logger.warn({ git_url: body.git_url }, 'Failed to fetch github_repo_id');
+      }
+
+      // Update pack with git source (user calls /constructs sync <slug> for initial data population)
+      await db
+        .update(packs)
+        .set({
+          sourceType: 'git',
+          gitUrl: body.git_url,
+          gitRef: body.git_ref,
+          githubRepoId,
+          updatedAt: new Date(),
+        })
+        .where(eq(packs.id, pack.id));
+    }
+
+    logger.info({ slug: body.slug, name: body.name, type: body.type, git_url: body.git_url, userId, requestId }, 'Construct registered');
 
     return c.json(
       {
         data: {
           slug: body.slug,
           status: 'reserved',
+          ...(body.git_url && {
+            source_type: 'git',
+            git_url: body.git_url,
+            git_ref: body.git_ref,
+            next_step: 'Run /constructs sync to populate the initial version',
+          }),
         },
         request_id: requestId,
       },

--- a/grimoires/bridgebuilder/agent-native-cli-landscape-research.md
+++ b/grimoires/bridgebuilder/agent-native-cli-landscape-research.md
@@ -1,0 +1,459 @@
+# Agent-Native CLI & Expertise Distribution: Landscape Research
+
+> **Date**: 2026-02-27
+> **Status**: Research artifact — landscape scan with strategic implications for constructs network
+> **Scope**: MCP, SKILL.md standard, TOON format, Vercel Skills.sh, on-demand tool loading, token efficiency patterns, and where constructs sit
+
+---
+
+## Executive Summary
+
+The agent tooling ecosystem has undergone rapid stratification in the last 90 days. Three distinct distribution layers have emerged, each solving a different problem:
+
+| Layer | What It Distributes | Exemplars | Token Model |
+|-------|-------------------|-----------|-------------|
+| **Tool Layer** | Executable capabilities (APIs, queries, mutations) | MCP servers | High (50+ tools = ~55K-134K tokens upfront) |
+| **Skill Layer** | Behavioral instructions (how-to, workflows, conventions) | SKILL.md / Skills.sh | Low (~50 tokens/skill metadata, ~2-5K when loaded) |
+| **Expertise Layer** | Bundled knowledge + skills + identity + orchestration | Constructs (packs) | Medium (manifest + progressive skill loading) |
+
+The construct model occupies the expertise layer — a position **above** both MCP and SKILL.md in the abstraction stack. No other system in the current landscape bundles persona, domain knowledge, capability metadata, inter-construct events, and golden-path workflows into a single distributable unit. This is both the construct model's unique value and its adoption risk: it's solving a problem that most teams haven't articulated yet.
+
+---
+
+## 1. MCP: The Tool Layer (State of Play)
+
+### Current Adoption
+
+MCP has achieved de facto standard status. Key metrics as of February 2026:
+
+- **97M monthly SDK downloads**
+- **5,500+ MCP servers** on registries (PulseMCP)
+- Adopted by Anthropic, OpenAI, Google, Microsoft (VS Code/Copilot)
+- OpenAI deprecated the Assistants API in favor of MCP (sunset mid-2026)
+- Governance donated to Agentic AI Foundation under the Linux Foundation (Dec 2025)
+- Enterprise wins: Block (Goose agent), Bloomberg (days-to-minutes integration)
+
+### The Token Problem
+
+MCP's core design flaw is context pollution. Every connected server dumps its full tool schema into the agent's context window before a single user message is processed.
+
+| Setup | Tool Count | Token Overhead |
+|-------|-----------|---------------|
+| 1 server (GitHub) | ~25 tools | ~23K tokens |
+| 5 servers | 58 tools | ~55K tokens |
+| 10+ servers | 100+ tools | 100K-134K tokens |
+
+This is not just a cost problem — it is an **accuracy** problem. Tool selection accuracy degrades significantly past 30 tools due to attention competition. Models pick wrong tools, hallucinate parameters, and confuse similarly-named operations.
+
+### Emerging Solutions
+
+**Anthropic Tool Search Tool** (January 2026): The most significant development. Tools marked with `defer_loading: true` are excluded from initial context. The agent receives only a search tool (~500 tokens) and discovers tools on-demand via regex or BM25 semantic search.
+
+- Results: **85% reduction** in token usage
+- Accuracy: Opus 4 improved from 49% to 74%; Opus 4.5 from 79.5% to 88.1%
+- Now enabled by default in Claude Code when MCP tools exceed 10% of context
+- Tool references auto-expand throughout conversation history (no re-search needed)
+
+**Hierarchical Semantic Routing** (MCP-Zero): Server-level matching first, then tool-level ranking. Avoids scanning thousands of tools at once.
+
+**Tool Groups** (Lunar MCPX): Named collections ("Development", "QA", "Admin") that scope tool visibility to relevant workflows.
+
+**Agentic MCP Configuration**: The "server selection" step carved out as its own agent step. Can handle ~1,000 server names/descriptions in a 200K context window, then dynamically loads only 3-4 servers per task.
+
+### What MCP Cannot Do
+
+MCP solves "how does an agent call a tool?" It does **not** solve:
+
+1. **When** to use a tool (sequencing, judgment)
+2. **Why** to use a tool (domain reasoning, trade-off analysis)
+3. **How well** to use a tool (best practices, conventions)
+4. **What success looks like** (quality criteria, acceptance gates)
+
+These are precisely the problems that the skill and expertise layers address.
+
+### Implications for Constructs
+
+Constructs already operate at the network-level MCP model (`mcp-registry.yaml`), which is correct. The construct model should NOT try to compete with MCP at the tool layer. Instead, it should be the **consumer** of MCP tools — the knowledge layer that teaches agents which tools to select, when to sequence them, and what quality gates to apply.
+
+The `capabilities.requires` stanza in skill `index.yaml` files (e.g., `tool_calling: true`) already hints at this relationship. A future integration could declare MCP server dependencies explicitly, allowing constructs to dynamically activate the right MCP servers for their skills.
+
+---
+
+## 2. SKILL.md: The Behavioral Layer
+
+### The Standard
+
+In December 2025, Anthropic released the SKILL.md open standard. OpenAI immediately adopted it for Codex CLI. It has since been adopted by 37+ agent platforms including Claude Code, Cursor, GitHub Copilot, Gemini CLI, Windsurf, and Google Antigravity.
+
+A skill is a directory with a `SKILL.md` file (YAML frontmatter + markdown instructions) plus optional scripts and references. The standard defines a three-tier progressive loading model:
+
+| Tier | Content | Token Cost | When Loaded |
+|------|---------|-----------|-------------|
+| **Metadata** | Name + description | ~50-100 tokens | Always (startup) |
+| **Instructions** | Full SKILL.md body | ~2,000-5,000 tokens | When skill activates |
+| **Resources** | Scripts, references, assets | Unbounded | When skill requests them |
+
+This progressive disclosure is the key insight: **skills extend context only when needed**. With 20 skills, startup cost is ~2K tokens instead of ~40K.
+
+### Vercel Skills.sh
+
+Launched January 20, 2026. The "npm for agent skills":
+
+- CLI: `npx skills add <package>` — installs across 37+ agent platforms
+- Registry: skills.sh — directory + leaderboard with anonymous telemetry
+- Growth: **147 new skills per day**, tens of thousands of installs in first weeks
+- Security: Snyk partnership for pre-install scanning (after ClawHavoc incident — 341 malicious skills)
+- Major publishers: Stripe, Cloudflare, Sentry, HuggingFace, Trail of Bits
+
+### Skills vs. MCP: The Clarified Distinction
+
+As of January 2026, this distinction has crystallized in the ecosystem:
+
+> **MCP gives agents abilities. Skills teach agents how to use those abilities well.**
+
+- MCP = verbs (what the agent can do)
+- Skills = adverbs (how the agent should do it)
+- MCP provides authenticated access to external systems
+- Skills provide local, fast behavioral guidance with no network overhead
+
+Importantly, MCP adopted progressive discovery in January 2026 (via Tool Search Tool), neutralizing the context efficiency advantage that skills previously held. What remains is a **semantic** distinction: tools are executable capabilities, skills are behavioral instructions.
+
+### Limitations of the SKILL.md Standard
+
+1. **Auto-invocation reliability**: Practitioners report ~50% reliability for automatic skill activation based on user intent — "basically a coin flip"
+2. **Non-deterministic execution**: Skills are natural language instructions, not executable code. Success depends on the LLM's capacity to interpret instructions correctly.
+3. **No authentication model**: Skills cannot access authenticated data or perform actions on behalf of the user
+4. **No composition model**: The SKILL.md standard has no way to express dependencies between skills, sequencing, or orchestrated workflows
+5. **No identity model**: Skills are anonymous behavioral instructions — they have no persona, domain expertise boundaries, or cognitive frame
+6. **No event model**: Skills cannot declare events they emit or consume, limiting inter-skill coordination
+
+### Implications for Constructs
+
+Points 4, 5, and 6 above are where the construct model differentiates. A construct pack like Artisan bundles:
+
+- **Identity** (`persona.yaml`, `expertise.yaml`) — cognitive frame, voice, domain boundaries
+- **Skill composition** (14 skills with a defined workflow sequence: Survey, Envision, Decompose, Craft, Iterate, Inscribe)
+- **Events** (`forge.artisan.taste_inscribed`, `forge.artisan.pattern_surveyed`) — inter-construct coordination
+- **Capability metadata** (`model_tier`, `danger_level`, `execution_hint`) — intelligent routing
+
+None of these exist in the SKILL.md standard. The construct model is not competing with SKILL.md — it is a **higher-order abstraction** that uses SKILL.md-compatible skills as its atomic unit.
+
+---
+
+## 3. TOON: Token-Oriented Object Notation
+
+### What It Is
+
+TOON (Token-Oriented Object Notation) is a compact, human-readable encoding of the JSON data model. It combines YAML's indentation-based structure for nested objects with CSV-style tabular layout for uniform arrays. It is a **translation layer**: services and frontends still use JSON; data is encoded to TOON before being sent to the LLM, then decoded back to JSON after.
+
+### Performance
+
+| Format | Accuracy | Tokens | Efficiency Score |
+|--------|----------|--------|-----------------|
+| TOON | 73.9% | 2,744 | 26.9 |
+| JSON (compact) | 70.7% | 3,081 | 22.9 |
+| YAML | 69.0% | 3,719 | 18.6 |
+| JSON (standard) | 69.7% | 4,545 | 15.3 |
+| XML | 67.1% | 5,167 | 13.0 |
+
+TOON achieves **30-60% token savings** over standard JSON while improving structured extraction accuracy. A production RAG pipeline reported $1,940 in JSON costs reduced to $760 with TOON — 61% fewer tokens, same answers.
+
+### Limitations
+
+- Best for uniform arrays of objects; deeply nested or non-uniform data may be less efficient
+- Cannot replace JSON for model **outputs** — only validated for input/context
+- Not yet widely supported; requires prompt tuning for models not pre-trained on TOON
+- TypeScript SDK available but ecosystem is nascent
+
+### Sweet Spot
+
+TOON is ideal for: user lists, product catalogs, knowledge base snippets, logs, event streams, tool results, agent memory blocks, and summarized database exports.
+
+### Implications for Constructs
+
+The construct model deals with structured metadata extensively: `construct.yaml`, skill `index.yaml`, capability stanzas, event declarations. Currently, these are YAML files consumed by validation scripts (not directly by the LLM). The more relevant application of TOON would be in **tool response formatting** — when construct skills invoke tools that return structured data (e.g., API results, database queries, registry listings), encoding those results in TOON before passing them to the agent could reduce context consumption significantly.
+
+This is a low-priority optimization. The construct model's token efficiency comes from progressive disclosure (skills auto-load when invoked), which is already well-implemented. TOON would provide marginal improvement on top of an already-efficient architecture.
+
+---
+
+## 4. On-Demand Tool Loading: The Convergence Pattern
+
+### The Pattern
+
+The most important design pattern of early 2026 is **lazy tool/skill loading**: instead of declaring everything upfront, agents discover capabilities on-demand.
+
+This pattern has independently emerged in three systems:
+
+| System | Mechanism | Savings |
+|--------|----------|---------|
+| **Claude Tool Search** | `defer_loading: true` on tool definitions | 85% token reduction |
+| **SKILL.md Standard** | Three-tier progressive disclosure (metadata / instructions / resources) | ~600 tokens startup vs. ~30K full load for 12 skills |
+| **Spring AI** | Tool Search Tool adapter | 34-64% token reduction |
+| **Google ADK** | Custom tool search in Agent Development Kit | 94% reduction in tool context |
+
+### The Coherence Cascade
+
+A compelling theoretical model from recent research: when an agent is made **aware** that relevant knowledge exists but isn't currently loaded, its coherence-seeking behavior creates a functional drive to retrieve it. This transforms retrieval from passive rule-following into active, goal-aligned behavior.
+
+In practice: the agent sees a skill name and description (~50 tokens), decides it's relevant, and actively requests the full instructions (~2-5K tokens). This mirrors cache hierarchies in computer architecture and schema-driven recall in cognitive psychology.
+
+### How Constructs Already Implement This
+
+The construct model implements a **four-tier** progressive disclosure:
+
+| Tier | Content | Token Cost | When Loaded |
+|------|---------|-----------|-------------|
+| 1. **Pack manifest** | construct.yaml — name, skills list | ~200 tokens | On install/browse |
+| 2. **Skill metadata** | index.yaml — name, description, triggers, capability stanza | ~100 tokens/skill | At session startup |
+| 3. **Skill instructions** | SKILL.md — full behavioral instructions | ~2-5K tokens | When skill activates |
+| 4. **Resources** | scripts/, references/, assets/ | Unbounded | When skill requests them |
+
+This four-tier model is strictly more granular than the three-tier SKILL.md standard because it adds the pack manifest layer. The construct model gives the agent awareness of the entire expertise domain (Artisan = "Brand and UI craftsmanship") before it ever sees individual skill metadata.
+
+### What's Missing
+
+The construct model does not yet implement **dynamic skill discovery across packs**. If an agent has 6 packs installed (49 skills), all 49 skill metadata entries are loaded at startup (~5K tokens). For a network with hundreds of constructs, this would need a tool-search-style mechanism: a "construct search" tool that discovers relevant packs on-demand, loading only their skill metadata when a domain is relevant.
+
+---
+
+## 5. Token Efficiency Patterns
+
+### Five Patterns in Production
+
+**1. Progressive Disclosure** (Already implemented in constructs)
+Load only what's needed, when it's needed. The construct model's four-tier system is state-of-the-art.
+
+**2. Structured Output Schemas** (Partially implemented)
+Enforce predefined output formats to reduce agent "guessing." The construct model uses this in audit/review skills but could standardize output schemas across all skills.
+
+**3. TOON for Data Payloads** (Not yet implemented)
+Encode structured data in TOON format for LLM input. Relevant for skills that process structured data (e.g., registry listings, API responses).
+
+**4. Call-to-Action Patterns** (Partially implemented)
+Skills like `crafting-physics` use decision trees that reduce agent reasoning overhead: "Is this a financial operation? YES -> Pessimistic sync, 800ms, confirmation required." This pattern should be standardized.
+
+**5. CodeAgents-style Structured Planning** (Not yet implemented)
+Codify multi-agent reasoning into modular pseudocode with control structures, typed variables, and boolean logic. The construct model's `workflow` section in CLAUDE.md is a natural-language precursor to this.
+
+### Quantified Impact
+
+| Strategy | Token Savings | Source |
+|----------|--------------|--------|
+| Progressive disclosure | 45-75% | Agent Skills benchmarks |
+| Tool search (defer_loading) | 85% | Anthropic internal testing |
+| TOON encoding | 30-60% | TOON benchmarks |
+| Decision trees over free reasoning | ~40% (estimated) | Call-to-action pattern analysis |
+| Structured planning (CodeAgents) | Varies by task | arXiv 2507.03254 |
+
+---
+
+## 6. The Landscape Map
+
+### Distribution Primitives
+
+```
+                    ┌──────────────────────────────────────────┐
+                    │           EXPERTISE LAYER                │
+                    │  Constructs (packs + identity + events)  │
+                    │  ─────────────────────────────────────── │
+                    │  What: Bundled domain expertise          │
+                    │  How:  Manifest + skills + persona +     │
+                    │        capability metadata + events      │
+                    │  Unit: Pack (6-14 skills + identity)     │
+                    └──────────────┬───────────────────────────┘
+                                   │ contains
+                    ┌──────────────┴───────────────────────────┐
+                    │            SKILL LAYER                   │
+                    │  SKILL.md / Skills.sh / Agent Skills     │
+                    │  ─────────────────────────────────────── │
+                    │  What: Behavioral instructions           │
+                    │  How:  SKILL.md + scripts + references   │
+                    │  Unit: Single skill directory            │
+                    └──────────────┬───────────────────────────┘
+                                   │ invokes
+                    ┌──────────────┴───────────────────────────┐
+                    │             TOOL LAYER                   │
+                    │  MCP servers / CLI tools / APIs          │
+                    │  ─────────────────────────────────────── │
+                    │  What: Executable capabilities           │
+                    │  How:  JSON-RPC protocol + OAuth         │
+                    │  Unit: Tool (function with schema)       │
+                    └──────────────────────────────────────────┘
+```
+
+### Competitive Positioning
+
+| Dimension | npm Packages | MCP Servers | Skills.sh | Constructs |
+|-----------|-------------|-------------|-----------|-----------|
+| **Distributes** | Code | Tools | Instructions | Expertise bundles |
+| **Format** | JS/TS code | JSON-RPC services | SKILL.md (markdown) | YAML manifests + SKILL.md + persona |
+| **Progressive loading** | N/A | defer_loading (Jan 2026) | 3-tier disclosure | 4-tier disclosure |
+| **Identity/persona** | None | None | None | Yes (persona.yaml, expertise.yaml) |
+| **Workflow orchestration** | None | None | None | Yes (golden path, CLAUDE.md workflow) |
+| **Capability routing** | None | None | None | Yes (model_tier, danger_level, effort_hint) |
+| **Inter-unit events** | None | None | None | Yes (emits/consumes in construct.yaml) |
+| **Dependency model** | package.json | N/A | None | pack_dependencies in construct.yaml |
+| **Quality gates** | Linting, tests | None | None | Yes (review, audit, circuit breaker) |
+| **Registry/discovery** | npmjs.org | PulseMCP, MCP.so | skills.sh | constructs.network |
+| **Security** | npm audit | OAuth scoping | Snyk scanning | None yet |
+| **Adoption** | Massive | 97M SDK downloads | 147 skills/day | 6 packs, ~50 skills |
+
+---
+
+## 7. What Constructs Do Better
+
+### 1. Expertise Bundling
+No other system bundles persona + skills + events + capability metadata + quality gates into a distributable unit. MCP distributes tools. Skills.sh distributes instructions. Constructs distribute **thinking** — how a domain expert approaches problems, what they consider, and how they validate quality.
+
+### 2. Four-Tier Progressive Disclosure
+The construct model's pack-manifest/skill-metadata/skill-instructions/resources hierarchy is the most granular progressive loading system in the landscape. This matters at scale: a network of 100 constructs (500+ skills) would need this granularity to remain token-efficient.
+
+### 3. Capability-Aware Routing
+The `capabilities` stanza (`model_tier: sonnet`, `danger_level: moderate`, `execution_hint: parallel`) enables intelligent dispatch that no other system provides. An orchestrator can route low-risk tasks to cheaper models, sequence high-danger operations through human-in-the-loop gates, and parallelize independent skills.
+
+### 4. Inter-Construct Event Coordination
+The `events.emits` / `events.consumes` model in `construct.yaml` enables loose coupling between expertise domains. When Artisan emits `forge.artisan.taste_inscribed`, Protocol can consume it to trigger verification. This event-driven composition model has no equivalent in MCP or Skills.sh.
+
+### 5. Quality Gates as First-Class Citizens
+The implement-review-audit cycle with circuit breaker protection is baked into the construct workflow. Skills.sh has no quality model. MCP has no quality model. Constructs treat quality as a structural concern, not an afterthought.
+
+---
+
+## 8. What Constructs Are Missing
+
+### 1. Security Model
+Skills.sh has Snyk integration (scanning every new skill before installation). MCP has OAuth scoping, sandboxing, and audit logging. The construct model has no supply-chain security mechanism for third-party packs. As the network grows beyond first-party constructs, this becomes critical. The ClawHavoc incident (341 malicious skills on ClawHub) is a cautionary tale.
+
+**Recommendation**: Implement construct signing and verification. Consider Snyk-style scanning at `constructs install` time.
+
+### 2. Cross-Platform Compatibility
+Skills.sh supports 37+ agent platforms. The construct model currently targets Claude Code (and partially Cursor via the runtime contract). The SKILL.md files within constructs ARE cross-platform compatible, but the pack-level abstractions (construct.yaml, persona.yaml, events) require a construct-aware runtime.
+
+**Recommendation**: Ensure every construct skill can degrade gracefully to a standalone SKILL.md when consumed outside the construct runtime. The construct.yaml becomes enrichment, not a hard dependency.
+
+### 3. Registry Distribution Infrastructure
+Skills.sh has `npx skills add`, npm as a transport layer, a leaderboard, anonymous telemetry, and category browsing. The construct model has `constructs.network` but limited CLI distribution tooling. The `browsing-constructs` skill exists but operates within Claude Code sessions, not as a standalone CLI.
+
+**Recommendation**: Ship a `npx constructs add <pack>` flow that wraps the existing install scripts. Consider publishing packs as npm packages (like skillpm) to leverage existing registry infrastructure.
+
+### 4. Dynamic Cross-Pack Discovery
+At 49 skills across 6 packs, loading all skill metadata at startup is manageable (~5K tokens). At 500 skills across 50 packs, it would be untenable. A tool-search-style mechanism for pack-level discovery is needed.
+
+**Recommendation**: Implement a "construct search" meta-tool that discovers relevant packs on-demand, similar to Anthropic's Tool Search Tool. Load pack manifests lazily, then skill metadata on pack activation, then skill instructions on skill invocation.
+
+### 5. Explicit MCP Integration
+Constructs should be able to declare which MCP servers they depend on, so that installing a construct can automatically configure the required MCP servers. Currently, MCP servers are network-level (`mcp-registry.yaml`), which is correct for infrastructure, but skill-level MCP requirements could enable more precise tool scoping.
+
+**Recommendation**: Add an optional `mcp_requires` field to skill `index.yaml` that declares which MCP server categories a skill needs. The runtime can then activate relevant MCP servers with `defer_loading` when the skill is invoked.
+
+### 6. Metrics and Telemetry
+Skills.sh tracks anonymous install/usage metrics for its leaderboard. Constructs have no telemetry for skill invocation frequency, success rates, or failure patterns. This data is essential for understanding which skills provide value and which need improvement.
+
+**Recommendation**: Optional telemetry hooks that log skill invocations to `.run/audit.jsonl` (already partially implemented via mutation logger hooks). Aggregate anonymized data for the constructs.network registry.
+
+---
+
+## 9. Patterns to Adopt
+
+### From MCP: defer_loading for Pack Discovery
+Apply the Tool Search Tool pattern at the construct level. At startup, load only a pack search tool (~500 tokens). When the agent encounters a domain-relevant task, search for matching packs, load skill metadata, then proceed with progressive disclosure.
+
+### From Skills.sh: npm as Transport
+Skills.sh's decision to use npm as the distribution backbone was pragmatic and effective. Constructs should evaluate whether packs can be published as npm packages containing `construct.yaml` + skills + identity, with a thin install script that places them in `.claude/constructs/packs/`.
+
+### From TOON: Token-Efficient Data Payloads
+For skills that process or return structured data (registry listings, audit results, gap analysis), consider TOON encoding of data payloads. This is low-priority compared to the architectural improvements above.
+
+### From Anthropic: Capability Metadata as Routing Contract
+The construct model's `capabilities` stanza is ahead of the market. Formalize it as a routing contract that runtimes can use for model selection, parallelization, and danger-gating. Publish this as a spec that other agent platforms can adopt.
+
+### From the Coherence Cascade: Awareness Before Loading
+The theoretical insight that awareness drives retrieval validates the construct model's design. The key is that agents need to know a capability EXISTS (pack manifest + description) before they can coherently request it. This is why the four-tier model works: awareness at each tier triggers goal-directed retrieval at the next tier.
+
+---
+
+## 10. Strategic Position
+
+The construct model occupies a genuinely novel position in the agent tooling landscape:
+
+```
+npm: "Here's code. Import it."
+MCP: "Here's a tool. Call it."
+Skills.sh: "Here's how to do this task. Follow these instructions."
+Constructs: "Here's a domain expert. It knows what to do, how to do it,
+             when to use which tools, what quality looks like, and how
+             to coordinate with other experts."
+```
+
+This is the difference between giving someone a hammer (MCP), giving them carpentry instructions (SKILL.md), and giving them access to a carpenter who owns a workshop (constructs).
+
+The risk is that this level of abstraction may be premature for the market. Most teams are still figuring out basic SKILL.md workflows and MCP server configuration. The construct model solves problems of scale, coordination, and quality that become critical at 50+ skills — a scale most organizations haven't reached yet.
+
+The opportunity is to be ready when they do. The teams that hit the 50-skill wall first (enterprise developer platforms, AI coding assistant companies, large open-source projects) will need exactly what the construct model provides: bundled expertise with identity, routing, events, and quality gates.
+
+**Recommended next move**: Ship the graceful-degradation story first. Every construct skill should work perfectly as a standalone SKILL.md on any of the 37+ platforms Skills.sh supports. The construct layer becomes enrichment for Claude Code users, not a walled garden. This expands the addressable market from "Claude Code users who understand constructs" to "anyone using any agent who wants better skills" — and the ones who need more will graduate into the full construct model.
+
+---
+
+## Sources
+
+### MCP
+- [MCP Wikipedia](https://en.wikipedia.org/wiki/Model_Context_Protocol)
+- [2026: The Year for Enterprise-Ready MCP Adoption](https://www.cdata.com/blog/2026-year-enterprise-ready-mcp-adoption)
+- [MCP on Every Executive Agenda (CIO)](https://www.cio.com/article/4136548/why-model-context-protocol-is-suddenly-on-every-executive-agenda.html)
+- [MCP Explained: Why It Matters in 2026](https://robomotion.io/blog/mcp-explained-why-model-context-protocol-matters-in-2026)
+- [MCP Tool Discovery for LLM Agents (Portkey)](https://portkey.ai/blog/mcp-tool-discovery-for-llm-agents/)
+- [How to Prevent MCP Tool Overload (Lunar)](https://www.lunar.dev/post/why-is-there-mcp-tool-overload-and-how-to-solve-it-for-your-ai-agents)
+- [Tool-space Interference in the MCP Era (Microsoft Research)](https://www.microsoft.com/en-us/research/blog/tool-space-interference-in-the-mcp-era-designing-for-agent-compatibility-at-scale/)
+- [Tool Search Tool (Claude API Docs)](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)
+- [Advanced Tool Use (Anthropic)](https://www.anthropic.com/engineering/advanced-tool-use)
+- [MCP Context Overload (EclipseSource)](https://eclipsesource.com/blogs/2026/01/22/mcp-context-overload/)
+- [Agentic MCP Configuration (PulseMCP)](https://www.pulsemcp.com/posts/agentic-mcp-configuration)
+
+### SKILL.md / Agent Skills Standard
+- [Equipping Agents for the Real World (Anthropic)](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills)
+- [Extend Claude with Skills (Claude Code Docs)](https://code.claude.com/docs/en/skills)
+- [Agent Skills (Claude API Docs)](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)
+- [Agent Skills FAQ (Vercel)](https://vercel.com/blog/agent-skills-explained-an-faq)
+- [Claude Agent Skills: A First Principles Deep Dive](https://leehanchung.github.io/blogs/2025/10/26/claude-skills-deep-dive/)
+- [The Complete Guide to Building Skills for Claude (Anthropic)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
+
+### Vercel Skills.sh
+- [Introducing Skills (Vercel Changelog)](https://vercel.com/changelog/introducing-skills-the-open-agent-skills-ecosystem)
+- [Skills.sh: Open Ecosystem for Agent Commands (InfoQ)](https://www.infoq.com/news/2026/02/vercel-agent-skills/)
+- [Skills GitHub Repository](https://github.com/vercel-labs/skills)
+- [Skills.sh Directory](https://skills.sh/docs)
+- [Snyk + Vercel: Securing Agent Skill Ecosystem](https://snyk.io/blog/snyk-vercel-securing-agent-skill-ecosystem/)
+
+### Skills vs. MCP Comparisons
+- [Skills vs MCP Tools: When to Use What (LlamaIndex)](https://www.llamaindex.ai/blog/skills-vs-mcp-tools-for-agents-when-to-use-what)
+- [MCP, Skills, and Agents (Cra.mr)](https://cra.mr/mcp-skills-and-agents/)
+- [Did Skills Kill MCP? (Goose / Block)](https://block.github.io/goose/blog/2025/12/22/agent-skills-vs-mcp/)
+- [Why Do We Need MCP If Skills Exist? (Mintlify)](https://www.mintlify.com/blog/why-do-we-need-mcp-if-skills-exist)
+- [Skills vs MCP vs Plugins vs Subagents (Awesome Skills)](https://awesomeskill.ai/blog/skills-vs-mcp-vs-plugins-vs-subagents)
+
+### TOON Format
+- [TOON vs JSON (Tensorlake)](https://www.tensorlake.ai/blog/toon-vs-json)
+- [TOON GitHub Repository](https://github.com/toon-format/toon)
+- [TOON vs JSON (DigitalOcean)](https://www.digitalocean.com/community/tutorials/toon-vs-json)
+- [What is TOON? (freeCodeCamp)](https://www.freecodecamp.org/news/what-is-toon-how-token-oriented-object-notation-could-change-how-ai-sees-data/)
+
+### On-Demand Loading / Progressive Disclosure
+- [Dynamic Tool Loading in Strands SDK (AWS)](https://builder.aws.com/content/2zeKrP0DJJLqC0Q9jp842IPxLMm/dynamic-tool-loading-in-strands-sdk-enabling-meta-tooling-for-adaptive-ai-agents)
+- [Smart Tool Selection: 34-64% Savings (Spring AI)](https://spring.io/blog/2025/12/11/spring-ai-tool-search-tools-tzolov/)
+- [Progressive Tool Discovery (Agentic Patterns)](https://agentic-patterns.com/patterns/progressive-tool-discovery/)
+- [The Coherence Cascade for AI (Medium)](https://medium.com/@todd.dsm/why-progressive-disclosure-works-for-ai-agents-a-theory-of-motivated-retrieval-665a9d1ea23a)
+- [Progressive Disclosure Matters (AI Positive)](https://aipositive.substack.com/p/progressive-disclosure-matters)
+
+### Token Efficiency / Structured Output
+- [CodeAgents: Token-Efficient Multi-Agent Reasoning (arXiv)](https://arxiv.org/abs/2507.03254)
+- [Agent Skills for Context Engineering (DeepWiki)](https://deepwiki.com/muratcankoylan/Agent-Skills-for-Context-Engineering)
+- [Coding Agents in Feb 2026 (calv.info)](https://calv.info/agents-feb-2026)
+- [Structured Outputs (Claude API Docs)](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)
+
+### Workflow Orchestration
+- [AI Agent Design Patterns (Azure Architecture Center)](https://learn.microsoft.com/en-us/azure/architecture/ai-ml/guide/ai-agent-design-patterns)
+- [Agentic Workflows for Software Development (McKinsey)](https://medium.com/quantumblack/agentic-workflows-for-software-development-dc8e64f4a79d)
+- [Every AI Agent Skills Platform in 2026 (DEV Community)](https://dev.to/haoyang_pang_a9f08cdb0b6c/every-ai-agent-skills-platform-you-need-to-know-in-2026-4alg)
+- [The Agent Skills Directory (skills.sh)](https://skills.sh/)

--- a/grimoires/bridgebuilder/incur-cli-vs-mcp-research.md
+++ b/grimoires/bridgebuilder/incur-cli-vs-mcp-research.md
@@ -1,0 +1,399 @@
+# incur & CLI-vs-MCP Research
+
+> **Date**: 2026-02-27
+> **Sources**: [wevm/incur](https://github.com/wevm/incur), [CLI vs MCP blog](https://kanyilmaz.me/2026/02/23/cli-vs-mcp.html), [TOON format](https://github.com/toon-format/toon)
+> **Context**: Evaluating incur patterns against Loa Constructs architecture for potential adoption
+
+---
+
+## 1. incur Architecture — Complete Findings
+
+### 1.1 Core Design: Three-Function Surface
+
+incur exposes exactly three methods: `Cli.create()`, `.command()`, `.serve()`. The deliberate minimalism means agents can author entire CLIs without learning framework abstractions. Every command definition carries:
+
+- `args` — Zod-validated positional arguments
+- `options` — Zod-validated flags
+- `env` — Zod-validated environment variables
+- `output` — Zod-validated return shape
+- `run()` — execution function with fully-typed parameters
+
+```ts
+Cli.create('greet', {
+  description: 'A greeting CLI',
+  args: z.object({ name: z.string().describe('Name to greet') }),
+  run({ args }) { return { message: `hello ${args.name}` } },
+}).serve()
+```
+
+### 1.2 How `skills add` Works
+
+The `my-cli skills add` command triggers a multi-stage pipeline:
+
+1. **Collection**: `collectEntries()` recursively walks the command `Map`, separating groups from leaf commands
+2. **Generation**: `Skill.split()` partitions commands into `File` objects based on a `depth` parameter — each file becomes a `SKILL.md` with YAML frontmatter + body
+3. **Rendering**: Each command produces sections for Arguments, Options, Environment Variables, Output schema, Examples, and Hints — all auto-derived from Zod schemas
+4. **Installation**: `Agents.install(tmpDir, { global, cwd })` writes files to agent-specific config directories (e.g., `~/.config/agents/skills/` for global)
+5. **Cleanup**: Stale skills from previous generations are removed via hash comparison (SHA-256 of serialized schemas)
+6. **Metadata**: `~/.local/share/incur/<name>.json` stores `{ hash, skills, at }` for staleness detection
+
+The key insight: **auto-registration means the CLI IS the skill definition**. There is no separate skill authoring step. Zod schemas become argument tables, descriptions become frontmatter, and the CLI tree structure becomes the file tree structure.
+
+### 1.3 TOON Format
+
+Token-Oriented Object Notation — a serialization format optimized for LLM consumption:
+
+**Encoding rules:**
+- Objects use YAML-style indentation (no braces)
+- Simple arrays: `friends[3]: ana,luis,sam`
+- Tabular arrays (the killer feature): header declares fields once, then CSV-style value rows
+
+```
+hikes[3]{id,name,distanceKm,elevationGain,companion,wasSunny}:
+  1,Blue Lake Trail,7.5,320,ana,true
+  2,Ridge Overlook,9.2,540,luis,false
+```
+
+**Benchmarked performance:**
+| Format | Accuracy | Tokens | Efficiency (acc/1K tokens) |
+|--------|----------|--------|---------------------------|
+| TOON | 73.9% | 2,744 | 26.9 |
+| JSON compact | 70.7% | 3,081 | 22.9 |
+| YAML | 69.0% | 3,719 | 18.6 |
+| JSON | 69.7% | 4,545 | 15.3 |
+| XML | 67.1% | 5,167 | 13.0 |
+
+TOON achieves **39.6% fewer tokens than JSON** with **higher accuracy**. The sweet spot is uniform arrays of objects — exactly the shape of tool listings, search results, and tabular data agents frequently produce.
+
+**When NOT to use TOON:**
+- Deeply nested structures (JSON-compact often smaller)
+- Semi-uniform arrays (40-60% tabular)
+- Pure flat tables (CSV smaller)
+
+### 1.4 On-Demand Skill Loading
+
+This is incur's most architecturally significant design decision.
+
+**MCP model**: All 20+ tool schemas injected into every conversation turn. Cost is front-loaded and paid regardless of how many tools are actually used.
+
+**incur model**: At session start, only **frontmatter** loads (name + description, ~40 tokens per skill). When the agent decides to use a skill, it reads the full SKILL.md for that command group on demand. After invocation, TOON output replaces JSON.
+
+**Token comparison (20-command CLI, 5 invocations):**
+
+| Phase | MCP + JSON | One Skill + JSON | incur |
+|-------|-----------|-----------------|-------|
+| Session start | 6,747 | 624 | 805 |
+| Discovery | 0 | 11,489 | 387 |
+| Invocation (x5) | 110 | 65 | 65 |
+| Response (x5) | 10,940 | 10,800 | 5,790 |
+| **Total cost** | **$0.0325** | **$0.0410** | **$0.0131** |
+
+The ~3x cost reduction comes from two independent optimizations: lazy loading (saves on discovery) and TOON output (saves on every response).
+
+### 1.5 Call-to-Action (CTA) Property
+
+CTAs are typed follow-up suggestions returned from command execution:
+
+```ts
+return ok({ items }, {
+  cta: {
+    commands: [
+      { command: 'get 1', description: 'View item' },
+      { command: 'list', args: { state: 'closed' }, description: 'View closed' },
+    ],
+  },
+})
+```
+
+Output appends a `Next:` section:
+```
+Next:
+my-cli get 1 – View item
+my-cli list closed – View closed
+```
+
+**Key properties:**
+- CTAs are **type-inferred** — command names, args, and options are validated at compile time via declaration merging on the `Register` interface
+- They guide agent workflow without the agent needing to know the full command tree
+- They create a **pull-based discovery** model: the agent learns about related commands only after executing the current one
+- They function as state-machine edges: each command output declares which commands are valid next steps
+
+### 1.6 Type Safety Story
+
+Zod schemas flow through TypeScript generics end-to-end:
+
+1. **Definition**: `args: z.object({ env: z.enum(['staging', 'production']) })`
+2. **Validation**: Input validated before `run()` executes — type errors surface at the CLI boundary, not inside business logic
+3. **Inference**: `run({ args, options, env })` has fully inferred types with zero manual annotations
+4. **Output**: `output: z.object({ url: z.string() })` declares the return shape — agents can parse without heuristics
+5. **CTA**: Via declaration merging on `Register`, CTA command references are compile-time checked
+6. **Generation**: `Schema.toJsonSchema()` converts Zod to JSON Schema for Markdown table generation and MCP tool registration
+
+### 1.7 MCP Bridge
+
+incur provides MCP as an alternative transport via `my-cli mcp add`. The `Mcp.ts` module:
+
+- Runs a stdio JSON-RPC server using `StdioServerTransport`
+- Flattens command groups into underscore-joined tool names (e.g., `pr_list`)
+- Merges args + options Zod shapes into a single JSON Schema per tool
+- Supports streaming via `notifications/progress` MCP notifications
+- Uses sentinel pattern (`Symbol.for('incur.sentinel')`) for ok/error signaling
+
+The MCP bridge is explicitly positioned as the fallback for runtimes that lack skill file support. Skills are the recommended path.
+
+---
+
+## 2. CLI vs MCP Thesis — Blog Post Findings
+
+### 2.1 Core Argument
+
+MCP front-loads the entire tool catalog as JSON Schema into every conversation. For large tool surfaces (84 tools across 6 servers), this costs ~15,540 tokens at session start regardless of usage. CLI-based tooling pays ~300 tokens at session start and loads details on demand.
+
+### 2.2 Quantified Comparison
+
+| Tools Used | MCP | CLI | Savings |
+|-----------|-----|-----|---------|
+| Session start | ~15,540 | ~300 | 98% |
+| 1 tool | ~15,570 | ~910 | 94% |
+| 10 tools | ~15,840 | ~964 | 94% |
+| 100 tools | ~18,540 | ~1,504 | 92% |
+
+### 2.3 Versus Anthropic Tool Search
+
+Anthropic's Tool Search (indexed tool selection) reduces the MCP overhead by ~85% but still retrieves full JSON Schema per tool. CLI remains cheaper:
+
+| Tools Used | MCP | Tool Search | CLI | CLI vs TS Savings |
+|-----------|-----|-------------|-----|-------------------|
+| 1 tool | ~15,570 | ~3,530 | ~910 | 74% |
+| 10 tools | ~15,840 | ~3,800 | ~964 | 75% |
+| 100 tools | ~18,540 | ~12,500 | ~1,504 | 88% |
+
+### 2.4 Key Insight
+
+The efficiency gap **widens** with repeated tool use because CLI discovery cost is amortized across the session while MCP schema overhead is paid every turn. This makes CLI the clear winner for any agent that interacts with tools iteratively over a session.
+
+### 2.5 Limitations Noted
+
+- CLI approach requires `--help` invocation per tool (~600 tokens per discovery), but only once per tool per session
+- MCP has zero per-tool discovery cost because schemas are pre-loaded
+- For very short sessions (1-2 tool calls), MCP may be competitive depending on total tool count
+
+---
+
+## 3. Synthesis: incur Patterns vs. Constructs Architecture
+
+### 3.1 Architectural Alignment Matrix
+
+| incur Concept | Constructs Equivalent | Alignment | Notes |
+|---------------|----------------------|-----------|-------|
+| `SKILL.md` (generated from Zod) | `SKILL.md` (hand-authored markdown) | **Same artifact, different authoring** | Constructs SKILL.md are richer (counterfactuals, context slots, workflow phases) |
+| Frontmatter (name + description) | `index.yaml` (metadata + capabilities) | **Converged intent** | Both solve "lightweight index at session start, full content on demand" |
+| `skills add` (auto-registration) | `/constructs install` (manual selection) | **Different discovery model** | incur: CLI generates its own skills. Constructs: registry of pre-authored packs |
+| `depth` parameter (file splitting) | Pack/skill hierarchy | **Structural parallel** | incur splits by command groups; Constructs organize by domain packs |
+| CTA property | No direct equivalent | **Gap** | Constructs have `golden_path.commands` and `quick_start` but no per-invocation CTAs |
+| TOON output format | No output format standardization | **Gap** | Constructs rely on runtime-native output (markdown, YAML, JSON) |
+| Zod schema validation | Capability metadata in `index.yaml` | **Different layer** | incur validates I/O at runtime; Constructs declare metadata for routing |
+| MCP bridge | MCP registry (`mcp-registry.yaml`) | **Complementary** | Constructs already lazy-load MCP; incur shows skills can replace MCP entirely |
+| `ok()`/`error()` sentinel pattern | Exit codes in Runtime Contract | **Same intent** | Both standardize success/failure signaling between execution layers |
+| Hash-based staleness detection | Version fields in manifests | **incur more automated** | incur auto-detects schema drift; Constructs use manual version bumps |
+
+### 3.2 Patterns Worth Adopting
+
+#### 3.2.1 TOON Output for Skill Results (HIGH VALUE)
+
+**Why**: The constructs network produces significant tabular output — pack listings, skill inventories, search results, audit reports, sprint task tables. TOON's header-then-values pattern would reduce token cost of every `/constructs browse`, `/loa` status check, and `/review-sprint` output.
+
+**Implementation path**:
+- Add TOON as an output format option in skill execution
+- Especially valuable for `constructs-browse.sh`, `constructs-loader.sh list`, and `beads-health.sh`
+- Does NOT require changing SKILL.md authoring — applies to runtime output only
+- Could be gated behind `.loa.config.yaml` flag: `output_format: toon | json | yaml | md`
+
+**Conflict level**: None. Additive change to output layer. Does not touch the construct/skill boundary.
+
+#### 3.2.2 Per-Invocation Call-to-Actions (MEDIUM VALUE)
+
+**Why**: Constructs have `golden_path` and `quick_start` but these are static, pack-level suggestions. incur's CTAs are dynamic — each skill invocation returns context-sensitive next steps. This would improve agent navigation, especially for users unfamiliar with the skill tree.
+
+**Implementation path**:
+- Add optional `cta` stanza to skill output format (after the main content, before any grimoire writes)
+- Each skill's SKILL.md could define a `## Next Steps` section that is context-dependent based on output
+- Bridge the CTA concept to the existing `golden_path.commands` in pack CLAUDE.md files
+
+**Example for `/decompose` (decomposing-feel)**:
+```
+Next:
+/inscribe — Codify the decomposition into taste tokens
+/iterate — Begin visual iteration on identified dimensions
+/survey — Survey similar patterns across the codebase
+```
+
+**Conflict level**: Low. Augments existing architecture without modifying it.
+
+#### 3.2.3 Hash-Based Staleness Detection for Installed Packs (MEDIUM VALUE)
+
+**Why**: Currently, `constructs-loader.sh check-updates` compares version strings. incur's approach hashes the actual schema content, catching cases where a skill's content changes without a version bump (common during development). This is especially relevant for the fork-drift problem identified in the Construct Lifecycle RFC (Issue #131).
+
+**Implementation path**:
+- Generate content hash during `constructs-install.sh` and store in `.constructs-meta.json`
+- Compare hash on `check-updates` in addition to version comparison
+- Feeds directly into the proposed Merkle-tree divergence detection from the RFC
+
+**Conflict level**: Low. Extends existing metadata without changing pack structure.
+
+#### 3.2.4 Zod Schema Validation for Skill I/O (LOW VALUE, HIGH EFFORT)
+
+**Why**: incur validates inputs and outputs at runtime using Zod. Constructs currently use `inputs`/`outputs` in `index.yaml` as documentation-only metadata. Runtime validation would catch malformed skill invocations earlier.
+
+**Implementation path**:
+- Would require a TypeScript execution layer that doesn't currently exist (constructs are Bash + Markdown)
+- The existing capability metadata (`model_tier`, `danger_level`, `effort_hint`) serves a routing purpose that Zod schemas do not
+- Better approached as a complement to, not replacement for, the current metadata
+
+**Conflict level**: Medium. Would require adding a TypeScript runtime layer alongside the existing Bash scripts.
+
+### 3.3 Patterns That Conflict with Existing Architecture
+
+#### 3.3.1 Auto-Generated SKILL.md from Code Definitions
+
+**Why it conflicts**: incur generates SKILL.md from Zod schemas automatically. Loa constructs are hand-authored with rich content that cannot be generated — counterfactual blocks, context slots, workflow phase descriptions, domain expertise, allowed-tools declarations, integration specifications, and educational content (teachable moments, FAANG parallels).
+
+The Loa SKILL.md is not a schema reference. It is an expertise document that teaches the agent how to think about a domain. This is a fundamental philosophical difference: incur treats skills as API documentation; Loa treats skills as cognitive frames.
+
+**Verdict**: Do NOT adopt. The hand-authored SKILL.md is a core differentiator of the constructs architecture. Auto-generation would lose the construct-as-expertise model.
+
+#### 3.3.2 CLI-as-Skill-Definition (CLI IS the Source of Truth)
+
+**Why it conflicts**: In incur, the TypeScript CLI code is the canonical definition and SKILL.md is a derived artifact. In Loa, the SKILL.md and index.yaml are the canonical definition and the runtime (Claude Code, Cursor) is the execution environment. This is the Runtime/Construct Boundary principle.
+
+Adopting incur's model would invert this boundary: the runtime code would become the source of truth, and the construct definition would become a generated artifact. This would break the multi-runtime portability that the Runtime Contract enables.
+
+**Verdict**: Do NOT adopt. The construct-as-definition, runtime-as-execution separation is architecturally load-bearing.
+
+#### 3.3.3 Global Skill Installation (`~/.config/agents/skills/`)
+
+**Why it conflicts**: incur installs skills globally by default. Loa constructs are per-repo (`.claude/constructs/packs/` is gitignored, per-project). The per-repo model enables:
+- Different projects using different pack versions
+- Context slot overlays specific to project topology
+- License validation per-repo
+- Pack dependency resolution scoped to project needs
+
+**Verdict**: Do NOT adopt. Per-repo installation is correct for the constructs use case.
+
+### 3.4 Nuanced Patterns (Adopt with Modification)
+
+#### 3.4.1 Frontmatter-Only Session Loading
+
+**Current state**: Loa already does this conceptually. The `CLAUDE.loa.md` file loaded at session start contains only the skill command table (name + description), not full SKILL.md content. Skills auto-load their SKILL.md when invoked (stated explicitly in the framework instructions).
+
+**incur's refinement**: incur quantifies the token savings precisely and splits skills by command group depth. Loa could benefit from:
+- Measuring the current session-start token cost of `CLAUDE.loa.md` + all `index.yaml` files
+- Potentially splitting the command table by pack (already partially done via pack CLAUDE.md files)
+- Documenting the lazy-loading contract more explicitly in the Runtime Contract
+
+**Conflict level**: None. This is refining what Loa already does.
+
+#### 3.4.2 Dual Transport: Skills + MCP Fallback
+
+**Current state**: Loa has MCP as a network-level concern (registry in `mcp-registry.yaml`) with lazy loading (Integrations Protocol). incur positions MCP as a fallback for runtimes without skill support.
+
+**What to adopt**: The incur model validates Loa's existing design choice — MCP servers are external integrations (GitHub, Linear, Vercel), while skills are the primary agent-expertise delivery mechanism. Loa should continue this separation rather than trying to serve constructs via MCP.
+
+**What NOT to adopt**: incur's ability to auto-generate an MCP server from CLI commands is clever but irrelevant — Loa constructs are not CLIs, and the expertise they encode cannot be reduced to tool schemas.
+
+---
+
+## 4. Implications for Constructs Network
+
+### 4.1 Token Economy Awareness
+
+The incur + blog post research establishes a clear hierarchy of agent-tool integration efficiency:
+
+```
+Most efficient → Least efficient:
+
+1. Skill files (frontmatter index + on-demand full load + TOON output)
+2. CLI --help (on-demand discovery + structured output)
+3. Anthropic Tool Search (indexed schema selection)
+4. MCP (full schema dump per conversation turn)
+```
+
+Loa constructs already sit at position 1 in this hierarchy. The existing `index.yaml` as lightweight index + `SKILL.md` as on-demand full load + lazy MCP integration matches incur's optimal pattern. The main gap is output format optimization (TOON or equivalent).
+
+### 4.2 Construct Lifecycle RFC Implications
+
+The Construct Lifecycle RFC (Issue #131) proposes bidirectional sync, registry onboarding, and multi-type support. incur patterns inform this work:
+
+1. **Hash-based staleness** should be part of the sync protocol (supplements version comparison for fork-drift detection)
+2. **`skills add` auto-registration** is relevant for Tool Pack constructs — a tool pack could generate its own skill files from its CLI interface, bridging the incur and Loa models
+3. **CTA-style next steps** could be standardized in the construct manifest as a `workflow.next` field, enabling the registry to suggest follow-up constructs after installation
+
+### 4.3 Competitive Positioning
+
+incur addresses a different market: CLI frameworks for tool authors who want their tools agent-accessible. Loa addresses a different market: agent expertise and workflow orchestration for project teams.
+
+The two are complementary, not competitive:
+- A tool author builds with incur (CLI → skills auto-generated)
+- A project team installs the resulting skills via Loa constructs (pack → per-repo installation)
+- The gap is a **bridge format** that converts incur-generated SKILL.md files into Loa-compatible construct definitions (adding capabilities metadata, context slots, workflow phases)
+
+### 4.4 TOON Adoption Decision Framework
+
+| Output Type | Current Format | TOON Benefit | Priority |
+|-------------|---------------|--------------|----------|
+| Pack listing (`/constructs browse`) | Markdown table | High (tabular array) | P1 |
+| Skill inventory (`/loa`) | Markdown table | High (tabular array) | P1 |
+| Sprint task list (`beads-health.sh`) | JSON/Markdown | High (uniform objects) | P1 |
+| Audit findings (`/review-sprint`) | Markdown sections | Low (non-uniform) | P3 |
+| Code review output | Markdown | None (free text) | Skip |
+| Grimoire artifacts | YAML/Markdown | None (persistent files) | Skip |
+
+---
+
+## 5. Recommended Actions
+
+### Immediate (No Architecture Changes)
+
+1. **Measure current session-start token cost** of `CLAUDE.loa.md` + pack CLAUDE.md files to establish baseline
+2. **Document the lazy-loading contract** explicitly in `runtime-contract.md` — Loa already does this but incur's quantified benchmarks show why it matters
+3. **Add CTA-style `## Next Steps` sections** to existing SKILL.md files that currently lack them (many already have workflow phases that imply next steps but do not state them explicitly)
+
+### Short-Term (Minor Architecture Extension)
+
+4. **Implement TOON output** for `constructs-browse.sh`, `constructs-loader.sh list`, and `beads-health.sh` behind a config flag
+5. **Add content hashing** to `constructs-install.sh` for staleness detection alongside version comparison
+6. **Standardize CTA output format** in a new protocol file (`.claude/protocols/skill-cta.md`)
+
+### Medium-Term (Lifecycle RFC Integration)
+
+7. **Define a bridge format** for converting incur-generated SKILL.md into Loa construct definitions (relevant to the Tool Pack archetype from RFC)
+8. **Evaluate TOON for checkpoint files** (`.loa-checkpoint/*.yaml`) where tabular data is common
+9. **Add `workflow.next` field** to construct manifest schema for registry-level CTA support
+
+### Do NOT Do
+
+- Do NOT auto-generate SKILL.md from code — hand-authored expertise documents are a core differentiator
+- Do NOT adopt global skill installation — per-repo is correct
+- Do NOT serve constructs via MCP — skills are the primary channel, MCP is for external integrations
+- Do NOT replace the Runtime Contract's exit code model with incur's sentinel pattern — they serve the same purpose and the exit code model is already implemented
+
+---
+
+## 6. Key Quotes and Reference Data
+
+### incur README
+> "Skills only load frontmatter (name + description) at session start. Full skill details load on demand."
+
+### Blog Post
+> "MCP front-loads every tool's full JSON Schema into each conversation as JSON Schema — every tool, parameter, and option upfront."
+
+### TOON Spec
+> "73.9% accuracy (vs JSON's 69.7%) while using 39.6% fewer tokens"
+
+### incur Token Comparison
+> incur total session cost: $0.0131 vs MCP: $0.0325 (60% savings)
+
+### Loa Framework Instructions (existing)
+> "Agent-driven development framework. Skills auto-load their SKILL.md when invoked."
+
+This confirms Loa already implements the core lazy-loading pattern that incur quantifies as its primary advantage.

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "active_cycle": null,
+  "active_cycle": "cycle-036",
   "global_sprint_counter": 36,
   "cycles": [
     {
@@ -408,6 +408,30 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260215-i331-merge-delete/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260215-i331-merge-delete/sprint.md"
+    },
+    {
+      "id": "cycle-036",
+      "label": "Constructs Network Distribution Layer",
+      "status": "active",
+      "created": "2026-02-27T21:45:00Z",
+      "prd": "grimoires/loa/prd.md",
+      "source_issues": [131, 120, 89, 127, 122],
+      "sdd": "grimoires/loa/sdd.md",
+      "sprint_plan": "grimoires/loa/sprint.md",
+      "sprints": [
+        {
+          "local_id": "sprint-1",
+          "label": "Seed Script Foundation + Dry-Run Validation"
+        },
+        {
+          "local_id": "sprint-2",
+          "label": "Register 4 New Constructs + The Easel Extraction"
+        },
+        {
+          "local_id": "sprint-3",
+          "label": "CLI detect_state + Post-Install Hooks"
+        }
+      ]
     }
   ]
 }

--- a/grimoires/loa/prd.md
+++ b/grimoires/loa/prd.md
@@ -1,365 +1,553 @@
-# PRD: R&D Synthesis — Measurement Honesty
+# PRD: Constructs Network Distribution Layer
 
-**Cycle**: cycle-035
-**Created**: 2026-02-21
+**Cycle**: cycle-036
+**Created**: 2026-02-27
 **Status**: Draft
-**Source**: `grimoires/bridgebuilder/rd-synthesis-behavioral-measurement.md` (4-expert R&D team output)
-**Linked Issues**: [#131](https://github.com/0xHoneyJar/loa-constructs/issues/131) (Construct Lifecycle), [loa#379](https://github.com/0xHoneyJar/loa/issues/379) (Verification Trust)
-**Predecessor**: cycle-034 (Type System, Dependency Graph — archived)
+**Source**: 4-agent R&D team (org-auditor, dx-analyst, incur-researcher, landscape-researcher)
+**Linked Issues**: [#131](https://github.com/0xHoneyJar/loa-constructs/issues/131) (Construct Lifecycle RFC), [#120](https://github.com/0xHoneyJar/loa-constructs/issues/120) (Skill Discovery Breaks Post-Install), [#89](https://github.com/0xHoneyJar/loa-constructs/issues/89) (Pack Autosync), [#127](https://github.com/0xHoneyJar/loa-constructs/issues/127) (Golden Path Leveling), [#122](https://github.com/0xHoneyJar/loa-constructs/issues/122) (MoE Routing)
+**Research artifacts**:
+- `grimoires/bridgebuilder/incur-cli-vs-mcp-research.md` (incur architecture, TOON, CLI-vs-MCP thesis)
+- `grimoires/bridgebuilder/agent-native-cli-landscape-research.md` (MCP, Skills.sh, TOON, market positioning)
+- `grimoires/bridgebuilder/ARCHETYPE.md` (Bridgebuilder design philosophy)
 **Grounded in**:
-- Codebase scan: `schema.ts` (1200+ lines), `packs.ts` (1977 lines), `constructs.ts` (339 lines), `analytics.ts` (136 lines)
-- Explorer: `constructs/[slug]/page.tsx` (305 lines), `fetch-constructs.ts` (247 lines)
-- R&D synthesis from Game Systems, Platform Economy, Creative Expression, and Behavioral Science experts
-- Founder's journal (6 pages, rave braindump): measurement against real behavior, Score calibration, creative abundance
-- Echelon first VerificationCertificate: precision 0.80, recall 0.55, composite 0.700, UNVERIFIED tier
+- Codebase scan: `scripts/seed-forge-packs.ts`, `packages/shared/src/types.ts`, `packages/shared/src/validation.ts`, `apps/api/src/routes/constructs.ts`, `apps/api/src/services/constructs.ts`, `apps/api/src/db/schema.ts`, `.claude/scripts/constructs-install.sh`, `.claude/scripts/golden-path.sh`
+- Full 0xHoneyJar org audit: 50+ repos scanned, all construct-* repos inventoried
+- Founder direction: CLI framework as distributable construct, surface unsurfaced constructs, cross-repo sync, structured foundation
 
 ---
 
 ## 1. Problem Statement
 
-The Constructs Network measures everything except whether its own judgments are correct.
+The Constructs Network has 80+ skills of domain expertise scattered across 10+ repos, but only 67 are installable. The distribution layer — the mechanism that turns expertise into something a builder can discover, install, and compose — has five concrete failures grounded in code:
 
-**Four concrete problems grounded in code:**
+### P1: The Seed Script Bottleneck
 
-1. **No retrospective accuracy loop.** Observer classifies signals as HIGH/MEDIUM/LOW (3x/1x/0.5x weight). There is no table, no endpoint, and no mechanism to track whether HIGH signals actually produced high-impact outcomes. The system operates blind — it predicts but never checks its predictions. The founder identified this: *"I am extracting signal from conversations but I am not practicing what I preach. This must be measured against real behavior."*
-   > Evidence: No `signal_accuracy` or `outcome_tracking` table in `schema.ts`. No analytics endpoint tracks signal-to-outcome correlation.
+`scripts/seed-forge-packs.ts` is the **only** way constructs enter the registry. It has 6 hardcoded Git URLs (lines 42-67). Adding a construct requires modifying source code and running a script with `DATABASE_URL`. There is no self-service registration, no webhook sync, no CLI-driven onboarding.
 
-2. **Download counts contradict stated philosophy.** `docs/GRADUATION.md:23` requires "10+ downloads" for experimental→beta graduation. `docs/GRADUATION.md:34` requires "100+ downloads" for beta→stable. But `ARCHETYPE.md:173-179` explicitly rejects "Total installs" as a vanity metric: *"A number goes up. Tells you nothing about impact."* The graduation system and the design philosophy are in direct contradiction.
-   > Evidence: `GRADUATION.md:23,34` vs `ARCHETYPE.md:173`. Downloads also weight search ranking at 0.3 in `constructs.ts:142` via `RELEVANCE_WEIGHTS.downloads`.
+The `POST /v1/constructs/register` endpoint (constructs.ts:257-339) reserves slugs but does not populate pack files. The `POST /v1/packs/:slug/versions` publishing flow exists but isn't the operational path. The DB schema has `pack_sync_events`, `github_repo_id`, and `content_hash` columns — all empty. The infrastructure is half-built.
 
-3. **Fork relationships are invisible.** `POST /v1/packs/fork` at `packs.ts:1669-1740` creates a new pack from a source but does NOT record the relationship. The `packs` table (`schema.ts:472-553`) has no `forked_from` column. Observer's 6→23 skill evolution in midi-interface — the most valuable product signal in the ecosystem — is untraceable in the registry.
-   > Evidence: `packs.ts:1712` creates fork without provenance. `schema.ts:472-553` has no `forked_from` field.
+> **Impact**: 3 constructs with valid `construct.yaml` v3 manifests (Herald/3 skills, Hardening/7 skills, Dynamic Auth/3 skills) sit in repos unable to be installed. The seed script is the single point of failure for the entire distribution story.
 
-4. **Explorer shows stat blocks instead of craft.** Construct detail page at `constructs/[slug]/page.tsx:128-130` displays `"Level"` with `graduationLevel` — theatrical RPG framing for professional tools. Lines 139-168 surface `construct_identities` JSONB (`cognitiveFrame`, `expertiseDomains`) instead of the SKILL.md prose that actually carries the construct's voice. No "Built With" showcases exist. No fork celebration. The Explorer is a database viewer, not a product page.
-   > Evidence: `page.tsx:129` — `<p className="text-white/40 mb-1">Level</p>`. No SKILL.md rendering anywhere in Explorer.
+### P2: Manifest Data Loss
 
----
+The seed script stores **7 of ~30** manifest fields. It constructs a minimal object (`schema_version, name, slug, version, description, author, license, skills`) and drops everything else: `golden_path`, `workflow`, `events`, `pack_dependencies`, `methodology`, `domain`, `expertise`, `quick_start`, `hooks.post_install`, `tier`.
 
-## 2. Goals & Success Metrics
+Every downstream consumer — the explorer, the CLI browse output, the golden path journey bar, the workflow gate reader — already knows how to read these fields. The Zod schema validates them. The TypeScript types declare them. **The data simply never reaches the database.**
 
-### Goals
+> **Impact**: `detect_state` is a dead field (declared in types.ts:303, validated by Zod, never evaluated by `golden-path.sh`). `workflow.gates` can't be read from registry data. Golden path journey bars show command names but can't show "you are here." The entire progressive disclosure system from ARCHETYPE.md Section 3 is blocked by a 20-line seed script function.
 
-| Goal | Rationale |
-|------|-----------|
-| **G1**: The system knows when it's wrong | Retrospective accuracy tracking closes the metacognitive loop — the single most important measurement per behavioral science analysis |
-| **G2**: Fork relationships are first-class | Fork drift is product signal, not technical debt. Celebrate it, measure it, surface it. |
-| **G3**: Explorer shows craft, not stat blocks | Professional tools need `git status` energy, not Clippy energy. Prose > JSONB. Visible output > download counts. |
-| **G4**: Graduation criteria match stated philosophy | Kill the download-count contradiction. Replace with criteria the ARCHETYPE.md would endorse. |
-| **G5**: Verification naming is honest | "CalibrationCertificate" borrows credibility from forecasting science (Brier scores) while measuring classification accuracy (precision/recall). Rename to VerificationCertificate. |
+### P3: Fork Drift Invisibility
 
-### Success Metrics
+midi-interface's Observer has **29 skills** (5 unique: `correlating-temporal`, `diagramming-states`, `enriching-temporal`, `grounding-code`, `triaging-signals`). The registry Observer has 24. The `packs` table has no `forked_from` column. The `content_hash` column exists but is never populated. There is no mechanism to detect, measure, or resolve divergence between installed packs and their registry versions.
 
-| Metric | Target | How Measured |
-|--------|--------|-------------|
-| Retrospective accuracy endpoint exists and accepts outcome data | Functional, tested | API integration tests |
-| Fork provenance tracked for all fork operations | 100% of `POST /fork` creates provenance | DB constraint + endpoint test |
-| Explorer shows SKILL.md prose on construct detail pages | Rendered for all constructs with SKILL.md | Visual verification + E2E |
-| Download counts removed from graduation criteria | Zero references to downloads in GRADUATION.md criteria | Grep verification |
-| "CalibrationCertificate" renamed to "VerificationCertificate" in code comments and docs | All references updated | Grep verification |
+> **Impact**: The most valuable product signal in the ecosystem — Observer evolving from 6→24→29 skills through real-world usage in midi-interface — is untraceable. Skills born from actual builder friction have no path back to the canonical construct.
 
----
+### P4: No Cross-Platform Degradation
 
-## 3. User & Stakeholder Context
+The SKILL.md standard has been adopted by **37+ agent platforms** (Claude Code, Cursor, GitHub Copilot, Gemini CLI, Windsurf, Google Antigravity). Vercel's Skills.sh publishes 147 new skills per day. Individual construct skills ARE SKILL.md-compatible, but the pack-level abstractions (`construct.yaml`, `persona.yaml`, events, capability metadata) require a construct-aware runtime.
 
-### Primary: The Builder (You)
+A construct skill cannot currently be consumed outside the Loa/Claude Code ecosystem. The addressable market is artificially constrained.
 
-The founder, operating as both builder and first user. The journal captures the core tension: *"Creating simple experiences that resonate with people is the exact tension that will get us to where we want to go. It parallels with grounding while also supporting visionary thinking."*
+> **Impact**: The construct model's unique value (expertise bundling, 4-tier progressive disclosure, capability routing, inter-construct events) is invisible to the 37-platform SKILL.md ecosystem. Builders on Cursor, Copilot, or Windsurf cannot access any of the 80+ skills.
 
-Needs: honest measurement that serves creative growth, not compliance theater.
+### P5: No "What Next?" After Skill Execution
 
-### Secondary: Tobias / Echelon
+When a builder runs `/observe` or `/inscribe`, the skill produces output and... stops. There is no per-invocation call-to-action telling the agent what to do next. The `golden_path.commands` field exists in manifests but is pack-level and static. The `detect_state` field was designed for this but is never evaluated.
 
-External collaborator building verification infrastructure. Currently the only external verifier. The rename from "CalibrationCertificate" to "VerificationCertificate" affects his integration semantics.
+incur solves this with typed CTAs returned from every command execution — dynamic, context-sensitive, referencing the next command based on output state. Constructs have the manifest schema for this but zero runtime implementation.
 
-Needs: clear naming, honest metrics, independent verification path.
-
-### Tertiary: Future Construct Authors
-
-The 500-pack ecosystem that doesn't exist yet. Decisions now set cultural norms. *"Establish the norm while you're small."*
-
-Needs: zero-friction creation. Verification as opt-in badge, never as gate to visibility.
+> **Impact**: Agents guess what to do next or ask the user. This breaks flow state — the Bridgebuilder's highest-priority protection (ARCHETYPE.md: "Never pull builders out of their CLI to learn, configure, or troubleshoot").
 
 ---
 
-## 4. Functional Requirements
+## 2. Vision
 
-### FR1: Retrospective Accuracy Tracking (P0)
+**Every construct in the 0xHoneyJar ecosystem is discoverable, installable, syncable, and composable via `/constructs` — with graceful degradation to standalone SKILL.md for any of the 37+ agent platforms.**
 
-*"Without this feedback loop, every other measurement in the system operates blind."*
+The construct model occupies a genuinely novel position in the agent tooling landscape:
 
-**New table**: `signal_outcomes`
-
-```sql
-CREATE TABLE signal_outcomes (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  pack_id UUID NOT NULL REFERENCES packs(id),        -- FK, not slug
-  signal_type TEXT NOT NULL,           -- 'gap_filed', 'signal_classified', 'journey_shaped'
-  signal_source TEXT NOT NULL,         -- namespaced: 'github:issue/123', 'canvas:utc/user-abc'
-  signal_source_url TEXT,              -- verifiable URL to original signal
-  predicted_impact TEXT NOT NULL CHECK (predicted_impact IN ('high', 'medium', 'low')),
-  actual_impact TEXT CHECK (actual_impact IN ('high', 'medium', 'low', 'none')),
-  outcome_summary TEXT,                -- public-facing summary (no sensitive data)
-  outcome_evidence TEXT,               -- private: URL or description (never exposed in public API)
-  recorded_by UUID NOT NULL REFERENCES users(id),     -- who created the prediction
-  evaluated_by UUID REFERENCES users(id),             -- who evaluated the outcome
-  created_at TIMESTAMPTZ DEFAULT NOW(),
-  evaluated_at TIMESTAMPTZ,
-  CONSTRAINT no_self_evaluation CHECK (recorded_by IS DISTINCT FROM evaluated_by),
-  CONSTRAINT unique_signal_evaluation UNIQUE (pack_id, signal_source)
-);
+```
+npm:          "Here's code. Import it."
+MCP:          "Here's a tool. Call it."
+Skills.sh:    "Here's how to do this task. Follow these instructions."
+Constructs:   "Here's a domain expert. It knows what to do, how to do it,
+               when to use which tools, what quality looks like, and how
+               to coordinate with other experts."
 ```
 
-**Impact rubric** (concrete, observable criteria):
-
-| Level | Definition | Time Window | Example |
-|-------|-----------|-------------|---------|
-| `high` | Resulted in merged code change or documented behavior shift within 14 days | 14 days | Gap filed → PR merged → user-facing change |
-| `medium` | Opened as issue/task but not yet resolved, OR indirect influence on subsequent decisions | 30 days | Gap filed → issue created → in backlog |
-| `low` | Acknowledged but no downstream action taken | 30 days | Gap discussed in review but deprioritized |
-| `none` | Signal was incorrect or irrelevant — no observable downstream effect | 30 days | Predicted high impact, nothing happened |
-
-**Evaluator integrity**: The `no_self_evaluation` constraint ensures the person who recorded the prediction cannot evaluate its outcome. For the current single-maintainer ecosystem, self-evaluations are logged but flagged in accuracy reports as `self_evaluated: true` with reduced weight (0.5x) in aggregate accuracy computation.
-
-**New endpoints**:
-
-| Method | Path | Purpose | Auth |
-|--------|------|---------|------|
-| `POST` | `/v1/packs/:slug/signals/outcomes` | Record an outcome for a prior signal | Pack owner |
-| `PATCH` | `/v1/packs/:slug/signals/outcomes/:id` | Evaluate a recorded signal | Pack owner or admin (not recorder) |
-| `GET` | `/v1/packs/:slug/signals/outcomes` | List outcomes (summaries only) | Public |
-| `GET` | `/v1/packs/:slug/signals/outcomes/detail` | List outcomes with evidence | Pack owner |
-| `GET` | `/v1/packs/:slug/signals/accuracy` | Compute accuracy stats (predicted vs actual) | Public |
-
-**Accuracy computation**: Return a structured accuracy report:
-- **Confusion matrix**: 3×4 grid (predicted high/medium/low × actual high/medium/low/none)
-- **Per-class precision/recall**: For each predicted_impact level
-- **Weighted kappa**: Ordinal agreement accounting for chance (Cohen's weighted kappa)
-- **Coverage**: `evaluated_signals / total_signals` — what fraction of signals have outcomes
-- **Time-to-outcome**: Median days from signal creation to evaluation
-- **Sample size guardrails**: Show "Insufficient data — N evaluations, need 20+" when n < 20. Show confidence intervals (95% Wilson) when n ≥ 20. Flag selection bias when coverage < 50%.
-
-### FR2: Fork Provenance Tracking (P0)
-
-*"Add `forked_from` to the packs table and celebrate forks."*
-
-**Schema change** — add to `packs` table (`schema.ts:~533`):
-```typescript
-forkedFrom: uuid('forked_from').references(() => packs.id),
-```
-
-**Fork endpoint fix**: `POST /v1/packs/fork` at `packs.ts:1712` must pass `forkedFrom: sourcePack.id` to `createPack()`.
-
-**API response additions**:
-- `GET /v1/constructs/:slug` returns `forked_from: { slug, name } | null`
-- `GET /v1/constructs/:slug` returns `fork_count: number`
-
-### FR3: Explorer Diagnostic Language (P1)
-
-*"Replace with `git status`-style diagnostics."*
-
-Replace `constructs/[slug]/page.tsx:128-130`:
-- `experimental` → "Experimental — needs README + 7 days for beta"
-- `beta` → "Beta — needs test coverage + docs for stable"
-- `stable` → "Stable"
-- `deprecated` → "Deprecated"
-
-No "Level" label. No theatrical framing. Pure diagnostic.
-
-### FR4: Explorer SKILL.md Prose Display (P1)
-
-*"Show SKILL.md prose as primary identity, not JSONB stat blocks."*
-
-**Schema change**: Add `skill_prose TEXT` to `packs` table.
-
-**SKILL.md format contract**: SKILL.md files are markdown with optional YAML frontmatter. The "primary SKILL.md" is the first file matching `**/SKILL.md` in the pack root (not nested skill directories). If multiple exist, prefer the one at the pack root level.
-
-**Git-sync change**: During `POST /v1/packs/sync`, extract prose from primary SKILL.md:
-1. Strip YAML frontmatter (if present)
-2. Extract up to 2000 chars, truncating at the last complete sentence boundary (`. `, `.\n`, or `.\r\n`)
-3. Sanitize: strip HTML tags, escape markdown injection vectors. Use `DOMPurify` or equivalent server-side sanitization before storage.
-4. Store in `skill_prose`. Set to `NULL` if no SKILL.md found.
-5. **Staleness**: `skill_prose` is refreshed on every sync operation. No separate cache invalidation needed — sync IS the refresh trigger.
-
-**Explorer**: Render `skill_prose` as sanitized markdown (via `react-markdown` with `rehype-sanitize`) above the identity section on detail page. Fall back to `description` if no prose exists. Never render raw HTML from user content.
-
-### FR5: Explorer Fork Celebration (P1)
-
-- If construct has `forked_from`: "Forked from [parent]" badge with link
-- If construct has forks: "N variants exist" with links
-- Fork count visible on construct cards in browse view
-
-### FR6: Explorer Built With Showcases (P2)
-
-**New table**: `construct_showcases`
-
-```sql
-CREATE TABLE construct_showcases (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  pack_id UUID NOT NULL REFERENCES packs(id),
-  title TEXT NOT NULL,
-  url TEXT NOT NULL,
-  description TEXT,
-  submitted_by UUID REFERENCES users(id),
-  approved BOOLEAN DEFAULT false,
-  created_at TIMESTAMPTZ DEFAULT NOW()
-);
-```
-
-**Endpoints**: `POST /v1/packs/:slug/showcases` (auth), `GET /v1/packs/:slug/showcases` (public, approved-only).
-
-### FR7: Kill Download-Count Graduation (P0)
-
-**`docs/GRADUATION.md` changes**:
-- Remove "10+ downloads" from exp→beta criteria (line 23)
-- Remove "100+ downloads" from beta→stable criteria (line 34)
-- Replace with concrete, automatable criteria:
-  - exp→beta: 7+ days since creation + README present with ≥200 words + at least 1 SKILL.md file
-  - beta→stable: 30+ days at beta + CHANGELOG present + no open issues labeled `critical` or `breaking` in source repo
-  - *Note*: "verified skill" was removed as a criterion because the only external verifier (Echelon) has 0.55 recall — gating on verification would block 45% of legitimate constructs. Verification remains opt-in badge, never a gate.
-
-**Search ranking**: Reduce `RELEVANCE_WEIGHTS.downloads` from 0.3 → 0.1 at `constructs.ts:142`.
-
-### FR8: Rename CalibrationCertificate → VerificationCertificate (P1)
-
-**Code** (comments only — identifiers already generic):
-- `schema.ts:1171` — JSDoc comment
-- `0005_construct_verifications.sql:77` — SQL COMMENT
-
-**Documentation**: Update all references in `echelon-integration-gaps.md` (14), `observer-laboratory-success-case.md` (9), `rd-synthesis-behavioral-measurement.md` (5).
+This PRD does not invent a new system. It completes the existing one — connecting the half-built infrastructure (DB schema, API endpoints, manifest validation) to the half-surfaced constructs (Herald, Hardening, Dynamic Auth, The Easel, midi-interface Observer extensions) through a self-service distribution layer.
 
 ---
 
-## 5. Technical & Non-Functional
+## 3. Goals & Success Metrics
 
-### Migration Safety
+### Business Objectives
 
-New migration `0006_measurement_honesty.sql` adds:
-- `forked_from` column to `packs` (nullable FK, non-breaking)
-- `skill_prose` column to `packs` (nullable text, non-breaking)
-- `signal_outcomes` table (new)
-- `construct_showcases` table (new)
+| Objective | Target | Measurement |
+|-----------|--------|-------------|
+| Surface all ready constructs | 10 packs installable (from 6) | `/constructs browse` returns 10+ packs |
+| Full manifest fidelity | 30/30 fields stored | Seed script stores complete validated manifest |
+| Self-service registration | < 5 min to register new construct | Time from `construct.yaml` creation to registry appearance |
+| Fork drift detection | 100% of installed packs have content hash | `content_hash` populated for all `pack_versions` rows |
+| Cross-platform compatibility | Every skill degrades to standalone SKILL.md | Skills usable in Cursor/Copilot without construct runtime |
 
-All changes are **additive**. No column removals, no type changes, no data migration.
+### Human-Connected Metrics (per ARCHETYPE.md Section 4)
 
-### API Backwards Compatibility
+| Metric | What It Captures | Baseline | Target |
+|--------|-----------------|----------|--------|
+| First-invocation success | Does trying a construct deliver on its description? | Unknown | > 80% of installs lead to first skill invocation |
+| Construct depth | How far through a construct's golden path | 1.2 steps avg (estimated) | 3+ steps avg |
+| Flow state preservation | Does the system keep builders in the zone? | No CTAs → agents ask user | CTAs guide next step without interruption |
+| Friction-to-resolution | Time from "I'm stuck" to "I understand" | No measurement | < 2 min for installation friction |
 
-All new endpoints are additions. Existing endpoints gain fields (additive, non-breaking).
+---
+
+## 4. User & Stakeholder Context
+
+### Persona 1: Internal Builder (Primary)
+
+Team members using constructs within 0xHoneyJar products (midi-interface, hub-interface, set-and-forgetti, score-api). They have constructs installed via Loa framework mounts. Their pain: constructs evolve in their repos but those improvements don't flow back to the registry, and new constructs from other repos aren't installable.
+
+### Persona 2: Construct Author (Secondary)
+
+Someone creating a new construct (e.g., Envio Indexer from #122, or a community contributor). Their pain: the only path to registry presence requires modifying the seed script and having `DATABASE_URL` access. No documentation on how to author a construct that the registry can consume.
+
+### Persona 3: External Agent User (Tertiary — Phase 3)
+
+Someone using Cursor, Copilot, or another SKILL.md-compatible agent. They want individual skills without the full construct runtime. Their pain: skills are locked inside the construct packaging and can't be consumed standalone.
+
+---
+
+## 5. Functional Requirements
+
+### Phase 1: Fix the Plumbing (Foundation)
+
+*Goal: Full manifest fidelity + surface ready constructs.*
+
+#### F1.1: Full Manifest Extraction in Seed Script
+
+**Current**: `seed-forge-packs.ts` constructs a minimal manifest (7 fields).
+**Target**: Store the full `construct.yaml` parsed to JSON, validated by `packManifestSchema.safeParse()`.
+
+Fields that will newly reach the database:
+- `golden_path` (commands, detect_state, truename_map)
+- `workflow` (depth, gates)
+- `events` (emits, consumes)
+- `pack_dependencies`
+- `methodology` (references, principles, knowledge_base)
+- `domain`, `expertise`
+- `quick_start`
+- `hooks` (post_install, pre_uninstall)
+- `tier`
+- `type` (pack, tool-pack, codex)
+
+**Acceptance criteria**:
+- Seed script uses Zod validation for all manifests
+- All 30+ manifest fields stored in `pack_versions.manifest` JSONB
+- Existing API responses (`GET /v1/constructs/:slug`) automatically surface new fields (they already destructure from manifest)
+- `content_hash` (SHA-256 of manifest + skill contents) populated for every `pack_versions` row
+
+#### F1.2: Register 3 Ready Constructs
+
+Add Herald, Hardening, and Dynamic Auth to the seed script:
+
+| Construct | Repo | Skills | Schema |
+|-----------|------|--------|--------|
+| Herald | `construct-herald` | 3 (grounding-announcements, synthesizing-voice, chronicling-changes) | v3 |
+| Hardening | `construct-hardening` | 7 (postmortem, triage, blast-radius, harden, regression-check, signal-audit, correlating) | v3 |
+| Dynamic Auth | `construct-dynamic-auth` | 3 (resolving-wallet-identity, enforcing-primary-wallet, backfilling-identity-links) | v3 |
+
+**Acceptance criteria**:
+- All 3 appear in `/constructs browse` output
+- All 3 installable via `/constructs install <slug>`
+- Total registered: 9 packs, 80 skills
+
+#### F1.5: Extract The Easel to Standalone Construct
+
+**Current**: The Easel (4 skills, `manifest.json` schema_version 1) lives embedded in `rektdrop-interface/.claude/constructs/packs/the-easel/`. It has 16 Taste Decision Records, a full vocabulary atlas (86 terms, 8 domains), and is actively used for cyberpunk aesthetic direction. Issue #131 incorrectly attributed it to hub-interface — it was always in rektdrop-interface. The Cartograph and The Mint (also attributed to hub-interface in #131) never existed anywhere in the org.
+
+**Target**: Extract the **core DNA** of The Easel to a standalone `construct-the-easel` repo — the universal creative studio workflow (vocabulary grounding → visual exploration → result capture → taste decisions). All rektdrop/cyberpunk-specific content (TDRs, aesthetic-direction.md, the cyberpunk vocabulary atlas) stays in rektdrop-interface as project-level grimoire content. The extracted construct is domain-agnostic creative tooling that any project can install and populate with its own aesthetic vocabulary.
+
+**Critical distinction**: The Easel's *process* (ground → explore → capture → record) is the construct. The rektdrop *content* (cyberpunk FUI terms, CRT emulation TDRs, Freeside Divergence aesthetics) is project state produced BY that process. The extraction ships the machine, not the output.
+
+**Extraction steps**:
+
+| Step | Detail | Effort |
+|------|--------|--------|
+| Create `construct-the-easel` repo | New repo with clean pack structure — NOT a copy of rektdrop's embedded version | Small |
+| Write domain-agnostic SKILL.md files | Generalize the 4 skills: remove cyberpunk references, use context slots for vocabulary domain | Medium |
+| Write `construct.yaml` v3 | Capabilities, events (`forge.easel.taste_recorded`, `forge.easel.vocabulary_grounded`), pack_dependencies (optional: Artisan for taste token handoff) | Small |
+| Add `index.yaml` per skill | All `model_tier: sonnet`, `danger_level: safe`, `effort_hint: medium` | Small |
+| Context slots for grimoire paths | `{{grimoire_path}}` instead of hardcoded `grimoires/the-easel/` | Small |
+| Ship empty templates only | `tdr-template.md` (blank), `vocabulary-template.md` (empty 8-domain structure), `quality-gates.md` (generic phase gates) | Small |
+| Add `identity/` directory | `persona.yaml` (creative studio voice — domain-agnostic) and `expertise.yaml` (design vocabulary, visual direction, taste documentation) | Small |
+| Register in seed script | Add to GIT_CONFIGS + PACK_ICONS | Trivial |
+| Update rektdrop-interface | Install construct from registry, keep existing `grimoires/the-easel/` content (TDRs, atlas, aesthetic-direction) as project state | Small |
+
+**What ships with the construct** (domain-agnostic):
+- 4 skill SKILL.md files with context slots
+- `tdr-template.md` — empty Taste Decision Record template
+- `vocabulary-template.md` — empty vocabulary atlas structure (8 domains, no terms)
+- `quality-gates.md` — generic Ground → Visualize → Tokenize → Implement phase gates
+
+**What stays in rektdrop** (project-specific):
+- 16 Taste Decision Records (TDR-001 through TDR-016)
+- `vocabulary/atlas.md` — 86 cyberpunk terms across 8 domains
+- `aesthetic-direction.md` — Freeside Divergence visual language
+- All exploration session artifacts, prompts, reviews
+
+**Skills** (generalized):
+- `grounding-creative` — Reviews project vocabulary and TDRs for a design area, identifies tensions and gaps
+- `exploring-visuals` — Generates prompts for image generation tools grounded in project vocabulary
+- `capturing-results` — Annotates generation results with vocabulary terms and TDR criteria
+- `recording-taste` — Taste Decision Record CRUD operations
+
+**Acceptance criteria**:
+- `construct-the-easel` repo exists with `construct.yaml` v3
+- All 4 skills are domain-agnostic — zero cyberpunk/rektdrop references in the construct
+- Skills use context slots for vocabulary paths, grimoire paths, and generation tool names
+- Installing on a fresh project produces empty templates ready to populate with any aesthetic vocabulary
+- rektdrop-interface installs from registry and its existing `grimoires/the-easel/` TDRs/atlas continue working
+- Registered on constructs.network, installable via `/constructs install the-easel`
+- Total registered after this + F1.2: **10 packs, 84 skills**
+
+#### F1.3: Activate detect_state in Golden Path
+
+**Current**: `golden-path.sh`'s `golden_detect_construct_journeys()` reads `golden_path.commands` but never evaluates `detect_state`.
+**Target**: If a pack declares `golden_path.detect_state` (a script path), execute it and use the returned state to highlight the current position in the journey bar.
+
+**Acceptance criteria**:
+- `/loa` shows "you are here" indicator per installed construct
+- detect_state scripts execute in the construct's directory context
+- Fallback: if no detect_state declared, show command names without position indicator (current behavior)
+
+#### F1.4: Post-Install Hook Execution
+
+**Current**: `hooks.post_install` is declared in manifests and validated by Zod but never executed by `constructs-install.sh`.
+**Target**: After pack extraction, execute `hooks.post_install` if declared.
+
+**Acceptance criteria**:
+- Post-install scripts run after file extraction
+- Scripts execute in the pack's installation directory
+- Failures are non-blocking (warn, don't abort install)
+- Security: scripts must be within the pack directory (no path traversal)
+
+### Phase 2: Self-Service Distribution
+
+*Goal: Construct authors can register, sync, and publish without modifying source code.*
+
+#### F2.1: Self-Service Registration API
+
+**Endpoint**: `POST /v1/constructs/register` (extend existing)
+
+Add `git_url` and `git_ref` fields to the registration schema. On registration:
+1. Validate caller identity (JWT auth)
+2. Clone the repo, read `construct.yaml`
+3. Validate manifest with Zod
+4. Create pack row with `source_type='git'`, populate `git_url`, `github_repo_id`
+5. Create first `pack_version` with full validated manifest
+6. Populate `construct_identities` from `identity/` directory
+
+**Acceptance criteria**:
+- `POST /v1/constructs/register { slug, git_url }` creates a fully populated registry entry
+- No seed script modification required
+- Response includes the construct's registry page URL
+
+#### F2.2: Sync Endpoint
+
+**Endpoint**: `POST /v1/packs/:slug/sync`
+
+Trigger re-sync from the registered `git_url`:
+1. Validate caller is pack owner
+2. Clone repo at latest `git_ref`
+3. Compare `content_hash` — skip if unchanged
+4. Parse manifest, validate with Zod
+5. Create new `pack_version` if version bumped, or update current if content changed
+6. Log to `pack_sync_events` (existing table, currently empty)
+
+**Acceptance criteria**:
+- Sync detects content changes via hash comparison
+- Sync is idempotent (running twice with no changes produces no new versions)
+- `pack_sync_events` table populated for audit trail
+- Rate limited per existing DB index
+
+#### F2.3: CLI Registration Commands
+
+Extend the `browsing-constructs` skill and install scripts:
+
+- `/constructs register <slug> --git-url <url>` — calls `POST /v1/constructs/register`
+- `/constructs sync <slug>` — calls `POST /v1/packs/:slug/sync`
+- `/constructs status <slug>` — shows installed version vs registry version + content hash comparison
+
+**Acceptance criteria**:
+- All three commands work from CLI within a Claude Code session
+- `constructs status` shows divergence indicator when hashes differ
+
+#### F2.4: GitHub Webhook Receiver
+
+**Endpoint**: `POST /v1/webhooks/github`
+
+Automated sync on push:
+1. Validate GitHub webhook signature (HMAC-SHA256)
+2. Match `github_repo_id` to a registered pack
+3. Trigger the same sync logic as F2.2
+4. Rate limit via `pack_sync_events`
+
+**Acceptance criteria**:
+- Webhook fires on push to default branch
+- Sync completes within 60 seconds of push
+- Failed syncs logged but don't break the webhook response
+
+### Phase 3: Cross-Platform Compatibility & Agent Navigation
+
+*Goal: Skills work standalone on 37+ platforms. Agents always know what to do next.*
+
+#### F3.1: Graceful SKILL.md Degradation
+
+Every skill within a construct must function as a standalone SKILL.md when consumed outside the construct runtime. This means:
+
+- Skill SKILL.md files must be self-contained (no hard references to construct.yaml, persona.yaml, or other pack-level files)
+- Context slots (`{{project_name}}`, etc.) should have sensible defaults or degrade to placeholders
+- The construct layer (identity, events, capability routing) is enrichment, not a dependency
+
+**Acceptance criteria**:
+- Any skill file copied to `~/.claude/commands/` or another SKILL.md-compatible agent works without the construct runtime
+- Skill audit script validates standalone compatibility
+
+#### F3.2: Per-Invocation Call-to-Actions
+
+After each skill execution, the runtime emits a `## Next Steps` section with context-sensitive suggestions based on the construct's `golden_path.commands` and the current `detect_state` output.
+
+**Example**: After running `/observe` (Observer's listening skill):
+```
+Next:
+/see — Synthesize what you've captured (5 canvases ready)
+/shape — Shape patterns into journey definitions (if 3+ canvases share themes)
+/loa — Check your full journey status
+```
+
+**Acceptance criteria**:
+- CTAs appear after skill execution for packs that declare `golden_path`
+- CTAs are dynamic (reference current state, not static command lists)
+- CTAs are optional — packs without golden_path show no CTAs
+- CTA format is a simple markdown `## Next Steps` section appended to skill output
+
+#### F3.3: Content-Hash Staleness Detection
+
+Extend `constructs-install.sh` and `constructs-loader.sh`:
+
+- On install: compute SHA-256 of manifest + all skill file contents, store in `.constructs-meta.json`
+- On `check-updates`: compare installed hash against registry hash
+- Surface drift: `/constructs status` shows `[SYNCED]`, `[BEHIND]`, or `[DIVERGED]` per pack
+
+**Acceptance criteria**:
+- Every installed pack has a `content_hash` in `.constructs-meta.json`
+- `check-updates` catches changes even without version bumps
+- Divergence detection feeds into the proposed Merkle-tree system from RFC #131
+
+---
+
+## 6. Technical & Non-Functional Requirements
+
+### Architecture Principles
+
+1. **Construct/Runtime Boundary preserved**: Skills define expertise. Runtime executes. No skill may assume a specific runtime.
+2. **Hand-authored SKILL.md**: Skills are expertise documents, not API references. Do NOT auto-generate from schemas (per incur research finding).
+3. **Per-repo installation**: Constructs install to `.claude/constructs/packs/` (gitignored, project-scoped). No global installation.
+4. **MCP stays external**: MCP servers are for external integrations (GitHub, Linear). Skills are the primary agent-expertise channel.
+5. **4-tier progressive disclosure preserved**: Pack manifest → skill metadata → skill instructions → resources.
+
+### Performance
+
+- Seed script sync: < 30 seconds per construct
+- API sync endpoint: < 60 seconds per construct
+- Install + post-install hooks: < 90 seconds
+- detect_state script execution: < 5 seconds
+- CTA generation: < 1 second (reads cached state)
 
 ### Security
 
-- `POST /v1/signals/outcomes`: pack owner auth only (verified via `packs.owner_id` FK join)
-- `GET /v1/signals/outcomes/:slug`: public, returns `outcome_summary` only (never `outcome_evidence`)
-- `GET /v1/signals/outcomes/:slug/detail`: pack owner only (returns full evidence)
-- `GET /v1/signals/accuracy/:slug`: public (aggregated stats only, no individual outcomes)
-- `POST /v1/packs/:slug/showcases`: authenticated user
-- Showcase approval: admin-only
-- **Content sanitization**: All user-supplied markdown (`skill_prose`, `outcome_summary`, showcase `description`) must be sanitized server-side before storage to prevent stored XSS
-- **Rate limiting**: `POST /v1/signals/outcomes` limited to 50 writes/hour per user to prevent accuracy stat flooding
+- Post-install hooks: sandboxed to pack directory, no network access, timeout after 30 seconds
+- Webhook signature validation: HMAC-SHA256 with per-pack secret
+- Registration: requires authenticated JWT (construct author)
+- Path traversal prevention: maintained from existing `constructs-install.sh` validation
+
+### Compatibility
+
+- construct.yaml (YAML) and manifest.json (JSON) both supported for input
+- All manifests stored as validated JSON in `pack_versions.manifest`
+- Zod schema is the single source of truth for validation
+- Skills must degrade to standalone SKILL.md (F3.1)
 
 ---
 
-## 6. Scope & Prioritization
+## 7. Scope & Prioritization
 
-### Sprint 1: Measurement Foundation (P0)
+### MVP (Phase 1 — Foundation)
 
-| Task | What |
-|------|------|
-| Migration 0006 | `signal_outcomes` table, `forked_from` + `skill_prose` columns |
-| Signal outcomes API | POST outcome, GET outcomes, GET accuracy |
-| Fork provenance | Fix fork endpoint, add to API response |
-| Kill download graduation | Update GRADUATION.md, reduce ranking weight |
+| Item | Priority | Effort |
+|------|----------|--------|
+| F1.1 Full manifest extraction | P0 | Small — ~50 lines of seed script |
+| F1.2 Register 3 ready constructs | P0 | Small — add to GIT_CONFIGS + icons |
+| F1.5 Extract The Easel | P0 | Medium — extract from rektdrop, upgrade v1→v3, register |
+| F1.3 Activate detect_state | P1 | Medium — golden-path.sh extension |
+| F1.4 Post-install hook execution | P1 | Small — constructs-install.sh extension |
 
-### Sprint 2: Explorer Reality (P1)
+### Phase 2 — Self-Service
 
-| Task | What |
-|------|------|
-| Diagnostic language | Replace "Level" with diagnostic text |
-| SKILL.md prose | Extract during sync, render on detail page |
-| Fork celebration | Badges, fork count, variant links |
-| Rename certificates | Comment/doc rename throughout |
+| Item | Priority | Effort |
+|------|----------|--------|
+| F2.1 Self-service registration API | P1 | Medium — ~200 lines API route |
+| F2.2 Sync endpoint | P1 | Medium — ~150 lines API route |
+| F2.3 CLI registration commands | P2 | Small — ~150 lines shell script |
+| F2.4 GitHub webhook receiver | P2 | Medium — ~300 lines API route |
 
-### Sprint 3: Visible Craft (P2)
+### Phase 3 — Cross-Platform & Navigation
 
-| Task | What |
-|------|------|
-| Showcases table + API | New table, POST/GET endpoints |
-| Explorer Built With | Showcase section on detail page |
-| Accuracy display | Show signal accuracy stats when data exists |
+| Item | Priority | Effort |
+|------|----------|--------|
+| F3.1 SKILL.md graceful degradation | P1 | Medium — audit + fix across 80 skills |
+| F3.2 Per-invocation CTAs | P2 | Medium — runtime extension + protocol |
+| F3.3 Content-hash staleness | P2 | Small — hash computation + comparison |
 
-### Out of Scope (Follow-Up Issues for Other Repos)
+### Explicitly Out of Scope
 
-| Item | Repo | Why Deferred |
-|------|------|-------------|
-| Kill 3x rank-based signal weighting | construct-observer | Observer-internal |
-| Observer Discovery mode (raw observation) | construct-observer | New skill |
-| Replace Level N framing in Loa golden path | loa | Framework-level |
-| Score API formula changes | midi-interface | Score developer context required |
-| Analytical signal layer (internal weights) | loa-constructs (future) | Needs Score API access patterns to stabilize |
-
----
-
-## 7. Risks & Dependencies
-
-| Risk | Severity | Mitigation |
-|------|----------|------------|
-| Migration 0006 on production Supabase | Medium | All additive; test on staging first |
-| Echelon affected by rename | Low | Only comments/docs; code identifiers generic |
-| SKILL.md extraction adds sync latency | Low | Sentence-boundary truncation at 2000 chars; skip if absent |
-| Signal accuracy data sparse initially | Expected | Show "Insufficient data — N evaluations, need 20+" |
-| Self-evaluation bias in single-maintainer ecosystem | Medium | `no_self_evaluation` constraint + `self_evaluated` flag with 0.5x weight |
-| Stored XSS via user-supplied markdown | Medium | Server-side DOMPurify + rehype-sanitize on render |
-
-| Dependency | Status |
-|------------|--------|
-| Migration 0005 in production | Verify — may need to be run |
-| Drizzle migration tooling | Working |
-| Explorer ISR caching | Working |
+- **TOON output format**: Valuable (39.6% token savings) but additive optimization, not structural. Deferred.
+- **Dynamic cross-pack discovery**: Needed at 500+ skills. Current 80 skills are manageable. Deferred.
+- **Billing / pricing tiers**: L1/L2/L3 tiers are metadata only, not pricing. Deferred.
+- **MCP bridge for constructs**: Constructs should not be served via MCP. Skills are the channel.
+- **Auto-generated SKILL.md**: Conflicts with hand-authored expertise model. Rejected.
+- **Global skill installation**: Per-repo is architecturally correct. Rejected.
+- **Supply-chain security scanning**: Important at scale but premature for 9 first-party packs. Deferred to Phase 4.
 
 ---
 
-## 8. Source Tracing
+## 8. Risks & Dependencies
 
-| Section | Primary Source | Supporting Evidence |
-|---------|---------------|-------------------|
-| Problem 1 (no accuracy loop) | `rd-synthesis.md:93-105` (Behavioral Science) | Founder journal: "measured against real behavior" |
-| Problem 2 (download contradiction) | `rd-synthesis.md:36-39` (All 4 experts) | `GRADUATION.md:23,34` vs `ARCHETYPE.md:173-179` |
-| Problem 3 (fork invisibility) | `rd-synthesis.md:187-191` (Platform Economy) | `packs.ts:1669-1740`, `schema.ts:472-553` |
-| Problem 4 (stat blocks not craft) | `rd-synthesis.md:79-88` (Creative Expression) | `page.tsx:128-130,139-168` |
-| FR1 (accuracy tracking) | Behavioral Science: "single most important measurement" | Tetlock, Brier decomposition |
-| FR2 (fork provenance) | Platform Economy: "add forked_from immediately" | npm fork model |
-| FR3 (diagnostic language) | Game Systems: "git status, not Clippy" | Portal, professional tool UX |
-| FR4 (SKILL.md prose) | Creative Expression: "prose > JSONB" | `construct_identities` vs SKILL.md |
-| FR7 (kill downloads) | All 4 experts unanimous | ARCHETYPE.md anti-vanity philosophy |
-| FR8 (rename certificate) | Behavioral Science: "naming theater" | Tetlock calibration vs classification |
+### Technical Risks
 
----
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Seed script Zod validation rejects existing manifests | Medium | High — breaks current packs | Run validation in dry-run mode first, fix manifests before switching |
+| detect_state scripts have side effects | Low | Medium | Sandbox execution, read-only filesystem access, 5s timeout |
+| Post-install hooks fail on different OSes | Medium | Low | Non-blocking, warn-only. Document OS requirements in manifest. |
+| Webhook sync creates version spam | Low | Medium | Rate limiting via `pack_sync_events` index. Deduplicate on content_hash. |
 
-## 9. Flatline Review Integration
+### External Dependencies
 
-**Review ID**: flatline-prd-20260221
-**Models**: Opus + GPT-5.2 | **Confidence**: FULL (100% agreement) | **Cost**: 46¢
+| Dependency | Status | Risk |
+|------------|--------|------|
+| GitHub API (for webhook configuration) | Stable | Low |
+| Supabase DB (for new rows/queries) | Active | Low |
+| construct-* repos (Herald, Hardening, Dynamic Auth) | Exist, valid manifests | Low — need icon assets |
+| rektdrop-interface (The Easel source) | Active, 16 TDRs produced | Low — extraction is pure copy + upgrade |
+| Railway API service | Deployed | Low |
 
-### HIGH_CONSENSUS Integrated (4)
+### Business Risks
 
-| ID | Finding | Integration |
-|----|---------|-------------|
-| IMP-001 | Accuracy metrics underspecified | Added confusion matrix, weighted kappa, coverage, sample size guardrails |
-| IMP-002 | Self-evaluation undermines integrity | Added `no_self_evaluation` constraint, evaluator role separation, self-eval flag |
-| IMP-003 | SKILL.md extraction contract missing | Added format contract, sentence-boundary truncation, XSS sanitization, sync trigger |
-| IMP-009 | signal_id must be typed reference | Changed to `signal_source` (namespaced) + `signal_source_url` (verifiable) with unique constraint |
-
-### BLOCKERS Addressed (7)
-
-| ID | Concern | Resolution |
-|----|---------|-----------|
-| SKP-001 (910) | No ground truth for actual_impact | Added impact rubric with observable criteria and time windows |
-| SKP-001 (900) | Self-assessment confirmation bias | Covered by IMP-002: `no_self_evaluation` + weighted flag |
-| SKP-002 (880) | Public endpoints leak evidence | Split into public (summary only) and owner-only (detail) endpoints |
-| SKP-002 (850) | Download removal without replacement | Replaced with concrete automatable criteria; removed "verified skill" gate |
-| SKP-003 (760) | Auth model + FK constraints | Changed to `pack_id` UUID FK, added unique constraint, RLS notes |
-| SKP-003 (750) | SKILL.md hidden complexity | Covered by IMP-003: format contract, staleness policy, sanitization |
-| SKP-004 (720) | Accuracy computation vague | Covered by IMP-001: confusion matrix, kappa, coverage metric |
+| Risk | Mitigation |
+|------|------------|
+| Construct authors don't adopt self-service | Internal team uses it first for all 9+ packs, proving the flow before external promotion |
+| Cross-platform degradation reduces construct value prop | Frame as expansion, not dilution — standalone skills are the on-ramp, full constructs are the graduation |
+| Fork drift resolution creates merge conflicts | Hash detection is informational first — surface drift, don't auto-merge |
 
 ---
 
-*"The best measurement system tells you when you're wrong before someone else does."*
+## 9. Construct Inventory (Current State)
+
+### Registered (6 packs, 67 skills)
+
+| Pack | Skills | Version | Status |
+|------|--------|---------|--------|
+| Observer | 24 | 2.0.0 | Active |
+| Artisan | 14 | 1.0.0 | Active |
+| Protocol | 10 | 1.0.0 | Active |
+| GTM Collective | 8 | 1.0.0 | Active |
+| Beacon | 6 | 2.0.0 | Active |
+| Crucible | 5 | 1.0.0 | Active |
+
+### Ready to Register (3 packs, 13 skills)
+
+| Pack | Skills | Repo | Schema | Readiness |
+|------|--------|------|--------|-----------|
+| Hardening | 7 | construct-hardening | v3 | HIGH — complete construct.yaml, identity, 7 domain skills |
+| Herald | 3 | construct-herald | v3 | HIGH — complete construct.yaml, identity, 3 skills |
+| Dynamic Auth | 3 | construct-dynamic-auth | v3 | HIGH — complete construct.yaml, identity, knowledge, 3 skills |
+
+### Needs Migration (2 packs, ~17 domain skills)
+
+| Pack | Domain Skills | Repo | Format | Issue |
+|------|--------------|------|--------|-------|
+| Rune/Sigil | ~15 | rune | manifest.json v4 | Old schema + Loa workflow skill contamination |
+| Ruggy Security | ~2 | ruggy-security | manifest.json v1.2 | Old schema + mostly Loa workflow clones |
+
+### Embedded — Extraction Target (1 pack, 4 skills)
+
+| Pack | Skills | Location | Issue | Extraction |
+|------|--------|----------|-------|------------|
+| The Easel | 4 | rektdrop-interface/.claude/constructs/packs/ | Not standalone repo | F1.5 — extract to `construct-the-easel`, upgrade manifest v1→v3 |
+
+### Fork Drift (1 case)
+
+| Source | Registry | Fork Location | Delta |
+|--------|----------|---------------|-------|
+| Observer (24) | construct-observer | midi-interface | +5 unique skills (correlating-temporal, diagramming-states, enriching-temporal, grounding-code, triaging-signals) |
+
+### Not Found
+
+- The Cartograph — referenced in issue #131 as hub-interface construct, not found in any repo
+- The Mint — referenced in issue #131 as hub-interface construct, not found in any repo
+
+---
+
+## 10. Market Positioning Context
+
+### The Agent Tooling Stack (Feb 2026)
+
+```
+EXPERTISE LAYER  ← Constructs (packs + identity + events + quality gates)
+   contains
+SKILL LAYER      ← SKILL.md / Skills.sh (behavioral instructions, 37+ platforms)
+   invokes
+TOOL LAYER       ← MCP servers / CLI tools / APIs (executable capabilities)
+```
+
+### Key Market Data
+
+- **MCP**: 97M monthly SDK downloads, 5,500+ servers. Suffers context pollution (50+ tools = 55-134K tokens before reasoning). Anthropic's Tool Search reduces by 85%.
+- **Skills.sh**: Launched Jan 20, 2026. 147 new skills/day. npm as transport. Snyk security scanning. ClawHavoc incident: 341 malicious skills.
+- **TOON**: 39.6% fewer tokens than JSON, 4.2 percentage points higher accuracy. TypeScript SDK available.
+- **incur (wevm)**: CLI-as-skills framework. Auto-registration via `skills add`. Type-safe with Zod. TOON output. 3x cheaper than MCP per session.
+
+### What Constructs Do That Nothing Else Does
+
+1. **Expertise bundling**: Persona + skills + events + capability routing + quality gates in a distributable unit
+2. **4-tier progressive disclosure**: Pack manifest → skill metadata → instructions → resources (most granular in the landscape)
+3. **Capability-aware routing**: `model_tier`, `danger_level`, `effort_hint` enable intelligent dispatch
+4. **Inter-construct events**: `emits`/`consumes` for loose coupling between domains
+5. **Quality gates as structural concern**: Implement → review → audit with circuit breaker
+
+### What Constructs Should NOT Do
+
+1. Auto-generate SKILL.md from code — hand-authored expertise is the differentiator
+2. Serve constructs via MCP — skills are the primary channel, MCP is for external integrations
+3. Install globally — per-repo installation enables project-scoped topology
+4. Compete with Skills.sh — instead, ensure every skill degrades to a standalone SKILL.md that can be published there
+
+---
+
+## 11. Implementation Sequence
+
+```
+Phase 1: Foundation (fix seed → register 3 + extract Easel → activate detect_state → post-install hooks)
+    ↓
+Phase 2: Self-Service (register API → sync endpoint → CLI commands → webhook)
+    ↓
+Phase 3: Reach (SKILL.md degradation → CTAs → content-hash staleness)
+```
+
+Each phase is independently shippable. Phase 1 is the highest-impact, lowest-effort change — it unblocks everything downstream by getting full manifest data into the database and 3 new constructs into the registry.
+
+---
+
+*"The best network doesn't add features. It removes the barriers between what exists and what's possible."*

--- a/grimoires/loa/sdd.md
+++ b/grimoires/loa/sdd.md
@@ -1,540 +1,297 @@
-# SDD: Constructs Network Distribution Layer — Phase 1 Foundation
+# SDD: Constructs Network Distribution Layer — Phase 2 Self-Service
 
 **Cycle**: cycle-036
 **Created**: 2026-02-27
 **Status**: Draft
 **PRD**: `grimoires/loa/prd.md` (Constructs Network Distribution Layer)
-**Scope**: Phase 1 only — F1.1, F1.2, F1.5, F1.3, F1.4
+**Scope**: Phase 2 — F2.1, F2.2, F2.3, F2.4
+**Depends on**: Phase 1 (complete — PR #143)
 
 ---
 
 ## 1. Overview
 
-Phase 1 fixes the plumbing between construct repos and the registry database. Five changes, all in existing files:
+Phase 2 enables self-service construct registration, sync, and status checking from the CLI. The critical discovery: **75% of the API surface already exists**.
 
-| ID | Change | Files | Lines |
-|----|--------|-------|-------|
-| F1.1 | Full manifest extraction | `scripts/seed-forge-packs.ts` | ~30 changed |
-| F1.2 | Register 3 constructs | `scripts/seed-forge-packs.ts` | ~20 added |
-| F1.5 | Extract The Easel | New repo `construct-the-easel` + seed entry | New repo + ~10 lines |
-| F1.3 | Activate detect_state | `.claude/scripts/golden-path.sh` | ~40 added |
-| F1.4 | Post-install hooks | `.claude/scripts/constructs-install.sh` | ~30 added |
+### Existing Infrastructure (Already Implemented)
 
-No new tables. No new API routes. No new packages. The downstream consumers (explorer, CLI browse, golden path, workflow gate reader) already know how to read these fields — they just need the data.
+| Feature | Endpoint | Status | File |
+|---------|----------|--------|------|
+| Register repo | `POST /v1/packs/:slug/register-repo` | Complete | `packs.ts:764` |
+| Sync from git | `POST /v1/packs/:slug/sync` | Complete | `packs.ts:879` |
+| GitHub webhook | `POST /v1/webhooks/github` | Complete | `webhooks.ts:380` |
+| Webhook config | `POST /v1/webhooks/configure` | Complete | `webhooks.ts:627` |
+| Git sync service | `syncFromRepo()` | Complete | `git-sync.ts:784` |
+| Rate limiting | `checkSyncRateLimit()` | Complete | `sync-rate-limit.ts` |
+| Git URL validation | `validateGitUrl()` | Complete | `git-sync.ts:170` |
+
+### What Needs Building
+
+| Feature | Type | Effort |
+|---------|------|--------|
+| F2.1a: Extend register endpoint to accept `git_url` | API extension | Small (~30 lines) |
+| F2.1b: Fix `userEmail` context bug | Bug fix | Trivial (1 line) |
+| F2.3a: `constructs register` CLI command | New script | Medium (~200 lines) |
+| F2.3b: `constructs sync` CLI command | New script | Small (~100 lines) |
+| F2.3c: `constructs status` CLI command | New script | Medium (~150 lines) |
+| F2.3d: Update browsing-constructs skill | Skill update | Small (~50 lines) |
+
+Total new code: ~530 lines across 4 files + 2 modified files.
 
 ---
 
 ## 2. Detailed Design
 
-### 2.1 F1.1: Full Manifest Extraction in Seed Script
+### 2.1 F2.1a: Extend Register Endpoint
 
-**File**: `scripts/seed-forge-packs.ts`
+**File**: `apps/api/src/routes/constructs.ts` (lines 257-339)
 
-**Current problem** (lines 358-367):
-```typescript
-const manifest = {
-  schema_version: pack.schema_version || 1,
-  name: pack.name,
-  slug: pack.slug,
-  version: pack.version,
-  description: pack.description,
-  author: pack.author || '0xHoneyJar',
-  license: pack.license || 'MIT',
-  skills: pack.skillSlugs.map((s) => ({ slug: s, path: `skills/${s}` })),
-};
-```
+**Current**: Accepts `{ slug, name, type }`, creates pack with `status: 'draft'`, `sourceType: 'registry'`.
 
-This constructs a 7-field object and discards everything else from construct.yaml.
-
-**Solution**: Parse the full YAML, validate with Zod, store the validated result.
-
-#### 2.1.1 Changes to `discoverPacks()` (lines 148-227)
-
-Replace the manual field extraction at lines 168-184 with full YAML parsing + Zod validation:
+**Change**: Add optional `git_url` and `git_ref` fields. When provided, chain to the existing `register-repo` logic after pack creation.
 
 ```typescript
-// In the construct.yaml branch (line 166):
-} else if (existsSync(constructYamlPath)) {
-  const content = await readFile(constructYamlPath, 'utf-8');
-  const parsed = yaml.load(content, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>;
-
-  // Validate with Zod — the shared schema is the single source of truth
-  const validation = packManifestSchema.safeParse(parsed);
-  if (!validation.success) {
-    console.warn(`   ⚠ ${slug}: manifest validation failed:`);
-    for (const issue of validation.error.issues) {
-      console.warn(`     - ${issue.path.join('.')}: ${issue.message}`);
-    }
-    // Fall back to partial manifest for backwards compatibility
-    fullManifest = null;
-    manifest = {
-      schema_version: (parsed.schema_version as number) || 1,
-      name: (parsed.name as string) || slug,
-      slug: (parsed.slug as string) || slug,
-      version: (parsed.version as string) || '1.0.0',
-      description: (parsed.description as string) || '',
-      author: parsed.author as string | undefined,
-      license: parsed.license as string | undefined,
-    };
-  } else {
-    fullManifest = validation.data;
-    manifest = validation.data;
-  }
-}
+// Extended request schema (line ~268)
+const registerSchema = z.object({
+  slug: z.string().min(3).max(100).regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/),
+  name: z.string().min(1).max(255),
+  type: z.enum(['skill-pack', 'tool-pack', 'codex', 'template']).optional().default('skill-pack'),
+  git_url: z.string().url().optional(),
+  git_ref: z.string().max(100).optional().default('main'),
+});
 ```
 
-**Import addition** (top of file):
-```typescript
-import { packManifestSchema } from '../packages/shared/src/validation.js';
-```
+When `git_url` is provided:
+1. Create pack (existing logic)
+2. Call `validateGitUrl(git_url)` from `git-sync.ts`
+3. Clone + read manifest (existing `syncFromRepo()`)
+4. Update pack with `sourceType='git'`, `gitUrl`, `gitRef`, `githubRepoId`
+5. Create first `pack_version` with full validated manifest
+6. Auto-publish pack (set `status: 'published'`) since manifest validation passed
+7. Return enriched response including version info
 
-#### 2.1.2 Changes to `DiscoveredPack` interface
+Without `git_url`: existing behavior (slug reservation only).
 
-Replace the minimal `PackManifest` interface (lines 69-79) with:
+### 2.1b: Fix userEmail Context Bug
 
-```typescript
-import type { ValidatedPackManifest } from '../packages/shared/src/validation.js';
+**File**: `apps/api/src/routes/constructs.ts` (line ~279)
 
-// DiscoveredPack now carries the full validated manifest when available
-interface DiscoveredPack {
-  // Core fields (always present)
-  name: string;
-  slug: string;
-  version: string;
-  description: string;
-  author?: string;
-  license?: string;
-  schema_version: number;
-  type?: string;
-  // Full validated manifest (null if Zod validation failed — legacy format)
-  fullManifest: ValidatedPackManifest | null;
-  // Derived fields
-  icon: string;
-  skillSlugs: string[];
-  packPath: string;
-  constructType: string;
-  identity?: IdentityData;
-}
-```
+**Current**: `c.get('userEmail' as never)` — cast hack, `userEmail` not in `ContextVariableMap`
+**Fix**: `c.get('user').email` — uses the declared `user: AuthUser` context variable
 
-#### 2.1.3 Changes to manifest storage (lines 358-367)
-
-Replace the 7-field construction with:
-
-```typescript
-// Store full manifest if validation passed, otherwise build minimal
-const manifest = pack.fullManifest ?? {
-  schema_version: pack.schema_version || 1,
-  name: pack.name,
-  slug: pack.slug,
-  version: pack.version,
-  description: pack.description,
-  author: pack.author || '0xHoneyJar',
-  license: pack.license || 'MIT',
-  skills: pack.skillSlugs.map((s) => ({ slug: s, path: `skills/${s}` })),
-};
-```
-
-The manifest stored in `pack_versions.manifest` JSONB becomes the full construct.yaml content when Zod-validated. All downstream consumers (`GET /v1/constructs/:slug`, explorer detail page, workflow gate reader) already destructure from this JSONB column.
-
-#### 2.1.4 Content Hash Computation
-
-Add after file collection (line 402):
-
-```typescript
-// Compute content hash: SHA-256 of manifest JSON + sorted file hashes
-const manifestJson = JSON.stringify(manifest, null, 0);
-const fileHashConcat = files.map(f => f.contentHash).sort().join('');
-const contentHash = createHash('sha256')
-  .update(manifestJson)
-  .update(fileHashConcat)
-  .digest('hex');
-```
-
-Store it in `pack_versions` (add to the INSERT at line 379):
-
-```sql
-content_hash = ${contentHash}
-```
-
-The `content_hash` column already exists in the schema (schema.ts line 592) — it's just never been populated.
-
-#### 2.1.5 Dry-Run Mode
-
-Add a `--dry-run` flag that validates all manifests against Zod without writing to the database:
-
-```typescript
-const DRY_RUN = process.argv.includes('--dry-run');
-```
-
-This allows testing manifest validation before switching to the full extraction. Critical for the migration — if any of the 6 existing manifests fail Zod validation, we need to fix them before deploying.
+Also gate on `c.get('user').emailVerified` for registration.
 
 ---
 
-### 2.2 F1.2: Register 3 Ready Constructs
+### 2.2 F2.2: Sync Endpoint — No Work Needed
 
-**File**: `scripts/seed-forge-packs.ts`
+`POST /v1/packs/:slug/sync` at `packs.ts:879-1090` is fully implemented:
+- Owner auth verification
+- `sourceType === 'git'` guard
+- Rate limiting (10/hour via `pack_sync_events`)
+- Full content sync via `syncFromRepo()`
+- Content hash computation
+- Identity parsing and upsert
+- Sync event recording
 
-Add to `GIT_CONFIGS` (line 42):
-
-```typescript
-herald: {
-  gitUrl: 'https://github.com/0xHoneyJar/construct-herald.git',
-  gitRef: 'main',
-},
-hardening: {
-  gitUrl: 'https://github.com/0xHoneyJar/construct-hardening.git',
-  gitRef: 'main',
-},
-'dynamic-auth': {
-  gitUrl: 'https://github.com/0xHoneyJar/construct-dynamic-auth.git',
-  gitRef: 'main',
-},
-```
-
-Add to `PACK_ICONS` (line 31):
-
-```typescript
-herald: '📢',
-hardening: '🛡️',
-'dynamic-auth': '🔐',
-```
-
-No other changes needed. The `discoverPacks()` function already handles cloning and manifest parsing generically.
-
-**Pre-check**: Verify all 3 repos have `construct.yaml` at root level (confirmed by org-auditor). Verify manifests pass `packManifestSchema.safeParse()` via dry-run.
+No changes needed.
 
 ---
 
-### 2.3 F1.5: Extract The Easel to Standalone Construct
+### 2.3 F2.3: CLI Registration Commands
 
-**New repo**: `0xHoneyJar/construct-the-easel`
+Three new commands added to the existing `constructs-install.sh` dispatch or as standalone scripts.
 
-#### 2.3.1 Repo Structure
-
-```
-construct-the-easel/
-├── construct.yaml          # v3 manifest
-├── identity/
-│   ├── persona.yaml        # Creative studio voice (domain-agnostic)
-│   └── expertise.yaml      # Design vocabulary, visual direction, taste documentation
-├── skills/
-│   ├── grounding-creative/
-│   │   ├── SKILL.md        # Generalized: reviews vocabulary + TDRs for any design area
-│   │   └── index.yaml      # model_tier: sonnet, danger_level: safe
-│   ├── exploring-visuals/
-│   │   ├── SKILL.md        # Generalized: generates prompts grounded in project vocabulary
-│   │   └── index.yaml
-│   ├── capturing-results/
-│   │   ├── SKILL.md        # Generalized: annotates results with vocabulary + TDR criteria
-│   │   └── index.yaml
-│   └── recording-taste/
-│       ├── SKILL.md        # Generalized: TDR CRUD operations
-│       └── index.yaml
-├── contexts/
-│   ├── vocabulary-template.md   # Empty 8-domain structure (no terms)
-│   ├── tdr-template.md          # Blank Taste Decision Record template
-│   └── quality-gates.md         # Generic Ground → Visualize → Tokenize → Implement gates
-└── README.md
-```
-
-#### 2.3.2 construct.yaml
-
-```yaml
-schema_version: 3
-name: "The Easel"
-slug: "the-easel"
-version: "1.0.0"
-description: "Creative studio for aesthetic direction — vocabulary grounding, visual exploration, result capture, and taste decisions. Domain-agnostic: install and populate with your project's aesthetic vocabulary."
-author: "0xHoneyJar"
-license: "MIT"
-type: "skill-pack"
-
-skills:
-  - slug: grounding-creative
-    path: skills/grounding-creative
-  - slug: exploring-visuals
-    path: skills/exploring-visuals
-  - slug: capturing-results
-    path: skills/capturing-results
-  - slug: recording-taste
-    path: skills/recording-taste
-
-identity:
-  persona: identity/persona.yaml
-  expertise: identity/expertise.yaml
-
-domain:
-  - design
-  - aesthetics
-  - visual-direction
-
-expertise:
-  - vocabulary-driven design
-  - taste decision records
-  - visual exploration
-  - aesthetic direction
-
-golden_path:
-  commands:
-    - name: ground
-      description: "Review vocabulary and TDRs for a design area"
-      truename_map:
-        no_vocabulary: /grounding-creative
-        vocabulary_ready: /grounding-creative
-    - name: explore
-      description: "Generate visual prompts grounded in vocabulary"
-      truename_map:
-        grounded: /exploring-visuals
-    - name: capture
-      description: "Annotate generation results with vocabulary terms"
-      truename_map:
-        explored: /capturing-results
-    - name: record
-      description: "Create or update a Taste Decision Record"
-      truename_map:
-        captured: /recording-taste
-
-events:
-  emits:
-    - name: forge.easel.vocabulary_grounded
-      description: "Vocabulary atlas reviewed and gaps identified"
-    - name: forge.easel.taste_recorded
-      description: "New TDR created or updated"
-  consumes:
-    - name: forge.artisan.taste_inscribed
-      description: "Can ground visual exploration in Artisan taste tokens"
-
-pack_dependencies:
-  optional:
-    - slug: artisan
-      reason: "Taste token handoff — Easel TDRs can inform Artisan inscribed tokens"
-
-workflow:
-  depth: light
-  gates:
-    prd: skip
-    sdd: skip
-    sprint: skip
-    implement: required
-    review: visual
-    audit: skip
-```
-
-#### 2.3.3 Skill Generalization Principles
-
-Each SKILL.md must:
-
-1. **Use context slots** for project-specific paths:
-   - `{{grimoire_path}}` → defaults to `grimoires/the-easel/` if not set
-   - `{{vocabulary_path}}` → defaults to `{{grimoire_path}}/vocabulary/atlas.md`
-   - `{{tdr_path}}` → defaults to `{{grimoire_path}}/tdr/`
-   - `{{generation_tool}}` → defaults to "your preferred image generation tool"
-
-2. **Zero domain-specific references**: No cyberpunk, no FUI, no rektdrop, no Freeside Divergence. The skills describe the *process*, not any specific aesthetic.
-
-3. **Ship empty templates**: `vocabulary-template.md` has the 8-domain structure with no terms. `tdr-template.md` is a blank TDR scaffold. Projects fill these in through the skills.
-
-#### 2.3.4 Registry Wiring
-
-Add to `seed-forge-packs.ts`:
-
-```typescript
-// GIT_CONFIGS
-'the-easel': {
-  gitUrl: 'https://github.com/0xHoneyJar/construct-the-easel.git',
-  gitRef: 'main',
-},
-
-// PACK_ICONS
-'the-easel': '🖼️',
-```
-
-#### 2.3.5 rektdrop-interface Update
-
-After extraction:
-1. Install The Easel from registry: `/constructs install the-easel`
-2. Keep existing `grimoires/the-easel/` (16 TDRs, atlas, aesthetic-direction) — this is project state
-3. Remove the embedded `.claude/constructs/packs/the-easel/` directory
-4. Skills now load from the installed pack but read/write to the existing grimoire paths
-
----
-
-### 2.4 F1.3: Activate detect_state in Golden Path
-
-**File**: `.claude/scripts/golden-path.sh`
-
-**Current** (lines 322-360): `golden_detect_construct_journeys()` builds journey bars from `golden_path.commands[].name` but ignores `detect_state`.
-
-**Change**: After extracting command names, check for `detect_state` script. If present, execute it and mark the current position.
-
-#### 2.4.1 Modified `golden_detect_construct_journeys()`
+#### 2.3a: `constructs register` — New script `constructs-register.sh`
 
 ```bash
-golden_detect_construct_journeys() {
-    local packs_dir="${PROJECT_ROOT}/.claude/constructs/packs"
-    [[ -d "$packs_dir" ]] || return 0
+# Usage:
+#   constructs-install.sh register <slug> --git-url <url> [--git-ref <ref>]
+#   constructs-install.sh register <slug> --name "Display Name" --git-url <url>
 
-    if ! type safe_yq_to_json &>/dev/null; then
-        return 0
-    fi
+# Flow:
+# 1. Validate inputs (slug format, URL format)
+# 2. Resolve API key via get_api_key()
+# 3. POST /v1/constructs/register { slug, name, type, git_url, git_ref }
+# 4. Display result: registry URL, sync status, skill count
+# 5. Optionally trigger first sync if git_url provided and register succeeded
+```
 
-    local manifest pack_name pack_dir commands_json detect_script current_state bar output=""
-    for manifest in "$packs_dir"/*/construct.yaml "$packs_dir"/*/construct.yml; do
-        [[ -f "$manifest" ]] || continue
-        pack_dir="$(dirname "$manifest")"
+API call pattern follows existing `constructs-browse.sh` — curl config file for auth:
 
-        # Extract golden_path via yq→jq
-        commands_json=$(safe_yq_to_json "$manifest" 2>/dev/null \
-            | jq -c '.golden_path.commands // empty' 2>/dev/null) || continue
-        [[ -z "$commands_json" || "$commands_json" == "null" ]] && continue
+```bash
+register_construct() {
+    local slug="$1" name="$2" git_url="$3" git_ref="${4:-main}"
+    local registry_url api_key
 
-        pack_name=$(safe_yq '.name' "$manifest" 2>/dev/null) || continue
-        [[ -z "$pack_name" ]] && continue
+    registry_url=$(get_registry_url)
+    api_key=$(get_api_key)
+    [[ -z "$api_key" ]] && { echo "ERROR: No API key. Run /constructs auth setup" >&2; return 1; }
 
-        # NEW: Execute detect_state script if declared
-        current_state=""
-        detect_script=$(safe_yq '.golden_path.detect_state' "$manifest" 2>/dev/null) || true
-        if [[ -n "$detect_script" && "$detect_script" != "null" ]]; then
-            local script_path="${pack_dir}/${detect_script}"
-            if [[ -f "$script_path" && -x "$script_path" ]]; then
-                current_state=$(cd "$pack_dir" && timeout 5 "$script_path" 2>/dev/null) || true
-            fi
-        fi
+    local curl_config
+    curl_config=$(mktemp)
+    chmod 600 "$curl_config"
+    echo "header = \"Authorization: Bearer ${api_key}\"" > "$curl_config"
 
-        # Build journey bar — mark current position with ●
-        bar=""
-        local first=true
-        while IFS= read -r cmd_name; do
-            [[ -z "$cmd_name" ]] && continue
-            local is_current=false
-            if [[ -n "$current_state" ]]; then
-                local mapped
-                mapped=$(echo "$commands_json" | jq -r \
-                    --arg name "$cmd_name" --arg state "$current_state" \
-                    '.[] | select(.name == $name) | .truename_map[$state] // empty' \
-                    2>/dev/null) || true
-                [[ -n "$mapped" ]] && is_current=true
-            fi
+    local body
+    body=$(jq -n \
+        --arg slug "$slug" \
+        --arg name "${name:-$slug}" \
+        --arg git_url "$git_url" \
+        --arg git_ref "$git_ref" \
+        '{slug: $slug, name: $name, git_url: $git_url, git_ref: $git_ref}')
 
-            local segment="/$cmd_name"
-            $is_current && segment="/$cmd_name ●"
+    local response http_code
+    response=$(curl -s -w "\n%{http_code}" \
+        --config "$curl_config" \
+        --proto =https --tlsv1.2 --max-time 120 \
+        -H "Content-Type: application/json" \
+        -d "$body" \
+        "${registry_url}/constructs/register")
 
-            if $first; then
-                bar="$segment"
-                first=false
-            else
-                bar="$bar ━━━ $segment"
-            fi
-        done < <(echo "$commands_json" | jq -r '.[].name' 2>/dev/null)
-
-        [[ -n "$bar" ]] && output="${output}  ${pack_name}: ${bar}"$'\n'
-    done
-
-    [[ -n "$output" ]] && printf "%s" "$output"
+    rm -f "$curl_config"
+    # Parse response...
 }
 ```
 
-#### 2.4.2 detect_state Script Contract
+#### 2.3b: `constructs sync` — Added to install dispatch
 
-A `detect_state` script must:
-- Be executable (`chmod +x`)
-- Print a single state string to stdout (e.g., `canvases_ready`, `grounded`, `no_vocabulary`)
-- Exit 0 on success, non-zero to indicate "unknown state"
-- Complete within 5 seconds
-- Read from the project's grimoire/state files, never write
+```bash
+# Usage:
+#   constructs-install.sh sync <slug>
+
+# Flow:
+# 1. Verify pack exists locally (check .constructs-meta.json)
+# 2. Resolve API key
+# 3. POST /v1/packs/<slug>/sync
+# 4. Display: version synced, files changed, commit hash
+# 5. If local install exists, offer to reinstall from updated registry
+```
+
+#### 2.3c: `constructs status` — Added to install dispatch
+
+```bash
+# Usage:
+#   constructs-install.sh status <slug>
+
+# Flow:
+# 1. Read local meta from .constructs-meta.json (installed version, content hash)
+# 2. GET /v1/constructs/<slug> (registry info)
+# 3. GET /v1/packs/<slug>/hash (registry content hash)
+# 4. Compare:
+#    - Version: local vs registry → [SYNCED] / [BEHIND] / [AHEAD]
+#    - Hash: local vs registry → [MATCH] / [DIVERGED]
+# 5. Display formatted status
+```
+
+Status display format:
+
+```
+Pack: observer
+  Installed: v2.0.0 (2026-02-15)
+  Registry:  v2.0.0 (2026-02-27)
+  Source:    git (https://github.com/0xHoneyJar/construct-observer.git)
+  Hash:      [MATCH] a3f2c1...
+  Status:    [SYNCED]
+
+Pack: artisan
+  Installed: v1.0.0 (2026-01-20)
+  Registry:  v2.0.0 (2026-02-25)
+  Hash:      [DIVERGED] local:b4e2d1... registry:f7a8c3...
+  Status:    [BEHIND] — run /constructs sync artisan
+```
+
+#### 2.3d: Update browsing-constructs skill
+
+**File**: `.claude/skills/browsing-constructs/SKILL.md`
+
+Add three new commands to the skill's command table:
+
+```markdown
+| `/constructs register <slug> --git-url <url>` | Register a new construct from a git repo |
+| `/constructs sync <slug>` | Sync installed construct from registry |
+| `/constructs status [slug]` | Show sync status and version comparison |
+```
+
+Update the dispatch logic to call the new scripts.
 
 ---
 
-### 2.5 F1.4: Post-Install Hook Execution
+### 2.4 F2.4: GitHub Webhook — No Work Needed
 
-**File**: `.claude/scripts/constructs-install.sh`
+`POST /v1/webhooks/github` at `webhooks.ts:380-615` is fully implemented:
+- HMAC-SHA256 signature verification
+- Replay protection via `github_webhook_deliveries`
+- Pack matching by `githubRepoId` or `gitUrl`
+- Rate limiting per pack
+- Full sync transaction
 
-After pack file extraction completes (where symlinks are created for commands), add:
+`POST /v1/webhooks/configure` at `webhooks.ts:627-679` provides setup instructions.
 
-```bash
-execute_post_install_hook() {
-    local pack_dir="$1"
-    local manifest="${pack_dir}/construct.yaml"
-    [[ -f "$manifest" ]] || return 0
-
-    if ! type safe_yq &>/dev/null 2>&1; then return 0; fi
-
-    local hook_script
-    hook_script=$(safe_yq '.hooks.post_install' "$manifest" 2>/dev/null) || return 0
-    [[ -z "$hook_script" || "$hook_script" == "null" ]] && return 0
-
-    local script_path="${pack_dir}/${hook_script}"
-
-    # Security: validate script is within pack directory
-    local real_script real_pack
-    real_script=$(realpath "$script_path" 2>/dev/null) || return 0
-    real_pack=$(realpath "$pack_dir" 2>/dev/null) || return 0
-    if [[ "$real_script" != "$real_pack"* ]]; then
-        echo "⚠ Post-install hook path traversal blocked: $hook_script" >&2
-        return 0
-    fi
-
-    if [[ -f "$script_path" && -x "$script_path" ]]; then
-        echo "  Running post-install hook..."
-        if ! (cd "$pack_dir" && timeout 30 "$script_path" 2>&1); then
-            echo "  ⚠ Post-install hook failed (non-blocking)" >&2
-        fi
-    fi
-}
-```
-
-**Security constraints**:
-- Path traversal prevention via `realpath` comparison
-- 30-second timeout
-- Executes in pack directory context
-- Non-blocking — failure is a warning, not an error
+No changes needed.
 
 ---
 
 ## 3. Data Flow
 
-### Before (Current)
+### Register Flow (New)
 
 ```
-construct.yaml (30 fields)
-  → seed-forge-packs.ts (reads YAML)
-    → manual extraction (7 fields)
-      → pack_versions.manifest (7-field JSON)
-        → API response (7 fields)
+CLI: /constructs register my-pack --git-url https://github.com/org/construct-my-pack.git
+  → constructs-register.sh
+    → POST /v1/constructs/register { slug, name, git_url, git_ref }
+      → Create pack (status: published)
+      → validateGitUrl() → cloneRepo() → readManifest() → collectFiles()
+      → INSERT pack_versions (full manifest + content hash)
+      → UPSERT construct_identities (if identity/ present)
+      → Fetch githubRepoId from GitHub API
+      → UPDATE packs SET sourceType, gitUrl, gitRef, githubRepoId
+    ← { slug, version, files_synced, registry_url }
 ```
 
-### After (Phase 1)
+### Sync Flow (Existing API, New CLI)
 
 ```
-construct.yaml (30 fields)
-  → seed-forge-packs.ts (reads YAML)
-    → Zod validation (packManifestSchema)
-      → pack_versions.manifest (full JSON) + content_hash
-        → API response (full fields — no API changes needed)
-        → golden-path.sh reads detect_state, executes script
-        → construct-workflow-read.sh reads workflow.gates (already works)
+CLI: /constructs sync my-pack
+  → constructs-install.sh sync my-pack
+    → POST /v1/packs/my-pack/sync
+      → checkSyncRateLimit()
+      → syncFromRepo(gitUrl, gitRef)
+      → Compare content_hash
+      → INSERT/UPDATE pack_versions if changed
+      → recordSyncEvent('manual')
+    ← { version, commit, files_synced }
+  → If installed locally: offer reinstall from updated registry
+```
+
+### Status Flow (New)
+
+```
+CLI: /constructs status my-pack
+  → constructs-install.sh status my-pack
+    → Read .constructs-meta.json (local version, hash)
+    → GET /v1/constructs/my-pack (registry version)
+    → GET /v1/packs/my-pack/hash (registry hash)
+    → Compare version + hash
+    ← Formatted status display
 ```
 
 ---
 
-## 4. Migration Strategy
+## 4. Files Modified
 
-### Step 1: Dry-Run Validation
-Run `seed-forge-packs.ts --dry-run` against all 10 construct repos. Fix any manifests that fail Zod validation BEFORE deploying.
+| File | Change Type | Description |
+|------|------------|-------------|
+| `apps/api/src/routes/constructs.ts` | Modified | Extend register schema with git_url/git_ref, fix userEmail bug |
+| `.claude/scripts/constructs-register.sh` | Created | New CLI registration command |
+| `.claude/scripts/constructs-install.sh` | Modified | Add sync + status subcommands to dispatch |
+| `.claude/skills/browsing-constructs/SKILL.md` | Modified | Add register, sync, status commands |
 
-### Step 2: Deploy Seed Script
-Update script, add 4 new GIT_CONFIGS entries, run against production DB.
-
-### Step 3: Deploy CLI Changes
-Update golden-path.sh and constructs-install.sh.
-
-### Step 4: Verify End-to-End
-- `/constructs browse` shows 10 packs
-- `/constructs install herald` succeeds
-- `/constructs install the-easel` succeeds
-- `/loa` shows construct journey bars with `●` position indicator
-- Explorer detail page shows golden_path, workflow, events, domain, expertise fields
+**No changes to**:
+- `apps/api/src/routes/packs.ts` — sync and register-repo endpoints already complete
+- `apps/api/src/routes/webhooks.ts` — GitHub webhook already complete
+- `apps/api/src/services/git-sync.ts` — sync service already complete
+- Database schema — all columns exist
 
 ---
 
@@ -542,35 +299,16 @@ Update golden-path.sh and constructs-install.sh.
 
 | Test | Type | Validates |
 |------|------|-----------|
-| Zod validation of all 10 construct.yaml files | Unit | F1.1 — no manifest regressions |
-| Seed script dry-run against prod clone | Integration | F1.1 — full manifest stored |
-| Content hash determinism | Unit | F1.1 — same input = same hash |
-| `golden_detect_construct_journeys` with mock detect_state | Unit | F1.3 — position indicator |
-| detect_state timeout handling | Unit | F1.3 — slow scripts don't block |
-| Post-install hook path traversal rejection | Unit | F1.4 — security enforced |
-| Post-install hook timeout handling | Unit | F1.4 — slow hooks don't block |
-| The Easel skills have zero cyberpunk references | Audit | F1.5 — domain-agnostic |
-| The Easel context slots have sensible defaults | Audit | F1.5 — works without config |
-| Full install → `/loa` → journey bar flow | E2E | All features integrated |
+| Register with git_url creates published pack | Integration | F2.1a — one-step register+link |
+| Register without git_url creates draft | Integration | F2.1a — backwards compatible |
+| Register with invalid git_url returns 400 | Integration | F2.1a — validation |
+| Fix: userEmail uses AuthUser.email | Unit | F2.1b — context variable |
+| CLI register calls correct endpoint | Unit | F2.3a — API integration |
+| CLI sync triggers re-download | Integration | F2.3b — local update |
+| CLI status shows SYNCED/BEHIND/DIVERGED | Unit | F2.3c — hash comparison |
+| Rate limit blocks >10 syncs/hour | Integration | Existing — verify |
+| Webhook triggers sync on push | Integration | Existing — verify |
 
 ---
 
-## 6. Files Modified
-
-| File | Change Type | Description |
-|------|------------|-------------|
-| `scripts/seed-forge-packs.ts` | Modified | Full manifest extraction, 4 new GIT_CONFIGS entries, content hash, dry-run mode |
-| `.claude/scripts/golden-path.sh` | Modified | detect_state activation in `golden_detect_construct_journeys()` |
-| `.claude/scripts/constructs-install.sh` | Modified | Post-install hook execution after extraction |
-| `construct-the-easel/` (new repo) | Created | 4 generalized skills, construct.yaml v3, identity, empty templates |
-
-**No changes to**:
-- `packages/shared/src/types.ts` — types already declare all fields
-- `packages/shared/src/validation.ts` — Zod schema already validates all fields
-- `apps/api/src/routes/constructs.ts` — API already destructures from manifest JSONB
-- `apps/api/src/db/schema.ts` — `content_hash` column already exists
-- `apps/explorer/` — explorer already renders fields when present in API response
-
----
-
-*"The data was always there. The pipe was just too narrow."*
+*"The infrastructure was already built. We just needed to put a door on the front."*

--- a/grimoires/loa/sdd.md
+++ b/grimoires/loa/sdd.md
@@ -1,314 +1,209 @@
-# SDD: Constructs Network Distribution Layer — Phase 2 Self-Service
+# SDD: Constructs Network Distribution Layer — Phase 3 Cross-Platform & Navigation
 
 **Cycle**: cycle-036
 **Created**: 2026-02-27
 **Status**: Draft
 **PRD**: `grimoires/loa/prd.md` (Constructs Network Distribution Layer)
-**Scope**: Phase 2 — F2.1, F2.2, F2.3, F2.4
-**Depends on**: Phase 1 (complete — PR #143)
+**Scope**: Phase 3 — F3.1, F3.2, F3.3
+**Depends on**: Phase 1 (complete), Phase 2 (complete)
 
 ---
 
 ## 1. Overview
 
-Phase 2 enables self-service construct registration, sync, and status checking from the CLI. The critical discovery: **75% of the API surface already exists**.
+Phase 3 closes the distribution layer with three features: standalone skill compatibility, per-invocation navigation, and local content-hash divergence detection.
 
-### Existing Infrastructure (Already Implemented)
+### Key Discovery: Skills Are Already 90% Standalone
 
-| Feature | Endpoint | Status | File |
-|---------|----------|--------|------|
-| Register repo | `POST /v1/packs/:slug/register-repo` | Complete | `packs.ts:764` |
-| Sync from git | `POST /v1/packs/:slug/sync` | Complete | `packs.ts:879` |
-| GitHub webhook | `POST /v1/webhooks/github` | Complete | `webhooks.ts:380` |
-| Webhook config | `POST /v1/webhooks/configure` | Complete | `webhooks.ts:627` |
-| Git sync service | `syncFromRepo()` | Complete | `git-sync.ts:784` |
-| Rate limiting | `checkSyncRateLimit()` | Complete | `sync-rate-limit.ts` |
-| Git URL validation | `validateGitUrl()` | Complete | `git-sync.ts:170` |
+The Loa framework skills (55 skills in `.claude/skills/`) have **zero** hard pack-level dependencies. The installed construct pack skills (23 skills across 5 packs) have two categories of non-standalone patterns:
+
+| Pattern | Count | Severity | Fix |
+|---------|-------|----------|-----|
+| `{context:...}` slots without fallback defaults | 23 skills | Medium — verbatim literal in output | Add default values in SKILL.md |
+| `grimoires/` read-dependencies | ~5 skills | Low — skills create the files they need | Document as optional |
+| `resources/` template refs | 2 skills | Low — bundled with pack | Note standalone limitation |
+| `persona.yaml` / `construct.yaml` refs | 0 skills | N/A | Already clean |
+
+### Existing Infrastructure
+
+| Feature | Status | File |
+|---------|--------|------|
+| `golden_path.detect_state` execution | Complete | `golden-path.sh:323` |
+| `GET /v1/packs/:slug/hash` | Complete | `packs.ts:1596` |
+| `compute_file_sha256` | Complete | `constructs-install.sh:1530` |
+| `update_pack_meta()` with git fields | Complete | `constructs-install.sh:913` |
+| Static "Next Steps" in skill outputs | Exists (6 skills) | Various SKILL.md files |
+| `validate-skills.sh` | Complete but no standalone check | `scripts/validate-skills.sh` |
 
 ### What Needs Building
 
 | Feature | Type | Effort |
 |---------|------|--------|
-| F2.1a: Extend register endpoint to accept `git_url` | API extension | Small (~30 lines) |
-| F2.1b: Fix `userEmail` context bug | Bug fix | Trivial (1 line) |
-| F2.3a: `constructs register` CLI command | New script | Medium (~200 lines) |
-| F2.3b: `constructs sync` CLI command | New script | Small (~100 lines) |
-| F2.3c: `constructs status` CLI command | New script | Medium (~150 lines) |
-| F2.3d: Update browsing-constructs skill | Skill update | Small (~50 lines) |
+| F3.1: Standalone audit check in validate-skills.sh | Script extension | Small (~40 lines) |
+| F3.1: Context slot default documentation | Doc updates | Small (23 skills need headers) |
+| F3.2: `## Next Steps` output section standard | Spec + SKILL.md updates | Medium (~30 lines per skill) |
+| F3.2: golden_path declarations in construct.yaml | Manifest updates | Small (~10 lines per pack) |
+| F3.3: Local content hash at install time | Script extension | Small (~30 lines) |
+| F3.3: Hash comparison in status command | Script extension | Small (~20 lines) |
 
-Total new code: ~530 lines across 4 files + 2 modified files.
+Total new code: ~300 lines across scripts + doc updates across skills.
 
 ---
 
 ## 2. Detailed Design
 
-### 2.1 F2.1a: Extend Register Endpoint
+### 2.1 F3.1: Standalone SKILL.md Audit
 
-**File**: `apps/api/src/routes/constructs.ts` (lines 257-339)
+#### 2.1a: Extend validate-skills.sh
 
-**Current**: Accepts `{ slug, name, type }`, creates pack with `status: 'draft'`, `sourceType: 'registry'`.
+**File**: `.claude/scripts/validate-skills.sh`
 
-**Change**: Add optional `git_url` and `git_ref` fields. When provided, chain to the existing `register-repo` logic after pack creation.
+Add a `--standalone` flag that checks each skill SKILL.md for:
+1. `{context:...}` slots without documented defaults
+2. Hard file reads from `grimoires/` without "if exists" guards
+3. References to pack-level files (`persona.yaml`, `construct.yaml`) as runtime deps
 
-```typescript
-// Extended request schema (line ~268)
-const registerSchema = z.object({
-  slug: z.string().min(3).max(100).regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/),
-  name: z.string().min(1).max(255),
-  type: z.enum(['skill-pack', 'tool-pack', 'codex', 'template']).optional().default('skill-pack'),
-  git_url: z.string().url().optional(),
-  git_ref: z.string().max(100).optional().default('main'),
-});
+Report format:
+```
+STANDALONE AUDIT
+================
+PASS: 55/78 skills are fully standalone
+WARN: 23/78 skills have context slots needing defaults
+  - beacon/accepting-payments: {context:chain_config.default_token} (no default)
+  - crucible/validating-journeys: {context:qa_fixtures} (no default)
+  ...
 ```
 
-When `git_url` is provided:
-1. Create pack (existing logic)
-2. Call `validateGitUrl(git_url)` from `git-sync.ts`
-3. Clone + read manifest (existing `syncFromRepo()`)
-4. Update pack with `sourceType='git'`, `gitUrl`, `gitRef`, `githubRepoId`
-5. Create first `pack_version` with full validated manifest
-6. Auto-publish pack (set `status: 'published'`) since manifest validation passed
-7. Return enriched response including version info
+#### 2.1b: Context Slot Default Documentation
 
-Without `git_url`: existing behavior (slug reservation only).
+For each of the 23 skills using `{context:...}` slots, add a **Required Context** header at the top of the SKILL.md that documents:
+1. Which context keys are needed
+2. What the slot does
+3. A sensible placeholder/default when context is unavailable
 
-### 2.1b: Fix userEmail Context Bug
+This is documentation only — the Loa runtime already handles context resolution. The goal is that an agent on Cursor/Copilot can read the SKILL.md and understand what values to substitute.
 
-**File**: `apps/api/src/routes/constructs.ts` (line ~279)
+**Pattern** (already used by beacon skills like `accepting-payments`):
+```markdown
+> **Required context:** `chain_config` overlay
+> Provide `chain_config.default_token`, `chain_config.network_id`, etc.
+> Without context, slots appear as `{context:...}` literals.
+```
 
-**Current**: `c.get('userEmail' as never)` — cast hack, `userEmail` not in `ContextVariableMap`
-**Fix**: `c.get('user').email` — uses the declared `user: AuthUser` context variable
-
-Also gate on `c.get('user').emailVerified` for registration.
+Scope: Review and document the 23 skills. Many already have partial documentation — standardize the format.
 
 ---
 
-### 2.2 F2.2: Sync Endpoint — No Work Needed
+### 2.2 F3.2: Per-Invocation Call-to-Actions
 
-`POST /v1/packs/:slug/sync` at `packs.ts:879-1090` is fully implemented:
-- Owner auth verification
-- `sourceType === 'git'` guard
-- Rate limiting (10/hour via `pack_sync_events`)
-- Full content sync via `syncFromRepo()`
-- Content hash computation
-- Identity parsing and upsert
-- Sync event recording
+#### Approach: SKILL.md Output Spec Enrichment
 
-No changes needed.
+Rather than building new runtime infrastructure, standardize the existing pattern where skills include `## Next Steps` in their output format spec. This is the lowest-infrastructure approach and works across all 37+ SKILL.md-compatible platforms.
+
+**Why not a runtime hook?** No packs currently declare `golden_path.commands` or `golden_path.detect_state`. Building a `constructs-loader.sh post-execution` hook would be dead code. Instead, formalize the static pattern that 6 skills already use.
+
+#### Standard
+
+Every skill that belongs to a pack with multiple skills SHOULD include a `## Next Steps` section at the end of its output format spec. The section:
+
+1. Lists 2-3 logical next commands from the same pack
+2. Uses conditional phrasing when suggestions depend on output state
+3. Always includes `/loa` as a fallback orientation command
+
+**Example** (for observer/analyzing-gaps):
+```markdown
+## Next Steps
+
+- `/file-gap` — File issues from gaps identified above
+- `/diagram` — Update state diagrams with new findings
+- `/loa` — Check your full workflow status
+```
+
+#### Scope
+
+Add `## Next Steps` sections to skills that don't already have them and belong to multi-skill packs. Prioritize the 5 installed packs (observer, artisan, crucible, beacon, gtm-collective).
+
+**Already have Next Steps** (6 skills): grounding-code, validating-journeys, analyzing-gaps, diagramming-states, accepting-payments, auditing-content
+
+**Need Next Steps**: Remaining skills in multi-skill packs (~15-20 skills).
+
+This is a documentation task, not a code change.
 
 ---
 
-### 2.3 F2.3: CLI Registration Commands
+### 2.3 F3.3: Content-Hash Staleness Detection
 
-Three new commands added to the existing `constructs-install.sh` dispatch or as standalone scripts.
+#### 2.3a: Compute Local Hash at Install Time
 
-#### 2.3a: `constructs register` — New script `constructs-register.sh`
+**File**: `constructs-install.sh` — modify `update_pack_meta()`
 
-```bash
-# Usage:
-#   constructs-install.sh register <slug> --git-url <url> [--git-ref <ref>]
-#   constructs-install.sh register <slug> --name "Display Name" --git-url <url>
-
-# Flow:
-# 1. Validate inputs (slug format, URL format)
-# 2. Resolve API key via get_api_key()
-# 3. POST /v1/constructs/register { slug, name, type, git_url, git_ref }
-# 4. Display result: registry URL, sync status, skill count
-# 5. Optionally trigger first sync if git_url provided and register succeeded
-```
-
-API call pattern follows existing `constructs-browse.sh` — curl config file for auth:
+After pack installation, compute the Merkle-root SHA-256 hash (same algorithm as the API):
 
 ```bash
-register_construct() {
-    local slug="$1" name="$2" git_url="$3" git_ref="${4:-main}"
-    local registry_url api_key
-
-    registry_url=$(get_registry_url)
-    api_key=$(get_api_key)
-    [[ -z "$api_key" ]] && { echo "ERROR: No API key. Run /constructs auth setup" >&2; return 1; }
-
-    local curl_config
-    curl_config=$(mktemp)
-    chmod 600 "$curl_config"
-    echo "header = \"Authorization: Bearer ${api_key}\"" > "$curl_config"
-
-    local body
-    body=$(jq -n \
-        --arg slug "$slug" \
-        --arg name "${name:-$slug}" \
-        --arg git_url "$git_url" \
-        --arg git_ref "$git_ref" \
-        '{slug: $slug, name: $name, git_url: $git_url, git_ref: $git_ref}')
-
-    local response http_code
-    response=$(curl -s -w "\n%{http_code}" \
-        --config "$curl_config" \
-        --proto =https --tlsv1.2 --max-time 120 \
-        -H "Content-Type: application/json" \
-        -d "$body" \
-        "${registry_url}/constructs/register")
-
-    rm -f "$curl_config"
-    # Parse response...
+compute_pack_hash() {
+    local pack_dir="$1"
+    # Compute SHA-256 of each file, sort by path, then hash the concatenation
+    find "$pack_dir" -type f -not -name '.license.json' -not -name '.constructs-meta.json' | \
+        sort | \
+        while read -r file; do
+            local rel_path="${file#$pack_dir/}"
+            local file_hash
+            file_hash=$(sha256sum "$file" | cut -d' ' -f1)
+            echo "$rel_path:$file_hash"
+        done | sha256sum | cut -d' ' -f1
 }
 ```
 
-#### 2.3b: `constructs sync` — Added to install dispatch
-
-```bash
-# Usage:
-#   constructs-install.sh sync <slug>
-
-# Flow:
-# 1. Verify pack exists locally (check .constructs-meta.json)
-# 2. Resolve API key
-# 3. POST /v1/packs/<slug>/sync
-# 4. Display: version synced, files changed, commit hash
-# 5. If local install exists, offer to reinstall from updated registry
+Store result in `.constructs-meta.json`:
+```json
+{
+  "installed_packs": {
+    "artisan": {
+      "version": "1.0.0",
+      "content_hash": "sha256:a3f2c1...",
+      ...
+    }
+  }
+}
 ```
 
-#### 2.3c: `constructs status` — Added to install dispatch
+#### 2.3b: Compare Hashes in Status Command
 
-```bash
-# Usage:
-#   constructs-install.sh status <slug>
+**File**: `constructs-install.sh` — modify `show_pack_status()`
 
-# Flow:
-# 1. Read local meta from .constructs-meta.json (installed version, content hash)
-# 2. GET /v1/constructs/<slug> (registry info)
-# 3. GET /v1/packs/<slug>/hash (registry content hash)
-# 4. Compare:
-#    - Version: local vs registry → [SYNCED] / [BEHIND] / [AHEAD]
-#    - Hash: local vs registry → [MATCH] / [DIVERGED]
-# 5. Display formatted status
-```
+Read local `content_hash` from meta, compare against registry hash (already fetched). Display:
 
-Status display format:
-
-```
-Pack: observer
-  Installed: v2.0.0 (2026-02-15)
-  Registry:  v2.0.0 (2026-02-27)
-  Source:    git (https://github.com/0xHoneyJar/construct-observer.git)
-  Hash:      [MATCH] a3f2c1...
-  Status:    [SYNCED]
-
-Pack: artisan
-  Installed: v1.0.0 (2026-01-20)
-  Registry:  v2.0.0 (2026-02-25)
-  Hash:      [DIVERGED] local:b4e2d1... registry:f7a8c3...
-  Status:    [BEHIND] — run /constructs sync artisan
-```
-
-#### 2.3d: Update browsing-constructs skill
-
-**File**: `.claude/skills/browsing-constructs/SKILL.md`
-
-Add three new commands to the skill's command table:
-
-```markdown
-| `/constructs register <slug> --git-url <url>` | Register a new construct from a git repo |
-| `/constructs sync <slug>` | Sync installed construct from registry |
-| `/constructs status [slug]` | Show sync status and version comparison |
-```
-
-Update the dispatch logic to call the new scripts.
+| Local Hash | Registry Hash | Display |
+|-----------|--------------|---------|
+| Match | Match | `[SYNCED]` |
+| Different | Present | `[DIVERGED]` — local files modified |
+| Present | Different version | `[BEHIND]` — registry has newer version |
+| Missing | Present | `[UNKNOWN]` — reinstall to compute hash |
 
 ---
 
-### 2.4 F2.4: GitHub Webhook — No Work Needed
-
-`POST /v1/webhooks/github` at `webhooks.ts:380-615` is fully implemented:
-- HMAC-SHA256 signature verification
-- Replay protection via `github_webhook_deliveries`
-- Pack matching by `githubRepoId` or `gitUrl`
-- Rate limiting per pack
-- Full sync transaction
-
-`POST /v1/webhooks/configure` at `webhooks.ts:627-679` provides setup instructions.
-
-No changes needed.
-
----
-
-## 3. Data Flow
-
-### Register Flow (New)
-
-```
-CLI: /constructs register my-pack --git-url https://github.com/org/construct-my-pack.git
-  → constructs-register.sh
-    → POST /v1/constructs/register { slug, name, git_url, git_ref }
-      → Create pack (status: published)
-      → validateGitUrl() → cloneRepo() → readManifest() → collectFiles()
-      → INSERT pack_versions (full manifest + content hash)
-      → UPSERT construct_identities (if identity/ present)
-      → Fetch githubRepoId from GitHub API
-      → UPDATE packs SET sourceType, gitUrl, gitRef, githubRepoId
-    ← { slug, version, files_synced, registry_url }
-```
-
-### Sync Flow (Existing API, New CLI)
-
-```
-CLI: /constructs sync my-pack
-  → constructs-install.sh sync my-pack
-    → POST /v1/packs/my-pack/sync
-      → checkSyncRateLimit()
-      → syncFromRepo(gitUrl, gitRef)
-      → Compare content_hash
-      → INSERT/UPDATE pack_versions if changed
-      → recordSyncEvent('manual')
-    ← { version, commit, files_synced }
-  → If installed locally: offer reinstall from updated registry
-```
-
-### Status Flow (New)
-
-```
-CLI: /constructs status my-pack
-  → constructs-install.sh status my-pack
-    → Read .constructs-meta.json (local version, hash)
-    → GET /v1/constructs/my-pack (registry version)
-    → GET /v1/packs/my-pack/hash (registry hash)
-    → Compare version + hash
-    ← Formatted status display
-```
-
----
-
-## 4. Files Modified
+## 3. Files Modified
 
 | File | Change Type | Description |
 |------|------------|-------------|
-| `apps/api/src/routes/constructs.ts` | Modified | Extend register schema with git_url/git_ref, fix userEmail bug |
-| `.claude/scripts/constructs-register.sh` | Created | New CLI registration command |
-| `.claude/scripts/constructs-install.sh` | Modified | Add sync + status subcommands to dispatch |
-| `.claude/skills/browsing-constructs/SKILL.md` | Modified | Add register, sync, status commands |
+| `.claude/scripts/validate-skills.sh` | Modified | Add `--standalone` audit flag |
+| `.claude/scripts/constructs-install.sh` | Modified | `compute_pack_hash()` + store in meta + compare in status |
+| `.claude/constructs/packs/*/skills/*/SKILL.md` | Modified | Context slot defaults + Next Steps sections |
 
-**No changes to**:
-- `apps/api/src/routes/packs.ts` — sync and register-repo endpoints already complete
-- `apps/api/src/routes/webhooks.ts` — GitHub webhook already complete
-- `apps/api/src/services/git-sync.ts` — sync service already complete
-- Database schema — all columns exist
+**No API changes needed** — all infrastructure exists.
 
 ---
 
-## 5. Testing Strategy
+## 4. Testing Strategy
 
 | Test | Type | Validates |
-|------|------|-----------|
-| Register with git_url creates published pack | Integration | F2.1a — one-step register+link |
-| Register without git_url creates draft | Integration | F2.1a — backwards compatible |
-| Register with invalid git_url returns 400 | Integration | F2.1a — validation |
-| Fix: userEmail uses AuthUser.email | Unit | F2.1b — context variable |
-| CLI register calls correct endpoint | Unit | F2.3a — API integration |
-| CLI sync triggers re-download | Integration | F2.3b — local update |
-| CLI status shows SYNCED/BEHIND/DIVERGED | Unit | F2.3c — hash comparison |
-| Rate limit blocks >10 syncs/hour | Integration | Existing — verify |
-| Webhook triggers sync on push | Integration | Existing — verify |
+|------|------|-----------:|
+| `validate-skills.sh --standalone` passes | Unit | F3.1 — standalone audit |
+| Context slot documentation present for all 23 skills | Manual audit | F3.1 — degradation docs |
+| `## Next Steps` present in all multi-pack skills | Manual audit | F3.2 — CTA coverage |
+| `content_hash` written to meta on install | Integration | F3.3 — hash computation |
+| `status` shows SYNCED/DIVERGED correctly | Integration | F3.3 — hash comparison |
 
 ---
 
-*"The infrastructure was already built. We just needed to put a door on the front."*
+*"Standalone compatibility is not about removing the construct layer. It's about making it optional."*

--- a/grimoires/loa/sdd.md
+++ b/grimoires/loa/sdd.md
@@ -1,1007 +1,576 @@
-# SDD: R&D Synthesis — Measurement Honesty
+# SDD: Constructs Network Distribution Layer — Phase 1 Foundation
 
-**Cycle**: cycle-035
-**Created**: 2026-02-22
+**Cycle**: cycle-036
+**Created**: 2026-02-27
 **Status**: Draft
-**PRD**: `grimoires/loa/prd.md`
-**Predecessor**: cycle-034 SDD (Type System, Dependency Graph — archived)
-**Grounded in**:
-- `schema.ts:472-553` (packs table), `schema.ts:1175-1206` (construct_verifications)
-- `packs.ts:1669-1740` (fork endpoint), `packs.ts:879-1048` (sync endpoint)
-- `constructs.ts:136-147` (RELEVANCE_WEIGHTS), `constructs.ts:340-422` (packToConstruct)
-- `page.tsx:128-130` (Level label), `page.tsx:139-168` (identity JSONB)
-- `fetch-constructs.ts:9-50` (APIConstruct), `transform-construct.ts:39-88` (transformToDetail)
+**PRD**: `grimoires/loa/prd.md` (Constructs Network Distribution Layer)
+**Scope**: Phase 1 only — F1.1, F1.2, F1.5, F1.3, F1.4
 
 ---
 
-## 1. Executive Summary
+## 1. Overview
 
-This SDD details the architecture for cycle-035: Measurement Honesty. The work spans 3 sprints across the API (`apps/api`) and Explorer (`apps/explorer`), adding:
+Phase 1 fixes the plumbing between construct repos and the registry database. Five changes, all in existing files:
 
-1. **Signal outcomes tracking** — new table, 4 endpoints, accuracy computation with statistical rigor
-2. **Fork provenance** — schema column, endpoint fix, API response enrichment
-3. **SKILL.md prose pipeline** — extraction during sync, sanitized storage, Explorer rendering
-4. **Diagnostic language** — replace theatrical "Level" framing with `git status` diagnostics
-5. **Graduation criteria overhaul** — kill download counts, replace with automatable criteria
-6. **Certificate rename** — CalibrationCertificate → VerificationCertificate (comments/docs only)
-7. **Built With showcases** — new table, 2 endpoints, Explorer section (Sprint 3)
+| ID | Change | Files | Lines |
+|----|--------|-------|-------|
+| F1.1 | Full manifest extraction | `scripts/seed-forge-packs.ts` | ~30 changed |
+| F1.2 | Register 3 constructs | `scripts/seed-forge-packs.ts` | ~20 added |
+| F1.5 | Extract The Easel | New repo `construct-the-easel` + seed entry | New repo + ~10 lines |
+| F1.3 | Activate detect_state | `.claude/scripts/golden-path.sh` | ~40 added |
+| F1.4 | Post-install hooks | `.claude/scripts/constructs-install.sh` | ~30 added |
 
-All database changes are additive (no column removals, no type changes). All API changes are backwards-compatible (new endpoints + new optional fields on existing responses).
-
----
-
-## 2. System Architecture
-
-### Affected Components
-
-```
-┌─────────────────────────────────────────────────────┐
-│ Explorer (Next.js 15, Vercel)                       │
-│  ├── constructs/[slug]/page.tsx  (FR3, FR4, FR5)    │
-│  ├── constructs browse cards     (FR5)              │
-│  └── lib/data/transform-construct.ts (new fields)   │
-├─────────────────────────────────────────────────────┤
-│ API (Hono, Railway)                                  │
-│  ├── routes/signals.ts           (FR1 — NEW FILE)   │
-│  ├── routes/packs.ts             (FR2, FR4, FR6)    │
-│  ├── services/constructs.ts      (FR7)              │
-│  ├── services/signals.ts         (FR1 — NEW FILE)   │
-│  └── services/showcases.ts       (FR6 — NEW FILE)   │
-├─────────────────────────────────────────────────────┤
-│ Database (Supabase PostgreSQL)                       │
-│  ├── schema.ts                   (FR1, FR2, FR4, FR6)│
-│  └── drizzle/0006_measurement_honesty.sql            │
-├─────────────────────────────────────────────────────┤
-│ Docs                                                 │
-│  ├── GRADUATION.md               (FR7)              │
-│  └── grimoires/bridgebuilder/*   (FR8)              │
-└─────────────────────────────────────────────────────┘
-```
-
-### Unchanged Components
-
-- Redis caching (Upstash) — existing `constructList` cache covers new pack fields. **New cache key**: `accuracy:{packId}` with 10-min TTL for accuracy computation (see §4.1.7)
-- Auth middleware (`requireAuth`, `optionalAuth`) — reused as-is
-- Stripe/NowPayments — untouched
-- MCP registry — untouched
+No new tables. No new API routes. No new packages. The downstream consumers (explorer, CLI browse, golden path, workflow gate reader) already know how to read these fields — they just need the data.
 
 ---
 
-## 3. Data Architecture
+## 2. Detailed Design
 
-### 3.1 Migration: `0006_measurement_honesty.sql`
+### 2.1 F1.1: Full Manifest Extraction in Seed Script
 
-Single migration file. All changes additive, safe for zero-downtime deployment.
+**File**: `scripts/seed-forge-packs.ts`
 
-#### 3.1.1 New columns on `packs` table
-
-```sql
--- Fork provenance (FR2)
-ALTER TABLE packs ADD COLUMN forked_from UUID REFERENCES packs(id);
-CREATE INDEX idx_packs_forked_from ON packs(forked_from) WHERE forked_from IS NOT NULL;
-
--- SKILL.md prose cache (FR4)
-ALTER TABLE packs ADD COLUMN skill_prose TEXT;
+**Current problem** (lines 358-367):
+```typescript
+const manifest = {
+  schema_version: pack.schema_version || 1,
+  name: pack.name,
+  slug: pack.slug,
+  version: pack.version,
+  description: pack.description,
+  author: pack.author || '0xHoneyJar',
+  license: pack.license || 'MIT',
+  skills: pack.skillSlugs.map((s) => ({ slug: s, path: `skills/${s}` })),
+};
 ```
 
-Both nullable, non-breaking. Existing rows get `NULL` values.
+This constructs a 7-field object and discards everything else from construct.yaml.
 
-**Fork backfill decision**: Historical forks will NOT be backfilled in this cycle. The ecosystem currently has 5 packs; the only known fork (Observer in midi-interface) was created outside the registry's fork endpoint. Backfilling would require manual identification of fork relationships with uncertain accuracy. All future forks via `POST /packs/fork` will correctly record provenance. This decision is explicitly documented — revisit if fork detection becomes automated.
+**Solution**: Parse the full YAML, validate with Zod, store the validated result.
 
-#### 3.1.2 New table: `signal_outcomes` (FR1)
+#### 2.1.1 Changes to `discoverPacks()` (lines 148-227)
 
-```sql
-CREATE TABLE signal_outcomes (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  pack_id UUID NOT NULL REFERENCES packs(id) ON DELETE CASCADE,
-  signal_type TEXT NOT NULL,
-  signal_source TEXT NOT NULL,
-  signal_source_url TEXT,
-  predicted_impact TEXT NOT NULL CHECK (predicted_impact IN ('high', 'medium', 'low')),
-  actual_impact TEXT CHECK (actual_impact IN ('high', 'medium', 'low', 'none')),
-  outcome_summary TEXT,
-  outcome_evidence TEXT,
-  recorded_by UUID NOT NULL REFERENCES users(id),
-  evaluated_by UUID REFERENCES users(id),
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  evaluated_at TIMESTAMPTZ,
-  CONSTRAINT no_self_evaluation CHECK (recorded_by IS DISTINCT FROM evaluated_by),
-  CONSTRAINT unique_signal_evaluation UNIQUE (pack_id, signal_type, signal_source)
-);
-
-CREATE INDEX idx_signal_outcomes_pack ON signal_outcomes(pack_id);
-CREATE INDEX idx_signal_outcomes_evaluated ON signal_outcomes(pack_id) WHERE actual_impact IS NOT NULL;
-```
-
-#### 3.1.3 New table: `construct_showcases` (FR6)
-
-```sql
-CREATE TABLE construct_showcases (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  pack_id UUID NOT NULL REFERENCES packs(id) ON DELETE CASCADE,
-  title TEXT NOT NULL,
-  url TEXT NOT NULL,
-  description TEXT,
-  submitted_by UUID REFERENCES users(id),
-  approved BOOLEAN NOT NULL DEFAULT false,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-CREATE INDEX idx_construct_showcases_pack ON construct_showcases(pack_id);
-CREATE INDEX idx_construct_showcases_approved ON construct_showcases(pack_id) WHERE approved = true;
-```
-
-### 3.2 Drizzle Schema Updates (`schema.ts`)
-
-#### 3.2.1 `packs` table additions (after `constructType` column, ~line 548)
+Replace the manual field extraction at lines 168-184 with full YAML parsing + Zod validation:
 
 ```typescript
-// Fork provenance (cycle-035, FR2)
-forkedFrom: uuid('forked_from').references(() => packs.id),
+// In the construct.yaml branch (line 166):
+} else if (existsSync(constructYamlPath)) {
+  const content = await readFile(constructYamlPath, 'utf-8');
+  const parsed = yaml.load(content, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>;
 
-// SKILL.md prose cache (cycle-035, FR4)
-skillProse: text('skill_prose'),
-```
-
-#### 3.2.2 `packsRelations` update (~line 777)
-
-Add to existing relations:
-
-```typescript
-forkedFromPack: one(packs, {
-  fields: [packs.forkedFrom],
-  references: [packs.id],
-  relationName: 'forkParent',
-}),
-```
-
-#### 3.2.3 New table: `signalOutcomes`
-
-```typescript
-export const signalOutcomes = pgTable('signal_outcomes', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  packId: uuid('pack_id').notNull().references(() => packs.id, { onDelete: 'cascade' }),
-  signalType: text('signal_type').notNull(),
-  signalSource: text('signal_source').notNull(),
-  signalSourceUrl: text('signal_source_url'),
-  predictedImpact: text('predicted_impact').notNull(),
-  actualImpact: text('actual_impact'),
-  outcomeSummary: text('outcome_summary'),
-  outcomeEvidence: text('outcome_evidence'),
-  recordedBy: uuid('recorded_by').notNull().references(() => users.id),
-  evaluatedBy: uuid('evaluated_by').references(() => users.id),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  evaluatedAt: timestamp('evaluated_at', { withTimezone: true }),
-}, (table) => ({
-  packIdx: index('idx_signal_outcomes_pack').on(table.packId),
-  evaluatedIdx: index('idx_signal_outcomes_evaluated').on(table.packId),
-  uniqueSignal: unique('unique_signal_evaluation').on(table.packId, table.signalType, table.signalSource),
-}));
-```
-
-#### 3.2.4 New table: `constructShowcases`
-
-```typescript
-export const constructShowcases = pgTable('construct_showcases', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  packId: uuid('pack_id').notNull().references(() => packs.id, { onDelete: 'cascade' }),
-  title: text('title').notNull(),
-  url: text('url').notNull(),
-  description: text('description'),
-  submittedBy: uuid('submitted_by').references(() => users.id),
-  approved: boolean('approved').notNull().default(false),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-}, (table) => ({
-  packIdx: index('idx_construct_showcases_pack').on(table.packId),
-  approvedIdx: index('idx_construct_showcases_approved').on(table.packId),
-}));
-```
-
----
-
-## 4. API Design
-
-### 4.1 Signal Outcomes API (FR1) — NEW: `routes/signals.ts`
-
-New Hono router mounted under `/v1/packs/:slug/signals` (pack-scoped, not construct-scoped — outcomes are keyed by `pack_id` FK, so endpoints must be pack-scoped to avoid slug/construct ambiguity). Follows existing patterns from `packs.ts`.
-
-#### 4.1.1 `POST /v1/packs/:slug/signals/outcomes`
-
-**Auth**: `requireAuth()` — pack owner verified via `isPackOwner()`
-**Rate limit**: 50 writes/hour per user (new rate limit function)
-
-**Request body** (Zod schema):
-
-```typescript
-const createOutcomeSchema = z.object({
-  pack_slug: z.string().min(3).max(100),
-  signal_type: z.enum(['gap_filed', 'signal_classified', 'journey_shaped']),
-  signal_source: z.string().min(1).max(500),       // namespaced: 'github:issue/123'
-  signal_source_url: z.string().url().max(2000).optional(),
-  predicted_impact: z.enum(['high', 'medium', 'low']),
-});
-```
-
-**Response** (201):
-
-```json
-{
-  "data": {
-    "id": "uuid",
-    "pack_slug": "observer",
-    "signal_type": "gap_filed",
-    "signal_source": "github:issue/123",
-    "predicted_impact": "high",
-    "actual_impact": null,
-    "created_at": "2026-02-22T..."
-  }
-}
-```
-
-**Logic**:
-1. Resolve `pack_slug` → `pack.id` via `getPackBySlug()`
-2. Verify `isPackOwner(pack.id, userId)` → 403
-3. Check rate limit (50/hr per user) → 429
-4. Insert with `recorded_by: userId`
-5. Return created outcome (sans `outcome_evidence`)
-
-#### 4.1.2 `PATCH /v1/packs/:slug/signals/outcomes/:id`
-
-**Auth**: `requireAuth()` — evaluator must be authorized AND must not be the recorder.
-
-**Evaluator authorization rules** (checked in order):
-1. `isPackOwner(pack.id, userId)` — pack owner can always evaluate (but not their own predictions)
-2. `isAdmin(userId)` — admins can evaluate any pack's outcomes
-3. All other users → 403 "Not authorized to evaluate outcomes for this pack"
-
-This prevents vandalism/brigading by restricting evaluation to trusted parties.
-
-**Request body**:
-
-```typescript
-const evaluateOutcomeSchema = z.object({
-  actual_impact: z.enum(['high', 'medium', 'low', 'none']),
-  outcome_summary: z.string().max(500).optional(),
-  outcome_evidence: z.string().max(2000).optional(),
-});
-```
-
-**Logic**:
-1. Resolve `:slug` → `pack.id` via `getPackBySlug()`
-2. Fetch outcome by ID → 404. Verify outcome belongs to this pack → 404
-3. Check evaluator authorization: `isPackOwner() || isAdmin()` → 403
-4. Check `userId !== outcome.recordedBy` → 403 "Cannot evaluate your own prediction"
-5. **Single-maintainer exception**: If pack has exactly 1 owner AND no admins have evaluated this pack's outcomes before, allow self-evaluation but flag it. Set `evaluated_by = recorded_by`. The accuracy service excludes self-evaluated outcomes from kappa computation entirely (weight = 0) and displays them separately.
-6. Sanitize `outcome_summary` (strip HTML)
-7. Update `actual_impact`, `outcome_summary`, `outcome_evidence`, `evaluated_by`, `evaluated_at`
-8. Invalidate accuracy cache for this pack (see §4.1.7)
-
-#### 4.1.3 `GET /v1/packs/:slug/signals/outcomes`
-
-**Auth**: `optionalAuth()`
-**Public response**: Returns `outcome_summary` but NOT `outcome_evidence`.
-
-```json
-{
-  "data": [
-    {
-      "id": "uuid",
-      "signal_type": "gap_filed",
-      "signal_source": "github:issue/123",
-      "predicted_impact": "high",
-      "actual_impact": "high",
-      "outcome_summary": "Gap led to PR #456 merged in 3 days",
-      "self_evaluated": false,
-      "created_at": "...",
-      "evaluated_at": "..."
+  // Validate with Zod — the shared schema is the single source of truth
+  const validation = packManifestSchema.safeParse(parsed);
+  if (!validation.success) {
+    console.warn(`   ⚠ ${slug}: manifest validation failed:`);
+    for (const issue of validation.error.issues) {
+      console.warn(`     - ${issue.path.join('.')}: ${issue.message}`);
     }
-  ],
-  "meta": { "total": 15, "evaluated": 8, "page": 1, "per_page": 50 }
-}
-```
-
-#### 4.1.4 `GET /v1/packs/:slug/signals/outcomes/detail`
-
-**Auth**: `requireAuth()` + `isPackOwner()` — owner-only, includes `outcome_evidence`.
-
-#### 4.1.5 `GET /v1/packs/:slug/signals/accuracy`
-
-**Auth**: `optionalAuth()` — public, aggregated stats only.
-
-**Response**:
-
-```json
-{
-  "data": {
-    "construct_slug": "observer",
-    "sample_size": 25,
-    "coverage": 0.62,
-    "sufficient_data": true,
-    "confusion_matrix": {
-      "high":   { "high": 5, "medium": 1, "low": 0, "none": 0 },
-      "medium": { "high": 1, "medium": 8, "low": 2, "none": 1 },
-      "low":    { "high": 0, "medium": 1, "low": 4, "none": 2 }
-    },
-    "per_class": {
-      "high":   { "precision": 0.83, "recall": 0.83 },
-      "medium": { "precision": 0.80, "recall": 0.67 },
-      "low":    { "precision": 0.67, "recall": 0.67 }
-    },
-    "weighted_kappa": 0.72,
-    "time_to_outcome_days": { "median": 8, "p25": 3, "p75": 18 },
-    "self_evaluated_fraction": 0.12,
-    "warnings": []
+    // Fall back to partial manifest for backwards compatibility
+    fullManifest = null;
+    manifest = {
+      schema_version: (parsed.schema_version as number) || 1,
+      name: (parsed.name as string) || slug,
+      slug: (parsed.slug as string) || slug,
+      version: (parsed.version as string) || '1.0.0',
+      description: (parsed.description as string) || '',
+      author: parsed.author as string | undefined,
+      license: parsed.license as string | undefined,
+    };
+  } else {
+    fullManifest = validation.data;
+    manifest = validation.data;
   }
 }
 ```
 
-**Guardrails** (implemented in `services/signals.ts`):
-- `sample_size < 20` → `sufficient_data: false`, `warnings: ["Insufficient data — 15 evaluations, need 20+"]`
-- `coverage < 0.5` → `warnings: ["Selection bias risk — only 40% of signals have outcomes"]`
-- `self_evaluated_fraction > 0.5` → `warnings: ["Majority self-evaluated — interpret with caution"]`
+**Import addition** (top of file):
+```typescript
+import { packManifestSchema } from '../packages/shared/src/validation.js';
+```
 
-#### 4.1.6 Accuracy Computation Service (`services/signals.ts`)
+#### 2.1.2 Changes to `DiscoveredPack` interface
+
+Replace the minimal `PackManifest` interface (lines 69-79) with:
 
 ```typescript
-export async function computeAccuracy(packId: string): Promise<AccuracyReport> {
-  // 1. Fetch all evaluated outcomes for pack
-  const outcomes = await db.select()
-    .from(signalOutcomes)
-    .where(and(
-      eq(signalOutcomes.packId, packId),
-      isNotNull(signalOutcomes.actualImpact)
-    ));
+import type { ValidatedPackManifest } from '../packages/shared/src/validation.js';
 
-  // 2. Fetch total signal count (including unevaluated)
-  const totalCount = await db.select({ count: count() })
-    .from(signalOutcomes)
-    .where(eq(signalOutcomes.packId, packId));
-
-  // 3. Build confusion matrix
-  const matrix = buildConfusionMatrix(outcomes);
-
-  // 4. Compute per-class precision/recall
-  const perClass = computePerClassMetrics(matrix);
-
-  // 5. Compute weighted kappa (ordinal: high > medium > low)
-  const kappa = computeWeightedKappa(outcomes);
-
-  // 6. Compute time-to-outcome distribution
-  const timeStats = computeTimeToOutcome(outcomes);
-
-  // 7. Compute self-evaluation fraction
-  const selfEvalFraction = outcomes.filter(o =>
-    o.recordedBy === o.evaluatedBy
-  ).length / outcomes.length;
-
-  // 8. Build warnings
-  const warnings = buildWarnings(outcomes.length, totalCount, selfEvalFraction);
-
-  return { ... };
+// DiscoveredPack now carries the full validated manifest when available
+interface DiscoveredPack {
+  // Core fields (always present)
+  name: string;
+  slug: string;
+  version: string;
+  description: string;
+  author?: string;
+  license?: string;
+  schema_version: number;
+  type?: string;
+  // Full validated manifest (null if Zod validation failed — legacy format)
+  fullManifest: ValidatedPackManifest | null;
+  // Derived fields
+  icon: string;
+  skillSlugs: string[];
+  packPath: string;
+  constructType: string;
+  identity?: IdentityData;
 }
 ```
 
-**Weighted kappa implementation**: Use linear weighting for ordinal scale:
-- Same category → weight 0 (perfect agreement)
-- Adjacent (high↔medium, medium↔low) → weight 1
-- Two apart (high↔low) → weight 2
-- `none` treated as equivalent to opposite end (high predicted, none actual = weight 3)
+#### 2.1.3 Changes to manifest storage (lines 358-367)
 
-Standard Cohen's weighted kappa formula: `κ_w = 1 - (Σ w_ij * o_ij) / (Σ w_ij * e_ij)` where `o` is observed and `e` is expected by chance.
-
-**Self-evaluated outcomes**: Excluded from kappa computation entirely (weight = 0). Displayed separately in the accuracy report as `self_evaluated_count` and `self_evaluated_fraction`. Warning threshold: 20% (not 50% — lowered per Flatline review to prevent majority self-evaluated data going unwarned).
-
-#### 4.1.7 Accuracy Caching
-
-Accuracy computation is expensive (multiple DB queries + statistical computation) and the endpoint is public (hit on every detail page). Cache with Redis:
+Replace the 7-field construction with:
 
 ```typescript
-const ACCURACY_CACHE_TTL = 600; // 10 minutes
-const accuracyCacheKey = (packId: string) => `accuracy:${packId}`;
-
-// In GET accuracy handler:
-const cached = await redis.get(accuracyCacheKey(packId));
-if (cached) return JSON.parse(cached);
-
-const report = await computeAccuracy(packId);
-await redis.set(accuracyCacheKey(packId), JSON.stringify(report), { ex: ACCURACY_CACHE_TTL });
+// Store full manifest if validation passed, otherwise build minimal
+const manifest = pack.fullManifest ?? {
+  schema_version: pack.schema_version || 1,
+  name: pack.name,
+  slug: pack.slug,
+  version: pack.version,
+  description: pack.description,
+  author: pack.author || '0xHoneyJar',
+  license: pack.license || 'MIT',
+  skills: pack.skillSlugs.map((s) => ({ slug: s, path: `skills/${s}` })),
+};
 ```
 
-**Invalidation**: On `PATCH /v1/packs/:slug/signals/outcomes/:id` (evaluation write), delete the cache key:
+The manifest stored in `pack_versions.manifest` JSONB becomes the full construct.yaml content when Zod-validated. All downstream consumers (`GET /v1/constructs/:slug`, explorer detail page, workflow gate reader) already destructure from this JSONB column.
+
+#### 2.1.4 Content Hash Computation
+
+Add after file collection (line 402):
+
 ```typescript
-await redis.del(accuracyCacheKey(outcome.packId));
+// Compute content hash: SHA-256 of manifest JSON + sorted file hashes
+const manifestJson = JSON.stringify(manifest, null, 0);
+const fileHashConcat = files.map(f => f.contentHash).sort().join('');
+const contentHash = createHash('sha256')
+  .update(manifestJson)
+  .update(fileHashConcat)
+  .digest('hex');
 ```
 
-#### 4.1.8 TypeScript Interfaces
+Store it in `pack_versions` (add to the INSERT at line 379):
+
+```sql
+content_hash = ${contentHash}
+```
+
+The `content_hash` column already exists in the schema (schema.ts line 592) — it's just never been populated.
+
+#### 2.1.5 Dry-Run Mode
+
+Add a `--dry-run` flag that validates all manifests against Zod without writing to the database:
 
 ```typescript
-/** Represents a single signal outcome record */
-export interface SignalOutcome {
-  id: string;
-  packId: string;
-  signalType: 'gap_filed' | 'signal_classified' | 'journey_shaped';
-  signalSource: string;
-  signalSourceUrl: string | null;
-  predictedImpact: 'high' | 'medium' | 'low';
-  actualImpact: 'high' | 'medium' | 'low' | 'none' | null;
-  outcomeSummary: string | null;
-  outcomeEvidence: string | null;
-  recordedBy: string;
-  evaluatedBy: string | null;
-  createdAt: Date;
-  evaluatedAt: Date | null;
+const DRY_RUN = process.argv.includes('--dry-run');
+```
+
+This allows testing manifest validation before switching to the full extraction. Critical for the migration — if any of the 6 existing manifests fail Zod validation, we need to fix them before deploying.
+
+---
+
+### 2.2 F1.2: Register 3 Ready Constructs
+
+**File**: `scripts/seed-forge-packs.ts`
+
+Add to `GIT_CONFIGS` (line 42):
+
+```typescript
+herald: {
+  gitUrl: 'https://github.com/0xHoneyJar/construct-herald.git',
+  gitRef: 'main',
+},
+hardening: {
+  gitUrl: 'https://github.com/0xHoneyJar/construct-hardening.git',
+  gitRef: 'main',
+},
+'dynamic-auth': {
+  gitUrl: 'https://github.com/0xHoneyJar/construct-dynamic-auth.git',
+  gitRef: 'main',
+},
+```
+
+Add to `PACK_ICONS` (line 31):
+
+```typescript
+herald: '📢',
+hardening: '🛡️',
+'dynamic-auth': '🔐',
+```
+
+No other changes needed. The `discoverPacks()` function already handles cloning and manifest parsing generically.
+
+**Pre-check**: Verify all 3 repos have `construct.yaml` at root level (confirmed by org-auditor). Verify manifests pass `packManifestSchema.safeParse()` via dry-run.
+
+---
+
+### 2.3 F1.5: Extract The Easel to Standalone Construct
+
+**New repo**: `0xHoneyJar/construct-the-easel`
+
+#### 2.3.1 Repo Structure
+
+```
+construct-the-easel/
+├── construct.yaml          # v3 manifest
+├── identity/
+│   ├── persona.yaml        # Creative studio voice (domain-agnostic)
+│   └── expertise.yaml      # Design vocabulary, visual direction, taste documentation
+├── skills/
+│   ├── grounding-creative/
+│   │   ├── SKILL.md        # Generalized: reviews vocabulary + TDRs for any design area
+│   │   └── index.yaml      # model_tier: sonnet, danger_level: safe
+│   ├── exploring-visuals/
+│   │   ├── SKILL.md        # Generalized: generates prompts grounded in project vocabulary
+│   │   └── index.yaml
+│   ├── capturing-results/
+│   │   ├── SKILL.md        # Generalized: annotates results with vocabulary + TDR criteria
+│   │   └── index.yaml
+│   └── recording-taste/
+│       ├── SKILL.md        # Generalized: TDR CRUD operations
+│       └── index.yaml
+├── contexts/
+│   ├── vocabulary-template.md   # Empty 8-domain structure (no terms)
+│   ├── tdr-template.md          # Blank Taste Decision Record template
+│   └── quality-gates.md         # Generic Ground → Visualize → Tokenize → Implement gates
+└── README.md
+```
+
+#### 2.3.2 construct.yaml
+
+```yaml
+schema_version: 3
+name: "The Easel"
+slug: "the-easel"
+version: "1.0.0"
+description: "Creative studio for aesthetic direction — vocabulary grounding, visual exploration, result capture, and taste decisions. Domain-agnostic: install and populate with your project's aesthetic vocabulary."
+author: "0xHoneyJar"
+license: "MIT"
+type: "skill-pack"
+
+skills:
+  - slug: grounding-creative
+    path: skills/grounding-creative
+  - slug: exploring-visuals
+    path: skills/exploring-visuals
+  - slug: capturing-results
+    path: skills/capturing-results
+  - slug: recording-taste
+    path: skills/recording-taste
+
+identity:
+  persona: identity/persona.yaml
+  expertise: identity/expertise.yaml
+
+domain:
+  - design
+  - aesthetics
+  - visual-direction
+
+expertise:
+  - vocabulary-driven design
+  - taste decision records
+  - visual exploration
+  - aesthetic direction
+
+golden_path:
+  commands:
+    - name: ground
+      description: "Review vocabulary and TDRs for a design area"
+      truename_map:
+        no_vocabulary: /grounding-creative
+        vocabulary_ready: /grounding-creative
+    - name: explore
+      description: "Generate visual prompts grounded in vocabulary"
+      truename_map:
+        grounded: /exploring-visuals
+    - name: capture
+      description: "Annotate generation results with vocabulary terms"
+      truename_map:
+        explored: /capturing-results
+    - name: record
+      description: "Create or update a Taste Decision Record"
+      truename_map:
+        captured: /recording-taste
+
+events:
+  emits:
+    - name: forge.easel.vocabulary_grounded
+      description: "Vocabulary atlas reviewed and gaps identified"
+    - name: forge.easel.taste_recorded
+      description: "New TDR created or updated"
+  consumes:
+    - name: forge.artisan.taste_inscribed
+      description: "Can ground visual exploration in Artisan taste tokens"
+
+pack_dependencies:
+  optional:
+    - slug: artisan
+      reason: "Taste token handoff — Easel TDRs can inform Artisan inscribed tokens"
+
+workflow:
+  depth: light
+  gates:
+    prd: skip
+    sdd: skip
+    sprint: skip
+    implement: required
+    review: visual
+    audit: skip
+```
+
+#### 2.3.3 Skill Generalization Principles
+
+Each SKILL.md must:
+
+1. **Use context slots** for project-specific paths:
+   - `{{grimoire_path}}` → defaults to `grimoires/the-easel/` if not set
+   - `{{vocabulary_path}}` → defaults to `{{grimoire_path}}/vocabulary/atlas.md`
+   - `{{tdr_path}}` → defaults to `{{grimoire_path}}/tdr/`
+   - `{{generation_tool}}` → defaults to "your preferred image generation tool"
+
+2. **Zero domain-specific references**: No cyberpunk, no FUI, no rektdrop, no Freeside Divergence. The skills describe the *process*, not any specific aesthetic.
+
+3. **Ship empty templates**: `vocabulary-template.md` has the 8-domain structure with no terms. `tdr-template.md` is a blank TDR scaffold. Projects fill these in through the skills.
+
+#### 2.3.4 Registry Wiring
+
+Add to `seed-forge-packs.ts`:
+
+```typescript
+// GIT_CONFIGS
+'the-easel': {
+  gitUrl: 'https://github.com/0xHoneyJar/construct-the-easel.git',
+  gitRef: 'main',
+},
+
+// PACK_ICONS
+'the-easel': '🖼️',
+```
+
+#### 2.3.5 rektdrop-interface Update
+
+After extraction:
+1. Install The Easel from registry: `/constructs install the-easel`
+2. Keep existing `grimoires/the-easel/` (16 TDRs, atlas, aesthetic-direction) — this is project state
+3. Remove the embedded `.claude/constructs/packs/the-easel/` directory
+4. Skills now load from the installed pack but read/write to the existing grimoire paths
+
+---
+
+### 2.4 F1.3: Activate detect_state in Golden Path
+
+**File**: `.claude/scripts/golden-path.sh`
+
+**Current** (lines 322-360): `golden_detect_construct_journeys()` builds journey bars from `golden_path.commands[].name` but ignores `detect_state`.
+
+**Change**: After extracting command names, check for `detect_state` script. If present, execute it and mark the current position.
+
+#### 2.4.1 Modified `golden_detect_construct_journeys()`
+
+```bash
+golden_detect_construct_journeys() {
+    local packs_dir="${PROJECT_ROOT}/.claude/constructs/packs"
+    [[ -d "$packs_dir" ]] || return 0
+
+    if ! type safe_yq_to_json &>/dev/null; then
+        return 0
+    fi
+
+    local manifest pack_name pack_dir commands_json detect_script current_state bar output=""
+    for manifest in "$packs_dir"/*/construct.yaml "$packs_dir"/*/construct.yml; do
+        [[ -f "$manifest" ]] || continue
+        pack_dir="$(dirname "$manifest")"
+
+        # Extract golden_path via yq→jq
+        commands_json=$(safe_yq_to_json "$manifest" 2>/dev/null \
+            | jq -c '.golden_path.commands // empty' 2>/dev/null) || continue
+        [[ -z "$commands_json" || "$commands_json" == "null" ]] && continue
+
+        pack_name=$(safe_yq '.name' "$manifest" 2>/dev/null) || continue
+        [[ -z "$pack_name" ]] && continue
+
+        # NEW: Execute detect_state script if declared
+        current_state=""
+        detect_script=$(safe_yq '.golden_path.detect_state' "$manifest" 2>/dev/null) || true
+        if [[ -n "$detect_script" && "$detect_script" != "null" ]]; then
+            local script_path="${pack_dir}/${detect_script}"
+            if [[ -f "$script_path" && -x "$script_path" ]]; then
+                current_state=$(cd "$pack_dir" && timeout 5 "$script_path" 2>/dev/null) || true
+            fi
+        fi
+
+        # Build journey bar — mark current position with ●
+        bar=""
+        local first=true
+        while IFS= read -r cmd_name; do
+            [[ -z "$cmd_name" ]] && continue
+            local is_current=false
+            if [[ -n "$current_state" ]]; then
+                local mapped
+                mapped=$(echo "$commands_json" | jq -r \
+                    --arg name "$cmd_name" --arg state "$current_state" \
+                    '.[] | select(.name == $name) | .truename_map[$state] // empty' \
+                    2>/dev/null) || true
+                [[ -n "$mapped" ]] && is_current=true
+            fi
+
+            local segment="/$cmd_name"
+            $is_current && segment="/$cmd_name ●"
+
+            if $first; then
+                bar="$segment"
+                first=false
+            else
+                bar="$bar ━━━ $segment"
+            fi
+        done < <(echo "$commands_json" | jq -r '.[].name' 2>/dev/null)
+
+        [[ -n "$bar" ]] && output="${output}  ${pack_name}: ${bar}"$'\n'
+    done
+
+    [[ -n "$output" ]] && printf "%s" "$output"
 }
-
-/** Public-facing outcome (no evidence) */
-export interface SignalOutcomePublic extends Omit<SignalOutcome, 'outcomeEvidence'> {
-  selfEvaluated: boolean;
-}
-
-/** Per-class precision/recall metrics */
-export interface ClassMetrics {
-  precision: number;
-  recall: number;
-}
-
-/** Structured accuracy report */
-export interface AccuracyReport {
-  packSlug: string;
-  sampleSize: number;
-  coverage: number;
-  sufficientData: boolean;
-  confusionMatrix: Record<'high' | 'medium' | 'low', Record<'high' | 'medium' | 'low' | 'none', number>>;
-  perClass: Record<'high' | 'medium' | 'low', ClassMetrics>;
-  weightedKappa: number;
-  timeToOutcomeDays: { median: number; p25: number; p75: number };
-  selfEvaluatedCount: number;
-  selfEvaluatedFraction: number;
-  warnings: string[];
-}
 ```
 
-### 4.2 Fork Provenance (FR2) — Modifications to `routes/packs.ts`
+#### 2.4.2 detect_state Script Contract
 
-#### 4.2.1 Fix `POST /packs/fork` (~line 1709)
+A `detect_state` script must:
+- Be executable (`chmod +x`)
+- Print a single state string to stdout (e.g., `canvases_ready`, `grounded`, `no_vocabulary`)
+- Exit 0 on success, non-zero to indicate "unknown state"
+- Complete within 5 seconds
+- Read from the project's grimoire/state files, never write
 
-Current code calls `createPack()` without `forkedFrom`. Fix:
+---
 
-```typescript
-// Before (current):
-const newPack = await createPack({
-  name: `${sourcePack.name} (fork)`,
-  slug: newSlug,
-  ownerId: userId,
-  ownerType: 'user',
-});
+### 2.5 F1.4: Post-Install Hook Execution
 
-// After:
-const newPack = await createPack({
-  name: `${sourcePack.name} (fork)`,
-  slug: newSlug,
-  ownerId: userId,
-  ownerType: 'user',
-  forkedFrom: sourcePack.id,  // NEW: record provenance
-});
-```
+**File**: `.claude/scripts/constructs-install.sh`
 
-#### 4.2.2 Enrich `GET /v1/constructs/:slug` response
+After pack file extraction completes (where symlinks are created for commands), add:
 
-In `packToConstruct()` at `constructs.ts`, add fork data to the `Construct` interface:
+```bash
+execute_post_install_hook() {
+    local pack_dir="$1"
+    local manifest="${pack_dir}/construct.yaml"
+    [[ -f "$manifest" ]] || return 0
 
-```typescript
-// Add to Construct interface:
-forkedFrom: { slug: string; name: string } | null;
-forkCount: number;
-```
+    if ! type safe_yq &>/dev/null 2>&1; then return 0; fi
 
-In the single-construct detail fetch path, join `forked_from` to get parent info:
+    local hook_script
+    hook_script=$(safe_yq '.hooks.post_install' "$manifest" 2>/dev/null) || return 0
+    [[ -z "$hook_script" || "$hook_script" == "null" ]] && return 0
 
-```typescript
-// In getConstructBySlug service:
-const parentPack = pack.forkedFrom
-  ? await db.select({ slug: packs.slug, name: packs.name })
-      .from(packs).where(eq(packs.id, pack.forkedFrom)).limit(1)
-  : null;
+    local script_path="${pack_dir}/${hook_script}"
 
-// Fork count:
-const forkCount = await db.select({ count: count() })
-  .from(packs).where(eq(packs.forkedFrom, pack.id));
-```
+    # Security: validate script is within pack directory
+    local real_script real_pack
+    real_script=$(realpath "$script_path" 2>/dev/null) || return 0
+    real_pack=$(realpath "$pack_dir" 2>/dev/null) || return 0
+    if [[ "$real_script" != "$real_pack"* ]]; then
+        echo "⚠ Post-install hook path traversal blocked: $hook_script" >&2
+        return 0
+    fi
 
-### 4.3 SKILL.md Prose Pipeline (FR4) — Modifications to sync endpoint
-
-#### 4.3.1 Extraction during `POST /packs/:slug/sync` (~line 950)
-
-After the existing sync logic extracts files, add prose extraction within the same transaction:
-
-```typescript
-// Inside the sync transaction, after packFiles insert:
-const skillProse = extractSkillProse(syncResult.files);
-
-// Update packs table:
-await tx.update(packs)
-  .set({
-    skillProse,           // NULL if no SKILL.md found
-    // ...existing fields
-  })
-  .where(eq(packs.id, pack.id));
-```
-
-#### 4.3.2 `extractSkillProse()` utility
-
-```typescript
-import createDOMPurify from 'isomorphic-dompurify';
-const DOMPurify = createDOMPurify();
-
-export function extractSkillProse(files: SyncFile[]): string | null {
-  // 1. Find primary SKILL.md (root-level preferred)
-  const skillFile = files
-    .filter(f => f.path.endsWith('/SKILL.md') || f.path === 'SKILL.md')
-    .sort((a, b) => a.path.split('/').length - b.path.split('/').length)[0];
-
-  if (!skillFile?.content) return null;
-
-  let content = skillFile.content;
-
-  // 2. Strip YAML frontmatter
-  if (content.startsWith('---')) {
-    const endIdx = content.indexOf('---', 3);
-    if (endIdx !== -1) {
-      content = content.slice(endIdx + 3).trim();
-    }
-  }
-
-  // 3. Truncate at sentence boundary within 2000 chars
-  if (content.length > 2000) {
-    const truncated = content.slice(0, 2000);
-    const lastSentence = Math.max(
-      truncated.lastIndexOf('. '),
-      truncated.lastIndexOf('.\n'),
-      truncated.lastIndexOf('.\r\n')
-    );
-    content = lastSentence > 0 ? truncated.slice(0, lastSentence + 1) : truncated;
-  }
-
-  // 4. Sanitize (strip HTML tags, prevent injection)
-  content = DOMPurify.sanitize(content, { ALLOWED_TAGS: [] });
-
-  return content || null;
+    if [[ -f "$script_path" && -x "$script_path" ]]; then
+        echo "  Running post-install hook..."
+        if ! (cd "$pack_dir" && timeout 30 "$script_path" 2>&1); then
+            echo "  ⚠ Post-install hook failed (non-blocking)" >&2
+        fi
+    fi
 }
 ```
 
-### 4.4 Showcases API (FR6) — NEW: `routes/showcases.ts` or in `packs.ts`
-
-Given the small surface area, add to existing `packs.ts` router.
-
-#### 4.4.1 `POST /v1/packs/:slug/showcases`
-
-**Auth**: `requireAuth()`
-
-```typescript
-const createShowcaseSchema = z.object({
-  title: z.string().min(1).max(200),
-  url: z.string().url().max(2000),
-  description: z.string().max(500).optional(),
-});
-```
-
-Sanitize `description` before storage. Set `approved: false`, `submitted_by: userId`.
-
-#### 4.4.2 `PATCH /v1/packs/:slug/showcases/:id/approve`
-
-**Auth**: `requireAuth()` + `isPackOwner() || isAdmin()` — pack owner or admin can approve.
-
-```typescript
-// Toggle approval
-await db.update(constructShowcases)
-  .set({ approved: true })
-  .where(eq(constructShowcases.id, showcaseId));
-```
-
-This gives pack owners control over what appears on their construct's page. Admins can moderate across all packs.
-
-#### 4.4.3 `GET /v1/packs/:slug/showcases`
-
-**Auth**: `optionalAuth()`
-Returns only `approved: true` showcases for public requests. Pack owners see all (including pending). Ordered by `created_at DESC`.
+**Security constraints**:
+- Path traversal prevention via `realpath` comparison
+- 30-second timeout
+- Executes in pack directory context
+- Non-blocking — failure is a warning, not an error
 
 ---
 
-## 5. Explorer Changes
+## 3. Data Flow
 
-### 5.1 Transport Layer — `APIConstruct` type update
+### Before (Current)
 
-Add to `APIConstruct` interface in `transform-construct.ts`:
-
-```typescript
-// New fields (all optional for backwards compat)
-forked_from?: { slug: string; name: string } | null;
-fork_count?: number;
-skill_prose?: string | null;
-showcases?: Array<{ id: string; title: string; url: string; description: string | null }>;
+```
+construct.yaml (30 fields)
+  → seed-forge-packs.ts (reads YAML)
+    → manual extraction (7 fields)
+      → pack_versions.manifest (7-field JSON)
+        → API response (7 fields)
 ```
 
-Add to `ConstructDetail` (camelCase):
+### After (Phase 1)
 
-```typescript
-forkedFrom: { slug: string; name: string } | null;
-forkCount: number;
-skillProse: string | null;
 ```
-
-### 5.2 Diagnostic Language (FR3) — `page.tsx:128-130`
-
-Replace the "Level" stat block:
-
-```tsx
-// BEFORE:
-<div className="border border-white/10 p-3">
-  <p className="text-white/40 mb-1">Level</p>
-  <p className="text-white capitalize">{construct.graduationLevel}</p>
-</div>
-
-// AFTER:
-<div className="border border-white/10 p-3">
-  <p className="text-white text-sm">
-    {diagnosticLabel(construct.graduationLevel)}
-  </p>
-</div>
+construct.yaml (30 fields)
+  → seed-forge-packs.ts (reads YAML)
+    → Zod validation (packManifestSchema)
+      → pack_versions.manifest (full JSON) + content_hash
+        → API response (full fields — no API changes needed)
+        → golden-path.sh reads detect_state, executes script
+        → construct-workflow-read.sh reads workflow.gates (already works)
 ```
-
-Helper function (in same file or extracted to utils):
-
-```typescript
-function diagnosticLabel(maturity: string): string {
-  switch (maturity) {
-    case 'experimental':
-      return 'Experimental — needs README + 7 days for beta';
-    case 'beta':
-      return 'Beta — needs CHANGELOG + no critical issues for stable';
-    case 'stable':
-      return 'Stable';
-    case 'deprecated':
-      return 'Deprecated';
-    default:
-      return 'Experimental — needs README + 7 days for beta';
-  }
-}
-```
-
-### 5.3 SKILL.md Prose Rendering (FR4) — `page.tsx`
-
-Above the existing identity section (line ~139), add:
-
-```tsx
-{construct.skillProse && (
-  <div className="mb-8">
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
-      rehypePlugins={[rehypeSanitize]}
-    >
-      {construct.skillProse}
-    </ReactMarkdown>
-  </div>
-)}
-```
-
-Dependencies: `react-markdown`, `remark-gfm`, `rehype-sanitize` (check if already in `explorer/package.json`).
-
-Falls back to existing `description` display when `skillProse` is null.
-
-### 5.4 Fork Celebration (FR5) — `page.tsx`
-
-Add near the maturity diagnostic:
-
-```tsx
-{construct.forkedFrom && (
-  <Link href={`/constructs/${construct.forkedFrom.slug}`}
-    className="text-sm text-amber-400/80 hover:text-amber-400">
-    Forked from {construct.forkedFrom.name}
-  </Link>
-)}
-
-{construct.forkCount > 0 && (
-  <p className="text-sm text-white/40">
-    {construct.forkCount} variant{construct.forkCount !== 1 ? 's' : ''} exist
-  </p>
-)}
-```
-
-On browse cards (construct list), show fork count as a small badge if > 0.
-
-### 5.5 Accuracy Display (Sprint 3) — `page.tsx`
-
-New section below showcases:
-
-```tsx
-{accuracy && accuracy.sufficient_data && (
-  <div className="border border-white/10 p-4">
-    <h3 className="text-white/60 text-sm mb-3">Signal Accuracy</h3>
-    <div className="grid grid-cols-3 gap-3">
-      <Stat label="Weighted κ" value={accuracy.weighted_kappa.toFixed(2)} />
-      <Stat label="Coverage" value={`${(accuracy.coverage * 100).toFixed(0)}%`} />
-      <Stat label="Sample" value={accuracy.sample_size} />
-    </div>
-    {accuracy.warnings.length > 0 && (
-      <div className="mt-2 text-amber-400/60 text-xs">
-        {accuracy.warnings.map(w => <p key={w}>{w}</p>)}
-      </div>
-    )}
-  </div>
-)}
-```
-
-Data fetched via `GET /v1/signals/accuracy/${slug}` in `fetchConstruct()`.
 
 ---
 
-## 6. Service Layer Detail
+## 4. Migration Strategy
 
-### 6.1 `services/signals.ts` (NEW)
+### Step 1: Dry-Run Validation
+Run `seed-forge-packs.ts --dry-run` against all 10 construct repos. Fix any manifests that fail Zod validation BEFORE deploying.
 
-```typescript
-export async function createSignalOutcome(params: {
-  packId: string;
-  signalType: string;
-  signalSource: string;
-  signalSourceUrl?: string;
-  predictedImpact: string;
-  recordedBy: string;
-}): Promise<SignalOutcome>;
+### Step 2: Deploy Seed Script
+Update script, add 4 new GIT_CONFIGS entries, run against production DB.
 
-export async function evaluateSignalOutcome(params: {
-  outcomeId: string;
-  actualImpact: string;
-  outcomeSummary?: string;
-  outcomeEvidence?: string;
-  evaluatedBy: string;
-}): Promise<SignalOutcome>;
+### Step 3: Deploy CLI Changes
+Update golden-path.sh and constructs-install.sh.
 
-export async function listOutcomes(
-  packId: string,
-  opts: { includeEvidence: boolean; page: number; perPage: number }
-): Promise<{ outcomes: SignalOutcome[]; total: number; evaluated: number }>;
-
-export async function computeAccuracy(packId: string): Promise<AccuracyReport>;
-```
-
-### 6.2 `services/constructs.ts` modifications
-
-#### 6.2.1 `RELEVANCE_WEIGHTS.downloads` change (FR7)
-
-```typescript
-// Before:
-downloads: 0.3,
-
-// After:
-downloads: 0.1,
-```
-
-No other changes to the scoring function. The log-scale formula at lines 219-222 remains the same, just with reduced weight.
-
-#### 6.2.2 `Construct` interface additions
-
-```typescript
-// Add to existing Construct interface:
-forkedFrom: { slug: string; name: string } | null;
-forkCount: number;
-skillProse: string | null;
-```
-
-#### 6.2.3 `packToConstruct` mapping additions (~line 411)
-
-Add fork and prose fields to the mapping function. The fork parent lookup is a separate query only for single-construct detail fetches (not list queries, to avoid N+1).
-
-For list queries: `forkedFrom: null, forkCount: 0, skillProse: null` (lightweight defaults).
-For detail queries: actual FK join + count subquery.
+### Step 4: Verify End-to-End
+- `/constructs browse` shows 10 packs
+- `/constructs install herald` succeeds
+- `/constructs install the-easel` succeeds
+- `/loa` shows construct journey bars with `●` position indicator
+- Explorer detail page shows golden_path, workflow, events, domain, expertise fields
 
 ---
 
-## 7. Documentation Changes
+## 5. Testing Strategy
 
-### 7.1 `docs/GRADUATION.md` (FR7)
-
-**Before** (lines 23, 34):
-```
-experimental → beta: 10+ downloads, README present, 7+ days
-beta → stable: 100+ downloads, test coverage, 30+ days
-```
-
-**After**:
-```
-experimental → beta: 7+ days since creation, README present (≥200 words), at least 1 SKILL.md file
-beta → stable: 30+ days at beta, CHANGELOG present, no open issues labeled `critical` or `breaking`
-```
-
-### 7.2 Certificate Rename (FR8)
-
-Comment-only changes (identifiers are already generic):
-
-| File | Line | Before | After |
-|------|------|--------|-------|
-| `schema.ts` | 1171 | `CalibrationCertificate` in JSDoc | `VerificationCertificate` |
-| `0005_construct_verifications.sql` | 77 | `CalibrationCertificate` in SQL COMMENT | `VerificationCertificate` |
-
-Documentation grep-and-replace across:
-- `grimoires/bridgebuilder/echelon-integration-gaps.md` (~14 occurrences)
-- `grimoires/bridgebuilder/observer-laboratory-success-case.md` (~9 occurrences)
-- `grimoires/bridgebuilder/rd-synthesis-behavioral-measurement.md` (~5 occurrences)
+| Test | Type | Validates |
+|------|------|-----------|
+| Zod validation of all 10 construct.yaml files | Unit | F1.1 — no manifest regressions |
+| Seed script dry-run against prod clone | Integration | F1.1 — full manifest stored |
+| Content hash determinism | Unit | F1.1 — same input = same hash |
+| `golden_detect_construct_journeys` with mock detect_state | Unit | F1.3 — position indicator |
+| detect_state timeout handling | Unit | F1.3 — slow scripts don't block |
+| Post-install hook path traversal rejection | Unit | F1.4 — security enforced |
+| Post-install hook timeout handling | Unit | F1.4 — slow hooks don't block |
+| The Easel skills have zero cyberpunk references | Audit | F1.5 — domain-agnostic |
+| The Easel context slots have sensible defaults | Audit | F1.5 — works without config |
+| Full install → `/loa` → journey bar flow | E2E | All features integrated |
 
 ---
 
-## 8. Security Architecture
+## 6. Files Modified
 
-### 8.1 Authentication & Authorization
+| File | Change Type | Description |
+|------|------------|-------------|
+| `scripts/seed-forge-packs.ts` | Modified | Full manifest extraction, 4 new GIT_CONFIGS entries, content hash, dry-run mode |
+| `.claude/scripts/golden-path.sh` | Modified | detect_state activation in `golden_detect_construct_journeys()` |
+| `.claude/scripts/constructs-install.sh` | Modified | Post-install hook execution after extraction |
+| `construct-the-easel/` (new repo) | Created | 4 generalized skills, construct.yaml v3, identity, empty templates |
 
-| Endpoint | Auth | Ownership Check |
-|----------|------|-----------------|
-| `POST /v1/packs/:slug/signals/outcomes` | `requireAuth()` | `isPackOwner(pack.id, userId)` |
-| `PATCH /v1/packs/:slug/signals/outcomes/:id` | `requireAuth()` | `(isPackOwner() OR isAdmin())` AND `userId !== outcome.recordedBy` |
-| `GET /v1/packs/:slug/signals/outcomes` | `optionalAuth()` | None (public summaries) |
-| `GET /v1/packs/:slug/signals/outcomes/detail` | `requireAuth()` | `isPackOwner()` |
-| `GET /v1/packs/:slug/signals/accuracy` | `optionalAuth()` | None (public aggregates, cached 10min) |
-| `POST /v1/packs/:slug/showcases` | `requireAuth()` | None (any authenticated user) |
-| `PATCH /v1/packs/:slug/showcases/:id/approve` | `requireAuth()` | `isPackOwner() OR isAdmin()` |
-| `GET /v1/packs/:slug/showcases` | `optionalAuth()` | None (approved only; owner sees all) |
-
-### 8.2 Input Sanitization
-
-All user-supplied text fields sanitized before DB storage:
-
-| Field | Sanitization | Library |
-|-------|-------------|---------|
-| `outcome_summary` | Strip HTML tags | `isomorphic-dompurify` |
-| `outcome_evidence` | URL validation (stored privately) | Zod `.url()` |
-| `skill_prose` | Strip HTML tags, strip frontmatter | `isomorphic-dompurify` |
-| `showcase.description` | Strip HTML tags | `isomorphic-dompurify` |
-| `showcase.url` | URL validation | Zod `.url()` |
-
-### 8.3 Rate Limiting
-
-| Endpoint | Limit | Per |
-|----------|-------|-----|
-| `POST /v1/packs/:slug/signals/outcomes` | 50/hour | User |
-| `POST /v1/packs/:slug/showcases` | 20/hour | User |
-
-Implementation: follows existing pattern from `checkSyncRateLimit()` in `packs.ts` — count recent records by user within time window via raw SQL.
-
-### 8.4 Data Privacy
-
-- `outcome_evidence` is NEVER returned in public endpoints
-- Public endpoints return `outcome_summary` only (free-text, sanitized)
-- Accuracy endpoint returns aggregated statistics, never individual outcomes
-- No PII in any new public response fields
+**No changes to**:
+- `packages/shared/src/types.ts` — types already declare all fields
+- `packages/shared/src/validation.ts` — Zod schema already validates all fields
+- `apps/api/src/routes/constructs.ts` — API already destructures from manifest JSONB
+- `apps/api/src/db/schema.ts` — `content_hash` column already exists
+- `apps/explorer/` — explorer already renders fields when present in API response
 
 ---
 
-## 9. Testing Strategy
-
-### 9.1 Unit Tests
-
-| Component | Tests |
-|-----------|-------|
-| `extractSkillProse()` | Frontmatter stripping, sentence boundary, XSS vector sanitization, null SKILL.md |
-| `computeAccuracy()` | Confusion matrix, kappa computation, guardrail thresholds, empty data |
-| `buildWarnings()` | Sample size < 20, coverage < 50%, self-eval > 50% |
-| `diagnosticLabel()` | All 4 maturity levels + unknown fallback |
-
-### 9.2 Integration Tests
-
-| Endpoint | Test Cases |
-|----------|------------|
-| `POST /v1/packs/:slug/signals/outcomes` | Happy path, non-owner 403, rate limit 429, duplicate signal 409 |
-| `PATCH /v1/packs/:slug/signals/outcomes/:id` | Happy path, self-evaluation blocked 403, single-maintainer self-eval allowed with flag |
-| `GET /v1/signals/accuracy/:slug` | Sufficient data, insufficient data, no data, warnings |
-| `POST /packs/fork` | Verify `forked_from` set on new pack |
-| `POST /packs/:slug/sync` | Verify `skill_prose` extracted and sanitized |
-| `GET /v1/constructs/:slug` | Verify `forked_from` and `fork_count` in response |
-
-### 9.3 Security Tests
-
-- Attempt XSS payload in `outcome_summary` → verify sanitized
-- Attempt HTML in `skill_prose` SKILL.md → verify stripped
-- Attempt to evaluate own prediction → verify 403
-- Attempt to read `outcome_evidence` via public endpoint → verify absent
-
----
-
-## 10. Deployment & Migration
-
-### 10.1 Migration Rollout
-
-1. Run `0006_measurement_honesty.sql` on staging Supabase
-2. Verify all existing queries still work (additive changes only)
-3. Deploy API with new schema code
-4. Run migration on production
-5. Deploy Explorer with new components
-
-### 10.2 Rollback
-
-All changes are additive. Rollback = revert code, columns remain unused. No data migration needed.
-
-### 10.3 Dependencies
-
-| Dependency | Status | Action |
-|-----------|--------|--------|
-| Migration 0005 (construct_verifications) | Verify in production | Check before running 0006 |
-| `isomorphic-dompurify` | Not in current deps | Add to `apps/api/package.json` |
-| `react-markdown` + `rehype-sanitize` | Check Explorer deps | Add if not present |
-| Drizzle migration tooling | Working | Generate migration from schema diff |
-
----
-
-## 11. Sprint Mapping
-
-### Sprint 1: Measurement Foundation (P0)
-
-| Task | Files Modified | New Files |
-|------|---------------|-----------|
-| Migration 0006 | `schema.ts` | `drizzle/0006_measurement_honesty.sql` |
-| Signal outcomes API | `packs.ts` (mount router) | `routes/signals.ts`, `services/signals.ts` |
-| Fork provenance | `packs.ts:1709`, `constructs.ts` (interface + mapping) | — |
-| Kill download graduation | `constructs.ts:142`, `docs/GRADUATION.md` | — |
-
-### Sprint 2: Explorer Reality (P1)
-
-| Task | Files Modified | New Files |
-|------|---------------|-----------|
-| Diagnostic language | `page.tsx:128-130` | — |
-| SKILL.md prose | `packs.ts` (sync), `page.tsx`, `transform-construct.ts` | Util: `extractSkillProse.ts` |
-| Fork celebration | `page.tsx`, `transform-construct.ts`, browse cards | — |
-| Certificate rename | `schema.ts:1171`, `0005_...sql:77`, 3 grimoire files | — |
-
-### Sprint 3: Visible Craft (P2)
-
-| Task | Files Modified | New Files |
-|------|---------------|-----------|
-| Showcases API | `packs.ts` (new routes) | — |
-| Explorer Built With | `page.tsx` | — |
-| Accuracy display | `page.tsx`, `fetch-constructs.ts` | — |
-
----
-
-## 12. Technical Risks & Mitigation
-
-| Risk | Severity | Mitigation |
-|------|----------|------------|
-| `isomorphic-dompurify` requires `jsdom` in Node.js | Low | Well-established pattern; alternative: `sanitize-html` |
-| Weighted kappa with sparse data produces unstable values | Medium | Only compute when n ≥ 20; show "insufficient data" otherwise |
-| Fork count N+1 on list queries | Low | Only compute fork count on detail page, not list. List shows boolean `is_fork` only |
-| `skill_prose` adds ~2KB per sync | Low | Only stored on `packs` table row; no separate file storage needed |
-| Migration 0006 lock on `packs` table during ALTER | Medium | Nullable ALTER TABLE is `ACCESS EXCLUSIVE` but instant on Postgres 11+; no data rewrite needed |
-
----
-
-## 13. Flatline Review Integration
-
-**Review ID**: flatline-sdd-20260222
-**Models**: Opus + GPT-5.2 | **Confidence**: FULL (90% agreement) | **Cost**: 62¢
-
-### HIGH_CONSENSUS Integrated (4)
-
-| ID | Finding | Integration |
-|----|---------|-------------|
-| IMP-001 | Missing TS interfaces for AccuracyReport/SignalOutcome | Added §4.1.8 with full interface definitions |
-| IMP-002 | Accuracy computation needs caching | Added §4.1.7 with Redis TTL 10min + invalidation on evaluation write |
-| IMP-003 | Evaluator authorization gap | Added explicit auth rules: isPackOwner OR isAdmin, not just "any user" |
-| IMP-006 | Showcase approval has no mechanism | Added PATCH approve endpoint with pack owner/admin auth |
-
-### DISPUTED Resolved (1)
-
-| ID | Finding | Resolution |
-|----|---------|-----------|
-| IMP-010 | Backfill historical fork provenance | Accepted as documented decision: NO backfill. Documented rationale in §3.1.1 |
-
-### BLOCKERS Addressed (5)
-
-| ID | Concern | Resolution |
-|----|---------|-----------|
-| SKP-001 (900) | constructSlug vs pack_slug path ambiguity | All signal endpoints now pack-scoped: `/v1/packs/:slug/signals/*` |
-| SKP-001 (850) | Self-evaluation bypass undermines premise | Self-evaluated outcomes excluded from kappa (weight=0), displayed separately, warning at 20% |
-| SKP-002 (750) | No caching for accuracy | Covered by IMP-002: Redis cache with 10min TTL |
-| SKP-002 (740) | Uniqueness constraint too coarse | Changed to `UNIQUE(pack_id, signal_type, signal_source)` |
-| SKP-003 (950) | Any auth user can evaluate | Covered by IMP-003: restricted to pack owner + admin |
-
----
-
-*"The architecture serves the measurement. The measurement serves the maker."*
+*"The data was always there. The pipe was just too narrow."*

--- a/grimoires/loa/sprint.md
+++ b/grimoires/loa/sprint.md
@@ -1,135 +1,115 @@
-# Sprint Plan: Constructs Network Distribution Layer — Phase 1
+# Sprint Plan: Distribution Layer Phase 2 — Self-Service
 
-**Cycle**: cycle-036
-**Created**: 2026-02-27
-**PRD**: `grimoires/loa/prd.md`
-**SDD**: `grimoires/loa/sdd.md`
-**Scope**: Phase 1 Foundation — F1.1, F1.2, F1.5, F1.3, F1.4
-
----
-
-## Dependency Graph
-
-```
-F1.1 (Full manifest extraction)
-  ↓ unblocks
-F1.2 (Register 3 constructs) ─── can run in parallel with F1.5
-F1.5 (Extract The Easel)     ─── can run in parallel with F1.2
-  ↓ both unblock
-F1.3 (Activate detect_state) ─── can run in parallel with F1.4
-F1.4 (Post-install hooks)    ─── can run in parallel with F1.3
-```
-
-F1.1 must land first — it's the seed script change that everything else builds on. F1.2 and F1.5 are independent of each other (different repos). F1.3 and F1.4 are independent CLI-side changes.
+**Cycle**: cycle-036 (Phase 2)
+**SDD**: `grimoires/loa/sdd.md` (Phase 2 Self-Service)
+**Branch**: `feat/cycle-036-distribution-layer`
+**Depends on**: Phase 1 (PR #143, merged to feature branch)
 
 ---
 
-## Sprint 1: Seed Script Foundation + Dry-Run Validation
+## Sprint 1: API Extension + Bug Fix (3 tasks)
 
-*Goal: Full manifest extraction with Zod validation, content hash, dry-run mode. Zero new registrations yet — validate first.*
+### T1.1: Fix userEmail context bug in register endpoint
+**File**: `apps/api/src/routes/constructs.ts`
+**Change**: Replace `c.get('userEmail' as never)` with `c.get('user').email` and gate on `c.get('user').emailVerified`
+**AC**: Register endpoint uses declared ContextVariableMap types, no cast hacks
 
-### Tasks
+### T1.2: Extend register schema to accept git_url and git_ref
+**File**: `apps/api/src/routes/constructs.ts`
+**Change**: Add optional `git_url` (z.string().url()) and `git_ref` (z.string(), default 'main') to the register Zod schema
+**AC**: Schema validates git_url as URL, git_ref as string
 
-| ID | Task | File | AC |
-|----|------|------|----|
-| T1.1 | Import `packManifestSchema` from shared package | `seed-forge-packs.ts` | Import compiles, no runtime errors |
-| T1.2 | Replace `PackManifest` interface with `DiscoveredPack` carrying `fullManifest` | `seed-forge-packs.ts` | Type-safe with `ValidatedPackManifest \| null` |
-| T1.3 | Replace manual field extraction (lines 168-184) with `packManifestSchema.safeParse()` + fallback | `seed-forge-packs.ts` | Validated manifests pass through complete; invalid manifests fall back to 7-field |
-| T1.4 | Replace 7-field manifest construction (lines 358-367) with `pack.fullManifest ?? minimal` | `seed-forge-packs.ts` | `pack_versions.manifest` stores full JSONB when validation passes |
-| T1.5 | Add content hash computation after file collection | `seed-forge-packs.ts` | `content_hash` column populated (SHA-256 of manifest + sorted file hashes) |
-| T1.6 | Add `--dry-run` flag that validates all manifests without DB writes | `seed-forge-packs.ts` | `pnpm tsx scripts/seed-forge-packs.ts --dry-run` reports validation results |
-| T1.7 | Run dry-run against all 6 existing construct repos | Manual | All 6 pass Zod validation, or issues documented and fixed in upstream repos |
-
-### Acceptance Criteria
-- `seed-forge-packs.ts --dry-run` validates all 6 existing manifests
-- Full manifest stored in `pack_versions.manifest` for all 6 packs
-- `content_hash` populated for all `pack_versions` rows
-- Fallback path works for any manifest that fails Zod (no regressions)
-- No API changes needed — `GET /v1/constructs/:slug` automatically returns new fields
-
----
-
-## Sprint 2: Register 4 New Constructs + The Easel Extraction
-
-*Goal: Herald, Hardening, Dynamic Auth registered. The Easel extracted as domain-agnostic construct. Total: 10 packs, 84 skills.*
-
-### Tasks
-
-| ID | Task | File | AC |
-|----|------|------|----|
-| T2.1 | Add Herald, Hardening, Dynamic Auth to `GIT_CONFIGS` and `PACK_ICONS` | `seed-forge-packs.ts` | 3 entries in each map |
-| T2.2 | Dry-run validate all 3 new construct repos | Manual | All 3 pass `packManifestSchema.safeParse()` |
-| T2.3 | Create `construct-the-easel` repo with structure from SDD §2.3.1 | New repo | Repo exists with `construct.yaml`, `identity/`, `skills/`, `contexts/` |
-| T2.4 | Write `construct.yaml` v3 manifest for The Easel | `construct-the-easel/construct.yaml` | Passes Zod validation, includes golden_path, events, pack_dependencies, workflow |
-| T2.5 | Write `identity/persona.yaml` — creative studio voice, domain-agnostic | `construct-the-easel/identity/persona.yaml` | Zero cyberpunk/rektdrop references |
-| T2.6 | Write `identity/expertise.yaml` — design vocabulary, visual direction, taste | `construct-the-easel/identity/expertise.yaml` | Domain-agnostic expertise descriptors |
-| T2.7 | Write `grounding-creative` SKILL.md — generalized with context slots | `construct-the-easel/skills/grounding-creative/` | SKILL.md + index.yaml, uses `{{grimoire_path}}` and `{{vocabulary_path}}` |
-| T2.8 | Write `exploring-visuals` SKILL.md — generalized with `{{generation_tool}}` | `construct-the-easel/skills/exploring-visuals/` | SKILL.md + index.yaml, no tool-specific references |
-| T2.9 | Write `capturing-results` SKILL.md — generalized result annotation | `construct-the-easel/skills/capturing-results/` | SKILL.md + index.yaml |
-| T2.10 | Write `recording-taste` SKILL.md — generalized TDR CRUD | `construct-the-easel/skills/recording-taste/` | SKILL.md + index.yaml |
-| T2.11 | Write empty templates: `vocabulary-template.md`, `tdr-template.md`, `quality-gates.md` | `construct-the-easel/contexts/` | 8-domain vocabulary structure with no terms, blank TDR, generic phase gates |
-| T2.12 | Add The Easel to `GIT_CONFIGS` and `PACK_ICONS` in seed script | `seed-forge-packs.ts` | Entry in each map with 🖼️ icon |
-| T2.13 | Run seed script against production DB with all 10 constructs | Manual | `/constructs browse` returns 10 packs, 84 skills total |
-| T2.14 | Verify all 10 constructs appear on constructs.network explorer | Manual | Explorer shows Herald, Hardening, Dynamic Auth, The Easel with full metadata |
-
-### Acceptance Criteria
-- 10 packs visible in `/constructs browse` and on constructs.network
-- Herald (3), Hardening (7), Dynamic Auth (3), The Easel (4) all installable
-- The Easel skills contain zero cyberpunk/rektdrop-specific content
-- The Easel ships with empty vocabulary template — installing on a fresh project gives blank slate
-- Total: 10 packs, 84 skills
+### T1.3: Chain register → register-repo → sync when git_url provided
+**File**: `apps/api/src/routes/constructs.ts`
+**Change**: After pack creation, if git_url provided:
+1. Import and call `validateGitUrl()` from `git-sync.ts`
+2. Import and call `syncFromRepo()` for initial version
+3. Update pack with source_type='git', git_url, git_ref, github_repo_id
+4. Create pack_version with full manifest + content_hash
+5. Set status='published' (validation passed)
+6. Return enriched response with version info
+**AC**: `POST /v1/constructs/register { slug, name, git_url }` creates a fully populated, published pack in one call. Without git_url, existing behavior preserved.
 
 ---
 
-## Sprint 3: CLI-Side — detect_state + Post-Install Hooks
+## Sprint 2: CLI Commands (4 tasks)
 
-*Goal: `/loa` shows "you are here" for installed constructs. Post-install hooks execute on installation.*
+### T2.1: Create constructs-register.sh
+**File**: `.claude/scripts/constructs-register.sh` (new)
+**Implements**: `register_construct()` function
+**Flow**:
+1. Parse args: `<slug> --git-url <url> [--name "Name"] [--git-ref <ref>]`
+2. Validate slug format via `validate_safe_identifier()`
+3. Validate URL format via `validate_url()`
+4. Resolve API key via `get_api_key()`
+5. POST to `/v1/constructs/register` with curl config file auth (SHELL-002 pattern)
+6. Parse response, display result
+**Security**: Curl config file for auth (not inline header), HTTPS-only, TLS 1.2+
+**AC**: `/constructs register my-pack --git-url https://github.com/org/construct-my-pack.git` succeeds
 
-### Tasks
+### T2.2: Add sync subcommand to constructs-install.sh
+**File**: `.claude/scripts/constructs-install.sh`
+**Change**: Add `sync` case to the main dispatch (alongside pack/skill/uninstall/link-commands)
+**Flow**:
+1. Verify slug is provided
+2. Check pack exists in .constructs-meta.json (optional — can sync even if not installed locally)
+3. POST to `/v1/packs/<slug>/sync` with curl config file auth
+4. Parse response: version, commit, files_synced
+5. If installed locally and version changed, suggest `/constructs install <slug>` to update
+**AC**: `/constructs sync observer` triggers sync and shows result
 
-| ID | Task | File | AC |
-|----|------|------|----|
-| T3.1 | Modify `golden_detect_construct_journeys()` to execute `detect_state` scripts | `golden-path.sh` | Function reads `golden_path.detect_state` from manifest, executes if present |
-| T3.2 | Implement `●` position marker based on detect_state output + truename_map matching | `golden-path.sh` | Journey bar shows `●` at the correct command position |
-| T3.3 | Add 5-second timeout and silent fallback for detect_state execution | `golden-path.sh` | Slow/missing scripts don't block `/loa` output |
-| T3.4 | Add `execute_post_install_hook()` function to constructs-install.sh | `constructs-install.sh` | Function extracts `hooks.post_install` from manifest, executes if present |
-| T3.5 | Add path traversal prevention for post-install hooks via `realpath` comparison | `constructs-install.sh` | Scripts outside pack directory are blocked |
-| T3.6 | Add 30-second timeout and non-blocking failure handling for hooks | `constructs-install.sh` | Hook failure = warning, not installation failure |
-| T3.7 | Wire `execute_post_install_hook()` call after pack extraction in install flow | `constructs-install.sh` | Hook runs after files are extracted and commands are symlinked |
-| T3.8 | Test: install a pack with golden_path + detect_state, verify `/loa` output | E2E | Journey bar renders with `●` position for the installed construct |
-| T3.9 | Test: install a pack with hooks.post_install, verify hook executes | E2E | Post-install script runs, output visible, failure is non-blocking |
-| T3.10 | Test: install a pack with neither detect_state nor hooks, verify no regression | E2E | Current behavior preserved — journey bar shows commands without `●`, no hook attempt |
+### T2.3: Add status subcommand to constructs-install.sh
+**File**: `.claude/scripts/constructs-install.sh`
+**Change**: Add `status` case to main dispatch
+**Flow**:
+1. If slug provided: show single pack status
+2. If no slug: show all installed packs status
+3. Read local data from `.constructs-meta.json`
+4. GET `/v1/constructs/<slug>` for registry data
+5. GET `/v1/packs/<slug>/hash` for registry content hash
+6. Compare versions (semver) → SYNCED / BEHIND / AHEAD
+7. Compare hashes → MATCH / DIVERGED
+8. Format output
+**AC**: `/constructs status` shows formatted status for all installed packs with sync indicators
 
-### Acceptance Criteria
-- `/loa` shows construct journey bars with `●` position indicator when detect_state is declared
-- Post-install hooks execute after installation with path traversal prevention
-- Fallback behavior preserved for packs without detect_state or hooks
-- No regressions for existing installed packs
-
----
-
-## Sprint Summary
-
-| Sprint | Focus | Tasks | Key Deliverable |
-|--------|-------|-------|-----------------|
-| 1 | Seed Script Foundation | 7 tasks | Full manifest in DB + content hash |
-| 2 | Register 4 + Extract Easel | 14 tasks | 10 packs / 84 skills on network |
-| 3 | CLI detect_state + Hooks | 10 tasks | "You are here" + post-install hooks |
-
-**Total**: 31 tasks across 3 sprints
-
-### Sprint Dependencies
-
-```
-Sprint 1 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ↓ must complete before
-Sprint 2 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ↓ must complete before (packs must be installable to test detect_state)
-Sprint 3 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-```
-
-Each sprint is independently shippable — Sprint 1 alone delivers full manifest fidelity for the existing 6 packs. Sprint 2 adds 4 new constructs. Sprint 3 enables the progressive disclosure UX.
+### T2.4: Wire dispatch for register, sync, status
+**File**: `.claude/scripts/constructs-install.sh`
+**Change**: Update the main case statement to dispatch `register` to `constructs-register.sh`, and handle `sync`/`status` inline
+**AC**: `constructs-install.sh register ...`, `constructs-install.sh sync ...`, `constructs-install.sh status ...` all dispatch correctly
 
 ---
 
-*"First the pipe. Then the water. Then the garden."*
+## Sprint 3: Skill Update + Integration (3 tasks)
+
+### T3.1: Update browsing-constructs SKILL.md
+**File**: `.claude/skills/browsing-constructs/SKILL.md`
+**Change**: Add `register`, `sync`, `status` to the command table and dispatch instructions
+**AC**: Skill documentation includes all three new commands with usage examples
+
+### T3.2: Update browsing-constructs index.yaml
+**File**: `.claude/skills/browsing-constructs/index.yaml`
+**Change**: Add `register`, `sync`, `status` to the valid `action` enum in inputs
+**AC**: Skill metadata reflects new actions
+
+### T3.3: End-to-end validation
+**Validation steps**:
+1. Verify API register endpoint compiles (TypeScript check)
+2. Verify CLI scripts pass `bash -n` syntax check
+3. Verify existing install/browse/uninstall commands unaffected
+4. Verify new dispatch cases route correctly
+**AC**: All new commands work, no regressions
+
+---
+
+## Task Summary
+
+| Sprint | Tasks | Files | Est. Lines |
+|--------|-------|-------|-----------|
+| 1 | 3 | 1 modified (constructs.ts) | ~80 |
+| 2 | 4 | 1 new + 1 modified (register.sh, install.sh) | ~400 |
+| 3 | 3 | 2 modified (SKILL.md, index.yaml) | ~60 |
+| **Total** | **10** | **4 files** | **~540** |
+
+---
+
+*"Self-service is not about automation. It's about removing yourself from the critical path."*

--- a/grimoires/loa/sprint.md
+++ b/grimoires/loa/sprint.md
@@ -1,115 +1,75 @@
-# Sprint Plan: Distribution Layer Phase 2 — Self-Service
+# Sprint Plan: Distribution Layer Phase 3 — Cross-Platform & Navigation
 
-**Cycle**: cycle-036 (Phase 2)
-**SDD**: `grimoires/loa/sdd.md` (Phase 2 Self-Service)
+**Cycle**: cycle-036 (Phase 3)
+**SDD**: `grimoires/loa/sdd.md` (Phase 3 Cross-Platform & Navigation)
 **Branch**: `feat/cycle-036-distribution-layer`
-**Depends on**: Phase 1 (PR #143, merged to feature branch)
+**Depends on**: Phase 1 (merged to feature branch), Phase 2 (merged to feature branch)
 
 ---
 
-## Sprint 1: API Extension + Bug Fix (3 tasks)
+## Sprint 1: Content-Hash Staleness Detection (3 tasks)
 
-### T1.1: Fix userEmail context bug in register endpoint
-**File**: `apps/api/src/routes/constructs.ts`
-**Change**: Replace `c.get('userEmail' as never)` with `c.get('user').email` and gate on `c.get('user').emailVerified`
-**AC**: Register endpoint uses declared ContextVariableMap types, no cast hacks
+### T1.1: Add compute_pack_hash() function
+**File**: `.claude/scripts/constructs-install.sh`
+**Change**: Add function that computes Merkle-root SHA-256 of all pack files (same algorithm as API)
+**AC**: Function returns consistent hash for same file set
 
-### T1.2: Extend register schema to accept git_url and git_ref
-**File**: `apps/api/src/routes/constructs.ts`
-**Change**: Add optional `git_url` (z.string().url()) and `git_ref` (z.string(), default 'main') to the register Zod schema
-**AC**: Schema validates git_url as URL, git_ref as string
+### T1.2: Store content_hash in .constructs-meta.json at install time
+**File**: `.claude/scripts/constructs-install.sh`
+**Change**: Call `compute_pack_hash()` in `update_pack_meta()`, write `content_hash` field
+**AC**: After `constructs-install.sh pack <slug>`, meta file has `content_hash` for installed pack
 
-### T1.3: Chain register → register-repo → sync when git_url provided
-**File**: `apps/api/src/routes/constructs.ts`
-**Change**: After pack creation, if git_url provided:
-1. Import and call `validateGitUrl()` from `git-sync.ts`
-2. Import and call `syncFromRepo()` for initial version
-3. Update pack with source_type='git', git_url, git_ref, github_repo_id
-4. Create pack_version with full manifest + content_hash
-5. Set status='published' (validation passed)
-6. Return enriched response with version info
-**AC**: `POST /v1/constructs/register { slug, name, git_url }` creates a fully populated, published pack in one call. Without git_url, existing behavior preserved.
+### T1.3: Compare local vs registry hash in status command
+**File**: `.claude/scripts/constructs-install.sh`
+**Change**: In `show_pack_status()`, read local `content_hash` from meta and compare against registry hash (already fetched). Show SYNCED/DIVERGED/BEHIND/UNKNOWN indicators.
+**AC**: `constructs-install.sh status` shows hash comparison results
 
 ---
 
-## Sprint 2: CLI Commands (4 tasks)
+## Sprint 2: Standalone Audit (2 tasks)
 
-### T2.1: Create constructs-register.sh
-**File**: `.claude/scripts/constructs-register.sh` (new)
-**Implements**: `register_construct()` function
-**Flow**:
-1. Parse args: `<slug> --git-url <url> [--name "Name"] [--git-ref <ref>]`
-2. Validate slug format via `validate_safe_identifier()`
-3. Validate URL format via `validate_url()`
-4. Resolve API key via `get_api_key()`
-5. POST to `/v1/constructs/register` with curl config file auth (SHELL-002 pattern)
-6. Parse response, display result
-**Security**: Curl config file for auth (not inline header), HTTPS-only, TLS 1.2+
-**AC**: `/constructs register my-pack --git-url https://github.com/org/construct-my-pack.git` succeeds
+### T2.1: Add --standalone flag to validate-skills.sh
+**File**: `.claude/scripts/validate-skills.sh`
+**Change**: Add audit that checks SKILL.md files for:
+1. `{context:...}` slots without documented defaults
+2. Hard reads from grimoires/ without guards
+3. Pack-level file references as runtime deps
+Report PASS/WARN/FAIL per skill with actionable details.
+**AC**: `validate-skills.sh --standalone` reports on all installed skills
 
-### T2.2: Add sync subcommand to constructs-install.sh
-**File**: `.claude/scripts/constructs-install.sh`
-**Change**: Add `sync` case to the main dispatch (alongside pack/skill/uninstall/link-commands)
-**Flow**:
-1. Verify slug is provided
-2. Check pack exists in .constructs-meta.json (optional — can sync even if not installed locally)
-3. POST to `/v1/packs/<slug>/sync` with curl config file auth
-4. Parse response: version, commit, files_synced
-5. If installed locally and version changed, suggest `/constructs install <slug>` to update
-**AC**: `/constructs sync observer` triggers sync and shows result
-
-### T2.3: Add status subcommand to constructs-install.sh
-**File**: `.claude/scripts/constructs-install.sh`
-**Change**: Add `status` case to main dispatch
-**Flow**:
-1. If slug provided: show single pack status
-2. If no slug: show all installed packs status
-3. Read local data from `.constructs-meta.json`
-4. GET `/v1/constructs/<slug>` for registry data
-5. GET `/v1/packs/<slug>/hash` for registry content hash
-6. Compare versions (semver) → SYNCED / BEHIND / AHEAD
-7. Compare hashes → MATCH / DIVERGED
-8. Format output
-**AC**: `/constructs status` shows formatted status for all installed packs with sync indicators
-
-### T2.4: Wire dispatch for register, sync, status
-**File**: `.claude/scripts/constructs-install.sh`
-**Change**: Update the main case statement to dispatch `register` to `constructs-register.sh`, and handle `sync`/`status` inline
-**AC**: `constructs-install.sh register ...`, `constructs-install.sh sync ...`, `constructs-install.sh status ...` all dispatch correctly
+### T2.2: Standardize Required Context headers in construct pack skills
+**Files**: `.claude/constructs/packs/*/skills/*/SKILL.md` (23 skills with context slots)
+**Change**: Ensure each skill using `{context:...}` has a standardized Required Context header documenting needed keys, purpose, and standalone degradation behavior.
+**AC**: All 23 context-slot skills have documented defaults; `validate-skills.sh --standalone` shows 0 WARN
 
 ---
 
-## Sprint 3: Skill Update + Integration (3 tasks)
+## Sprint 3: Per-Invocation CTAs (2 tasks)
 
-### T3.1: Update browsing-constructs SKILL.md
-**File**: `.claude/skills/browsing-constructs/SKILL.md`
-**Change**: Add `register`, `sync`, `status` to the command table and dispatch instructions
-**AC**: Skill documentation includes all three new commands with usage examples
+### T3.1: Add ## Next Steps to skills that lack them
+**Files**: `.claude/constructs/packs/*/skills/*/SKILL.md`
+**Change**: Add `## Next Steps` output section to multi-pack skills that don't already have one. Each section lists 2-3 logical next commands from the same pack + `/loa` fallback.
+**AC**: All skills in multi-skill packs have Next Steps sections
 
-### T3.2: Update browsing-constructs index.yaml
-**File**: `.claude/skills/browsing-constructs/index.yaml`
-**Change**: Add `register`, `sync`, `status` to the valid `action` enum in inputs
-**AC**: Skill metadata reflects new actions
-
-### T3.3: End-to-end validation
+### T3.2: End-to-end validation
 **Validation steps**:
-1. Verify API register endpoint compiles (TypeScript check)
-2. Verify CLI scripts pass `bash -n` syntax check
-3. Verify existing install/browse/uninstall commands unaffected
-4. Verify new dispatch cases route correctly
-**AC**: All new commands work, no regressions
+1. Verify `validate-skills.sh --standalone` passes
+2. Verify `bash -n` on all modified scripts
+3. Verify content_hash field present in meta schema
+4. Verify existing install/browse/sync commands unaffected
+**AC**: All features work, no regressions
 
 ---
 
 ## Task Summary
 
 | Sprint | Tasks | Files | Est. Lines |
-|--------|-------|-------|-----------|
-| 1 | 3 | 1 modified (constructs.ts) | ~80 |
-| 2 | 4 | 1 new + 1 modified (register.sh, install.sh) | ~400 |
-| 3 | 3 | 2 modified (SKILL.md, index.yaml) | ~60 |
-| **Total** | **10** | **4 files** | **~540** |
+|--------|-------|-------|-----------:|
+| 1 | 3 | 1 modified (constructs-install.sh) | ~60 |
+| 2 | 2 | 1 modified + ~23 SKILL.md updates | ~80 + docs |
+| 3 | 2 | ~15 SKILL.md updates + validation | docs |
+| **Total** | **7** | **2 scripts + ~38 SKILL.md files** | **~140 + docs** |
 
 ---
 
-*"Self-service is not about automation. It's about removing yourself from the critical path."*
+*"Cross-platform compatibility is not about the lowest common denominator. It's about graceful enrichment — each platform gets the best it can use."*

--- a/grimoires/loa/sprint.md
+++ b/grimoires/loa/sprint.md
@@ -1,438 +1,135 @@
-# Sprint Plan: R&D Synthesis — Measurement Honesty
+# Sprint Plan: Constructs Network Distribution Layer — Phase 1
 
-**Cycle**: cycle-035
-**Created**: 2026-02-22
+**Cycle**: cycle-036
+**Created**: 2026-02-27
 **PRD**: `grimoires/loa/prd.md`
 **SDD**: `grimoires/loa/sdd.md`
-**Sprints**: 3 (global IDs: sprint-34, sprint-35, sprint-36)
-**Team**: Solo (single-agent)
+**Scope**: Phase 1 Foundation — F1.1, F1.2, F1.5, F1.3, F1.4
 
 ---
 
-## Sprint 1: Measurement Foundation (P0)
-
-**Global ID**: sprint-34
-**Goal**: Database migration, signal outcomes API, fork provenance, graduation criteria fix
-**Priority**: P0 — all other sprints depend on this schema
-
-### Task 1.1: Migration 0006 — Schema Foundation
-
-**Files**: `apps/api/src/db/schema.ts`, `apps/api/drizzle/0006_measurement_honesty.sql`
-
-**Description**: Create migration `0006_measurement_honesty.sql` with:
-- `forked_from UUID REFERENCES packs(id)` column on `packs` table
-- `skill_prose TEXT` column on `packs` table
-- `signal_outcomes` table (full DDL from SDD §3.1.2)
-- `construct_showcases` table (full DDL from SDD §3.1.3)
-- All indexes per SDD
-
-Update Drizzle schema in `schema.ts`:
-- Add `forkedFrom` and `skillProse` to packs definition
-- Add `signalOutcomes` table definition with constraints
-- Add `constructShowcases` table definition
-- Update `packsRelations` with `forkedFromPack` relation
-
-**Null handling**: Both new packs columns (`forked_from`, `skill_prose`) are nullable. Existing rows get NULL. Application code must handle NULL for both: `forkedFrom: pack.forkedFrom ?? null` in mapping, `skillProse: pack.skillProse ?? null` in sync. No backfill needed — see SDD §3.1.1 rationale.
-
-**Rollback strategy**: All changes are additive (no column removals, no type changes). Rollback = revert code deploy; columns and tables remain unused. If migration partially fails, `signal_outcomes` and `construct_showcases` are independent tables that can be created/dropped individually. The `ALTER TABLE packs ADD COLUMN` statements are also independent and can be retried.
-
-**DDL reference**: See SDD §3.1.1–§3.1.3 for exact DDL. Key constraints to verify:
-- `signal_outcomes.no_self_evaluation`: CHECK (recorded_by IS DISTINCT FROM evaluated_by)
-- `signal_outcomes.unique_signal_evaluation`: UNIQUE (pack_id, signal_type, signal_source)
-- `signal_outcomes.predicted_impact`: CHECK IN ('high', 'medium', 'low')
-- `signal_outcomes.actual_impact`: CHECK IN ('high', 'medium', 'low', 'none')
-
-**Acceptance Criteria**:
-- [ ] Migration runs cleanly on empty DB and on DB with existing 0005 migration
-- [ ] Migration tested on production-like snapshot (existing packs with data)
-- [ ] `pnpm drizzle-kit generate` shows no diff after schema.ts update
-- [ ] All FK constraints, CHECK constraints, and UNIQUE constraints in place
-- [ ] Indexes created: `idx_packs_forked_from`, `idx_signal_outcomes_pack`, `idx_signal_outcomes_evaluated`, `idx_construct_showcases_pack`, `idx_construct_showcases_approved`
-- [ ] Existing packs queries work unchanged with null forked_from and null skill_prose
-
-**Dependencies**: Migration 0005 must be verified in production
-**Effort**: Small
-
----
-
-### Task 1.2: Signal Outcomes API — Core Endpoints
-
-**Files**: NEW `apps/api/src/routes/signals.ts`, NEW `apps/api/src/services/signals.ts`, `apps/api/src/index.ts` (mount router)
-
-**Description**: Implement the signal outcomes API per SDD §4.1:
-
-1. `POST /v1/packs/:slug/signals/outcomes` — Create signal outcome prediction
-   - Resolve slug → pack_id, verify isPackOwner
-   - Rate limit: 50/hour per user (Redis key: `rl:signals:create:{userId}`, follows existing `checkSyncRateLimit()` pattern in packs.ts)
-   - Sanitize inputs, insert with recorded_by = userId
-
-2. `PATCH /v1/packs/:slug/signals/outcomes/:id` — Evaluate a recorded signal
-   - Auth: `isPackOwner() || isAdmin()` AND `userId !== recorded_by`
-   - Single-maintainer exception: allow self-eval, flag it
-   - Sanitize outcome_summary
-   - Invalidate accuracy cache on write
-
-3. `GET /v1/packs/:slug/signals/outcomes` — List outcomes (public, summaries only)
-   - Returns outcome_summary, never outcome_evidence
-   - Pagination: page + per_page
-   - Computed field: self_evaluated boolean
-
-4. `GET /v1/packs/:slug/signals/outcomes/detail` — List with evidence (owner only)
-   - Same as above but includes outcome_evidence
-   - Auth: isPackOwner
-
-Add `isomorphic-dompurify` to `apps/api/package.json` for sanitization.
-
-**Acceptance Criteria**:
-- [ ] POST creates outcome with correct recorded_by, returns 201
-- [ ] POST returns 403 for non-owner, 429 for rate limit, 409 for duplicate (pack_id, signal_type, signal_source)
-- [ ] PATCH updates actual_impact, evaluated_by, evaluated_at
-- [ ] PATCH returns 403 for self-evaluation (non-single-maintainer), 403 for non-owner/non-admin
-- [ ] PATCH by non-owner non-admin returns 403 (explicit test)
-- [ ] PATCH with userId === recorded_by returns 403 unless single-maintainer (explicit test)
-- [ ] GET public returns outcome_summary, never outcome_evidence
-- [ ] GET detail returns full data, 403 for non-owner
-- [ ] All text inputs sanitized (HTML stripped)
-- [ ] Rate limit returns 429 after 50 requests/hour (Redis-based, per-user key)
-
-**Dependencies**: Task 1.1
-**Effort**: Medium
-
----
-
-### Task 1.3: Signal Accuracy API — Computation + Caching
-
-**Files**: `apps/api/src/services/signals.ts` (add computeAccuracy), `apps/api/src/routes/signals.ts` (add accuracy endpoint)
-
-**Description**: Implement accuracy computation per SDD §4.1.5–4.1.8:
-
-1. `GET /v1/packs/:slug/signals/accuracy` — Public accuracy report
-   - Redis cache: `accuracy:{packId}` with 10min TTL
-   - Invalidated on PATCH evaluation write
-
-2. `computeAccuracy()` service function:
-   - Build 3×4 confusion matrix (predicted high/medium/low × actual high/medium/low/none)
-   - Compute per-class precision/recall
-   - Compute weighted kappa (linear weights, ordinal scale)
-   - Reference implementation: match scikit-learn `cohen_kappa_score(weights='linear')` output
-   - Self-evaluated outcomes excluded from kappa (weight = 0)
-   - Coverage: evaluated/total ratio
-   - Time-to-outcome: median, p25, p75
-   - Warnings: sample < 20, coverage < 50%, self-eval > 20%
-   - **Degenerate cases**: All predictions same class → kappa = 0 (not NaN). Zero evaluated outcomes → `sufficient_data: false`. Division by zero in precision/recall → 0.
-
-3. TypeScript interfaces: `SignalOutcome`, `SignalOutcomePublic`, `AccuracyReport`, `ClassMetrics` (SDD §4.1.8)
-
-4. **Redis fallback**: If Redis unavailable, compute accuracy on every request (no cache). Log warning, do not error. Use try/catch around Redis get/set — never let cache failure break the accuracy endpoint.
-
-**Golden Test Fixtures**: Include at least 3 hardcoded test datasets with pre-computed expected outputs:
-- Fixture A: Perfect agreement (kappa = 1.0, all predictions match outcomes)
-- Fixture B: Random/no agreement (kappa ≈ 0.0)
-- Fixture C: Mixed with some self-evaluations excluded (verify exclusion logic)
-Verify against scikit-learn `cohen_kappa_score(weights='linear')` output. Store fixtures in test file, not external dependency.
-
-**Acceptance Criteria**:
-- [ ] Accuracy endpoint returns correct confusion matrix for test dataset
-- [ ] Weighted kappa matches scikit-learn reference for all 3 golden fixtures (tolerance ±0.001)
-- [ ] Returns `sufficient_data: false` when sample_size < 20
-- [ ] All-same-class predictions return kappa = 0 (not NaN/Infinity)
-- [ ] Self-evaluated outcomes excluded from kappa, reported separately
-- [ ] Redis cache hit on second request; invalidated after PATCH evaluation
-- [ ] Redis unavailable → computes without cache, no error returned
-- [ ] Warnings fire at correct thresholds (20% self-eval, 50% coverage, 20 sample size)
-- [ ] Empty data returns clean empty state, not error
-
-**Dependencies**: Task 1.2
-**Effort**: Medium
-
----
-
-### Task 1.4: Fork Provenance — Endpoint Fix + API Response
-
-**Files**: `apps/api/src/routes/packs.ts:~1709`, `apps/api/src/services/constructs.ts`
-
-**Description**: Per SDD §4.2:
-
-1. Fix `POST /packs/fork` to pass `forkedFrom: sourcePack.id` to createPack()
-2. Add `forkedFrom` and `forkCount` to `Construct` interface
-3. In `getConstructBySlug` (detail path only): join forked_from → parent slug/name, count forks
-4. In list path: `forkedFrom: null, forkCount: 0` (lightweight defaults, no N+1)
-
-**Acceptance Criteria**:
-- [ ] POST /packs/fork sets forked_from FK on new pack
-- [ ] GET /v1/constructs/:slug returns forked_from with slug + name when present
-- [ ] GET /v1/constructs/:slug returns fork_count (count of packs forking this one)
-- [ ] List endpoint returns null/0 defaults (no performance impact)
-
-**Dependencies**: Task 1.1
-**Effort**: Small
-
----
-
-### Task 1.5: Kill Download-Count Graduation
-
-**Files**: `docs/GRADUATION.md`, `apps/api/src/services/constructs.ts:142`
-
-**Description**: Per PRD FR7 and SDD §6.2.1:
-
-1. Update `GRADUATION.md`:
-   - exp→beta: 7+ days + README ≥200 words + at least 1 SKILL.md
-   - beta→stable: 30+ days at beta + CHANGELOG present + no `critical`/`breaking` issues
-   - Remove all "10+ downloads" and "100+ downloads" references
-
-2. Reduce `RELEVANCE_WEIGHTS.downloads` from 0.3 → 0.1 at `constructs.ts:142`
-
-**Acceptance Criteria**:
-- [ ] Zero references to download counts in GRADUATION.md criteria (grep verification)
-- [ ] RELEVANCE_WEIGHTS.downloads === 0.1
-- [ ] Graduation criteria are concrete and automatable (word counts, file presence, time gates)
-
-**Dependencies**: None
-**Effort**: Small
-
----
-
-## Sprint 2: Explorer Reality (P1)
-
-**Global ID**: sprint-35
-**Goal**: Explorer diagnostic language, SKILL.md prose, fork celebration, certificate rename
-**Priority**: P1 — user-facing improvements that depend on Sprint 1 schema
-
-### Task 2.1: Diagnostic Language — Replace "Level" Label
-
-**Files**: `apps/explorer/app/(marketing)/constructs/[slug]/page.tsx:128-130`
-
-**Description**: Per SDD §5.2:
-
-Replace theatrical "Level" stat block with diagnostic text:
-- experimental → "Experimental — needs README + 7 days for beta"
-- beta → "Beta — needs CHANGELOG + no critical issues for stable"
-- stable → "Stable"
-- deprecated → "Deprecated"
-- unknown/default → "Experimental — needs README + 7 days for beta"
-
-Remove the "Level" label entirely. Pure diagnostic output.
-
-**Acceptance Criteria**:
-- [ ] No "Level" text appears on construct detail page
-- [ ] Each maturity level shows correct diagnostic text
-- [ ] Unknown/missing maturity defaults to experimental diagnostic
-- [ ] Visual styling: text-sm, no stat-block framing
-
-**Dependencies**: None (can start immediately)
-**Effort**: Small
-
----
-
-### Task 2.2: SKILL.md Prose Pipeline
-
-**Files**: `apps/api/src/routes/packs.ts` (sync), NEW `apps/api/src/utils/extractSkillProse.ts`, `apps/explorer/app/(marketing)/constructs/[slug]/page.tsx`, `apps/explorer/lib/data/transform-construct.ts`
-
-**Description**: Per SDD §4.3 and §5.3:
-
-**API side (sanitize on write)**:
-1. Create `extractSkillProse()` utility (SDD §4.3.2):
-   - Find primary SKILL.md (root-level preferred over nested)
-   - Strip YAML frontmatter
-   - Truncate at sentence boundary within 2000 chars
-   - Sanitize with DOMPurify (strip all HTML) — this is the **canonical sanitization point**
-   - Return null if no SKILL.md
-2. Call during `POST /packs/:slug/sync` within existing transaction
-3. Store result in `packs.skill_prose` (stored clean)
-
-**Explorer side (sanitize on render — defense in depth)**:
-4. Add `skill_prose` to APIConstruct type and ConstructDetail
-5. Add `react-markdown`, `remark-gfm`, `rehype-sanitize` to explorer deps (if not present)
-6. Render skill_prose as sanitized markdown above identity section — `rehype-sanitize` provides second layer even though stored content is already clean
-7. Fall back to description when skill_prose is null
-
-**Sanitization strategy**: Sanitize on write (DOMPurify in API) AND sanitize on render (rehype-sanitize in Explorer). Double sanitization is intentional defense-in-depth — if either layer fails, the other catches it.
-
-**Acceptance Criteria**:
-- [ ] extractSkillProse strips frontmatter correctly
-- [ ] Truncation at sentence boundary (not mid-word/sentence)
-- [ ] XSS payloads in SKILL.md are sanitized on API side (HTML stripped before storage)
-- [ ] Explorer renders with rehype-sanitize (defense in depth)
-- [ ] `<script>alert(1)</script>` in SKILL.md → no script tag in stored prose or rendered output
-- [ ] Null SKILL.md → null skill_prose → description fallback on Explorer
-- [ ] Sync updates skill_prose on every call
-- [ ] Explorer renders markdown safely (no raw HTML)
-
-**Dependencies**: Task 1.1 (skill_prose column must exist)
-**Effort**: Medium
-
----
-
-### Task 2.3: Fork Celebration — Explorer Display
-
-**Files**: `apps/explorer/app/(marketing)/constructs/[slug]/page.tsx`, `apps/explorer/lib/data/transform-construct.ts`, browse card components
-
-**Description**: Per SDD §5.4:
-
-1. Add `forked_from` and `fork_count` to ConstructDetail type
-2. On detail page: "Forked from [parent]" link badge when forkedFrom is present
-3. On detail page: "N variants exist" text when forkCount > 0
-4. On browse cards: small fork count badge when > 0
-
-**Acceptance Criteria**:
-- [ ] Forked construct shows "Forked from [parent name]" link
-- [ ] Link navigates to parent construct page
-- [ ] Constructs with forks show "N variants exist"
-- [ ] Browse cards show fork count badge
-- [ ] Constructs without forks show nothing (no empty state clutter)
-
-**Dependencies**: Task 1.4 (fork data in API response)
-**Effort**: Small
-
----
-
-### Task 2.4: Rename CalibrationCertificate → VerificationCertificate
-
-**Files**: `apps/api/src/db/schema.ts:1171`, `apps/api/drizzle/0005_construct_verifications.sql:77`, `grimoires/bridgebuilder/echelon-integration-gaps.md`, `grimoires/bridgebuilder/observer-laboratory-success-case.md`, `grimoires/bridgebuilder/rd-synthesis-behavioral-measurement.md`
-
-**Description**: Per PRD FR8 and SDD §7.2:
-
-1. Update JSDoc comment at schema.ts:1171 — "CalibrationCertificate" → "VerificationCertificate"
-2. Update SQL COMMENT at 0005_construct_verifications.sql:77
-3. Grep-and-replace across 3 grimoire files (~28 occurrences total)
-4. Verify no code identifiers use "CalibrationCertificate" (they don't — already generic)
-
-**Acceptance Criteria**:
-- [ ] `grep -ri "CalibrationCertificate"` returns zero results across entire repo
-- [ ] Code identifiers unchanged (only comments and docs modified)
-- [ ] All 3 grimoire files updated
-
-**Dependencies**: None
-**Effort**: Small
-
----
-
-## Sprint 3: Visible Craft (P2)
-
-**Global ID**: sprint-36
-**Goal**: Showcases API, Explorer showcase display, accuracy display
-**Priority**: P2 — enhances user experience, builds on Sprint 1+2
-
-### Task 3.1: Showcases API — Table + Endpoints
-
-**Files**: `apps/api/src/routes/packs.ts` (add routes)
-
-**Description**: Per SDD §4.4:
-
-1. `POST /v1/packs/:slug/showcases` — Submit showcase (any authenticated user)
-   - Zod: title (1-200), url (valid URL, max 2000), description (max 500, optional)
-   - Sanitize description with DOMPurify, set approved: false, submitted_by: userId
-   - Rate limit: 20/hour per user (Redis key: `rl:showcases:create:{userId}`, follows existing `checkSyncRateLimit()` pattern)
-
-2. `PATCH /v1/packs/:slug/showcases/:id/approve` — Approve showcase
-   - Auth: isPackOwner OR isAdmin
-   - Toggle approved: true
-
-3. `GET /v1/packs/:slug/showcases` — List showcases
-   - Public: only approved: true
-   - Pack owner: all (including pending)
-   - Ordered by created_at DESC
-
-**Acceptance Criteria**:
-- [ ] POST creates showcase with approved: false
-- [ ] PATCH approve sets approved: true, returns 403 for non-owner/non-admin
-- [ ] GET public returns only approved showcases
-- [ ] GET by pack owner returns all showcases
-- [ ] Description sanitized, URL validated
-- [ ] Rate limit enforced
-
-**Dependencies**: Task 1.1 (construct_showcases table)
-**Effort**: Small
-
----
-
-### Task 3.2: Explorer Built With — Showcase Display
-
-**Files**: `apps/explorer/app/(marketing)/constructs/[slug]/page.tsx`, `apps/explorer/lib/data/fetch-constructs.ts`
-
-**Description**: Per SDD §5.5 (showcases section):
-
-1. Fetch showcases via `GET /v1/packs/:slug/showcases` in fetchConstruct()
-2. Add showcases to ConstructDetail type
-3. Render "Built With" section on detail page:
-   - Title linked to URL (target="_blank", rel="noopener noreferrer")
-   - Description text below
-   - Only show section when showcases array is non-empty
-
-**Acceptance Criteria**:
-- [ ] Showcases section appears when construct has approved showcases
-- [ ] Each showcase shows title (linked), description
-- [ ] Links open in new tab with security attributes
-- [ ] Section hidden when no showcases
-
-**Dependencies**: Task 3.1
-**Effort**: Small
-
----
-
-### Task 3.3: Accuracy Display — Explorer Component
-
-**Files**: `apps/explorer/app/(marketing)/constructs/[slug]/page.tsx`, `apps/explorer/lib/data/fetch-constructs.ts`
-
-**Description**: Per SDD §5.5 (accuracy section):
-
-1. Fetch accuracy via `GET /v1/packs/:slug/signals/accuracy` in fetchConstruct()
-2. Add accuracy data to ConstructDetail type
-3. Render accuracy section when sufficient_data is true:
-   - Weighted κ, Coverage %, Sample size
-   - Warning messages in amber text
-4. Show nothing when insufficient data or no data
-
-**Acceptance Criteria**:
-- [ ] Accuracy section appears when sufficient_data === true
-- [ ] Shows weighted kappa, coverage, sample size
-- [ ] Warnings displayed when present
-- [ ] No section when insufficient data (clean empty state)
-- [ ] Uses cached API response (10min TTL from backend)
-
-**Dependencies**: Task 1.3 (accuracy API must exist)
-**Effort**: Small
-
----
-
-## Sprint Dependencies
+## Dependency Graph
 
 ```
-Sprint 1 (P0):
-  1.1 Migration ──────→ 1.2 Signal API ──→ 1.3 Accuracy API
-  1.1 Migration ──────→ 1.4 Fork Provenance
-  1.5 Graduation (independent)
-
-Sprint 2 (P1):
-  2.1 Diagnostic Language (independent)
-  1.1 ──→ 2.2 SKILL.md Prose
-  1.4 ──→ 2.3 Fork Celebration
-  2.4 Certificate Rename (independent)
-
-Sprint 3 (P2):
-  1.1 ──→ 3.1 Showcases API ──→ 3.2 Explorer Showcases
-  1.3 ──→ 3.3 Accuracy Display
+F1.1 (Full manifest extraction)
+  ↓ unblocks
+F1.2 (Register 3 constructs) ─── can run in parallel with F1.5
+F1.5 (Extract The Easel)     ─── can run in parallel with F1.2
+  ↓ both unblock
+F1.3 (Activate detect_state) ─── can run in parallel with F1.4
+F1.4 (Post-install hooks)    ─── can run in parallel with F1.3
 ```
 
----
-
-## Risk Buffer
-
-| Sprint | Buffer | Rationale |
-|--------|--------|-----------|
-| Sprint 1 | 30% | Accuracy computation (kappa) is non-trivial; golden fixture validation + degenerate case handling + Redis fallback add testing surface |
-| Sprint 2 | 10% | Mostly UI changes + straightforward extraction; prose pipeline is the unknown |
-| Sprint 3 | 10% | Simple CRUD + display; low complexity |
+F1.1 must land first — it's the seed script change that everything else builds on. F1.2 and F1.5 are independent of each other (different repos). F1.3 and F1.4 are independent CLI-side changes.
 
 ---
 
-## Out of Scope (Follow-Up Issues)
+## Sprint 1: Seed Script Foundation + Dry-Run Validation
 
-| Item | Target Repo | Why Deferred |
-|------|-------------|-------------|
-| Kill 3x rank-based signal weighting | construct-observer | Observer-internal change |
-| Observer Discovery mode (raw observation) | construct-observer | New skill, not a fix |
-| Replace Level N framing in Loa golden path | loa | Framework-level, not registry |
-| Score API formula changes | midi-interface | Score developer context required |
-| Analytical signal layer (internal weights) | loa-constructs (future) | Needs Score API access patterns to stabilize |
-| Community evaluator system | loa-constructs (future) | Requires user growth before meaningful |
+*Goal: Full manifest extraction with Zod validation, content hash, dry-run mode. Zero new registrations yet — validate first.*
+
+### Tasks
+
+| ID | Task | File | AC |
+|----|------|------|----|
+| T1.1 | Import `packManifestSchema` from shared package | `seed-forge-packs.ts` | Import compiles, no runtime errors |
+| T1.2 | Replace `PackManifest` interface with `DiscoveredPack` carrying `fullManifest` | `seed-forge-packs.ts` | Type-safe with `ValidatedPackManifest \| null` |
+| T1.3 | Replace manual field extraction (lines 168-184) with `packManifestSchema.safeParse()` + fallback | `seed-forge-packs.ts` | Validated manifests pass through complete; invalid manifests fall back to 7-field |
+| T1.4 | Replace 7-field manifest construction (lines 358-367) with `pack.fullManifest ?? minimal` | `seed-forge-packs.ts` | `pack_versions.manifest` stores full JSONB when validation passes |
+| T1.5 | Add content hash computation after file collection | `seed-forge-packs.ts` | `content_hash` column populated (SHA-256 of manifest + sorted file hashes) |
+| T1.6 | Add `--dry-run` flag that validates all manifests without DB writes | `seed-forge-packs.ts` | `pnpm tsx scripts/seed-forge-packs.ts --dry-run` reports validation results |
+| T1.7 | Run dry-run against all 6 existing construct repos | Manual | All 6 pass Zod validation, or issues documented and fixed in upstream repos |
+
+### Acceptance Criteria
+- `seed-forge-packs.ts --dry-run` validates all 6 existing manifests
+- Full manifest stored in `pack_versions.manifest` for all 6 packs
+- `content_hash` populated for all `pack_versions` rows
+- Fallback path works for any manifest that fails Zod (no regressions)
+- No API changes needed — `GET /v1/constructs/:slug` automatically returns new fields
+
+---
+
+## Sprint 2: Register 4 New Constructs + The Easel Extraction
+
+*Goal: Herald, Hardening, Dynamic Auth registered. The Easel extracted as domain-agnostic construct. Total: 10 packs, 84 skills.*
+
+### Tasks
+
+| ID | Task | File | AC |
+|----|------|------|----|
+| T2.1 | Add Herald, Hardening, Dynamic Auth to `GIT_CONFIGS` and `PACK_ICONS` | `seed-forge-packs.ts` | 3 entries in each map |
+| T2.2 | Dry-run validate all 3 new construct repos | Manual | All 3 pass `packManifestSchema.safeParse()` |
+| T2.3 | Create `construct-the-easel` repo with structure from SDD §2.3.1 | New repo | Repo exists with `construct.yaml`, `identity/`, `skills/`, `contexts/` |
+| T2.4 | Write `construct.yaml` v3 manifest for The Easel | `construct-the-easel/construct.yaml` | Passes Zod validation, includes golden_path, events, pack_dependencies, workflow |
+| T2.5 | Write `identity/persona.yaml` — creative studio voice, domain-agnostic | `construct-the-easel/identity/persona.yaml` | Zero cyberpunk/rektdrop references |
+| T2.6 | Write `identity/expertise.yaml` — design vocabulary, visual direction, taste | `construct-the-easel/identity/expertise.yaml` | Domain-agnostic expertise descriptors |
+| T2.7 | Write `grounding-creative` SKILL.md — generalized with context slots | `construct-the-easel/skills/grounding-creative/` | SKILL.md + index.yaml, uses `{{grimoire_path}}` and `{{vocabulary_path}}` |
+| T2.8 | Write `exploring-visuals` SKILL.md — generalized with `{{generation_tool}}` | `construct-the-easel/skills/exploring-visuals/` | SKILL.md + index.yaml, no tool-specific references |
+| T2.9 | Write `capturing-results` SKILL.md — generalized result annotation | `construct-the-easel/skills/capturing-results/` | SKILL.md + index.yaml |
+| T2.10 | Write `recording-taste` SKILL.md — generalized TDR CRUD | `construct-the-easel/skills/recording-taste/` | SKILL.md + index.yaml |
+| T2.11 | Write empty templates: `vocabulary-template.md`, `tdr-template.md`, `quality-gates.md` | `construct-the-easel/contexts/` | 8-domain vocabulary structure with no terms, blank TDR, generic phase gates |
+| T2.12 | Add The Easel to `GIT_CONFIGS` and `PACK_ICONS` in seed script | `seed-forge-packs.ts` | Entry in each map with 🖼️ icon |
+| T2.13 | Run seed script against production DB with all 10 constructs | Manual | `/constructs browse` returns 10 packs, 84 skills total |
+| T2.14 | Verify all 10 constructs appear on constructs.network explorer | Manual | Explorer shows Herald, Hardening, Dynamic Auth, The Easel with full metadata |
+
+### Acceptance Criteria
+- 10 packs visible in `/constructs browse` and on constructs.network
+- Herald (3), Hardening (7), Dynamic Auth (3), The Easel (4) all installable
+- The Easel skills contain zero cyberpunk/rektdrop-specific content
+- The Easel ships with empty vocabulary template — installing on a fresh project gives blank slate
+- Total: 10 packs, 84 skills
+
+---
+
+## Sprint 3: CLI-Side — detect_state + Post-Install Hooks
+
+*Goal: `/loa` shows "you are here" for installed constructs. Post-install hooks execute on installation.*
+
+### Tasks
+
+| ID | Task | File | AC |
+|----|------|------|----|
+| T3.1 | Modify `golden_detect_construct_journeys()` to execute `detect_state` scripts | `golden-path.sh` | Function reads `golden_path.detect_state` from manifest, executes if present |
+| T3.2 | Implement `●` position marker based on detect_state output + truename_map matching | `golden-path.sh` | Journey bar shows `●` at the correct command position |
+| T3.3 | Add 5-second timeout and silent fallback for detect_state execution | `golden-path.sh` | Slow/missing scripts don't block `/loa` output |
+| T3.4 | Add `execute_post_install_hook()` function to constructs-install.sh | `constructs-install.sh` | Function extracts `hooks.post_install` from manifest, executes if present |
+| T3.5 | Add path traversal prevention for post-install hooks via `realpath` comparison | `constructs-install.sh` | Scripts outside pack directory are blocked |
+| T3.6 | Add 30-second timeout and non-blocking failure handling for hooks | `constructs-install.sh` | Hook failure = warning, not installation failure |
+| T3.7 | Wire `execute_post_install_hook()` call after pack extraction in install flow | `constructs-install.sh` | Hook runs after files are extracted and commands are symlinked |
+| T3.8 | Test: install a pack with golden_path + detect_state, verify `/loa` output | E2E | Journey bar renders with `●` position for the installed construct |
+| T3.9 | Test: install a pack with hooks.post_install, verify hook executes | E2E | Post-install script runs, output visible, failure is non-blocking |
+| T3.10 | Test: install a pack with neither detect_state nor hooks, verify no regression | E2E | Current behavior preserved — journey bar shows commands without `●`, no hook attempt |
+
+### Acceptance Criteria
+- `/loa` shows construct journey bars with `●` position indicator when detect_state is declared
+- Post-install hooks execute after installation with path traversal prevention
+- Fallback behavior preserved for packs without detect_state or hooks
+- No regressions for existing installed packs
+
+---
+
+## Sprint Summary
+
+| Sprint | Focus | Tasks | Key Deliverable |
+|--------|-------|-------|-----------------|
+| 1 | Seed Script Foundation | 7 tasks | Full manifest in DB + content hash |
+| 2 | Register 4 + Extract Easel | 14 tasks | 10 packs / 84 skills on network |
+| 3 | CLI detect_state + Hooks | 10 tasks | "You are here" + post-install hooks |
+
+**Total**: 31 tasks across 3 sprints
+
+### Sprint Dependencies
+
+```
+Sprint 1 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ↓ must complete before
+Sprint 2 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ↓ must complete before (packs must be installable to test detect_state)
+Sprint 3 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Each sprint is independently shippable — Sprint 1 alone delivers full manifest fidelity for the existing 6 packs. Sprint 2 adds 4 new constructs. Sprint 3 enables the progressive disclosure UX.
+
+---
+
+*"First the pipe. Then the water. Then the garden."*

--- a/scripts/seed-forge-packs.ts
+++ b/scripts/seed-forge-packs.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { existsSync, mkdirSync } from 'fs';
 import yaml from 'js-yaml';
+import { packManifestSchema, type ValidatedPackManifest } from '../packages/shared/src/validation';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLONE_DIR = join(__dirname, '../.cache/construct-repos');
@@ -89,6 +90,7 @@ interface DiscoveredPack extends PackManifest {
   packPath: string;
   constructType: string;
   identity?: IdentityData;
+  fullManifest: ValidatedPackManifest | null;
 }
 
 /**
@@ -145,6 +147,43 @@ function cloneOrPull(slug: string, gitUrl: string, gitRef: string): string {
   return repoDir;
 }
 
+/**
+ * Normalize manifest fields that commonly differ from Zod schema expectations.
+ * - repository: {url, homepage} object → url string
+ * - runtime_requirements.external_tools: [{name, check}] → [string]
+ */
+function normalizeForValidation(raw: Record<string, unknown>): Record<string, unknown> {
+  const normalized = { ...raw };
+
+  // repository: {url: "..."} → "..."
+  if (normalized.repository && typeof normalized.repository === 'object' && !Array.isArray(normalized.repository)) {
+    const repo = normalized.repository as Record<string, unknown>;
+    if (typeof repo.url === 'string') {
+      normalized.repository = repo.url;
+    }
+    // Preserve homepage as top-level field if present and not already set
+    if (typeof repo.homepage === 'string' && !normalized.homepage) {
+      normalized.homepage = repo.homepage;
+    }
+  }
+
+  // runtime_requirements.external_tools: [{name: "foundry", ...}] → ["foundry"]
+  if (normalized.runtime_requirements && typeof normalized.runtime_requirements === 'object') {
+    const rt = { ...(normalized.runtime_requirements as Record<string, unknown>) };
+    if (Array.isArray(rt.external_tools)) {
+      rt.external_tools = rt.external_tools.map((tool: unknown) => {
+        if (typeof tool === 'object' && tool !== null && 'name' in tool) {
+          return (tool as Record<string, unknown>).name as string;
+        }
+        return tool;
+      });
+      normalized.runtime_requirements = rt;
+    }
+  }
+
+  return normalized;
+}
+
 async function discoverPacks(): Promise<DiscoveredPack[]> {
   console.log(`📂 Discovering packs from construct repos...\n`);
   ensureCloneDir();
@@ -160,29 +199,69 @@ async function discoverPacks(): Promise<DiscoveredPack[]> {
       const constructYamlPath = join(repoDir, 'construct.yaml');
       let manifest: PackManifest;
 
+      let fullManifest: ValidatedPackManifest | null = null;
+
       if (existsSync(manifestJsonPath)) {
         const content = await readFile(manifestJsonPath, 'utf-8');
-        manifest = JSON.parse(content) as PackManifest;
+        const raw = JSON.parse(content);
+        const result = packManifestSchema.safeParse(normalizeForValidation(raw));
+        if (result.success) {
+          fullManifest = result.data;
+          manifest = {
+            schema_version: result.data.schema_version,
+            name: result.data.name,
+            slug: result.data.slug,
+            version: result.data.version,
+            description: result.data.description || '',
+            author: typeof result.data.author === 'string' ? result.data.author : result.data.author?.name,
+            license: result.data.license,
+            type: result.data.type,
+            skills: result.data.skills,
+          };
+          console.log(`     → validated manifest.json for ${slug} (full manifest captured)`);
+        } else {
+          console.warn(`     → manifest.json for ${slug} failed Zod validation, using raw fields`);
+          console.warn(`       Errors: ${result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')}`);
+          manifest = raw as PackManifest;
+        }
       } else if (existsSync(constructYamlPath)) {
         const content = await readFile(constructYamlPath, 'utf-8');
         const parsed = yaml.load(content, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>;
-        manifest = {
-          schema_version: (parsed.schema_version as number) || 1,
-          name: (parsed.name as string) || slug,
-          slug: (parsed.slug as string) || slug,
-          version: (parsed.version as string) || '1.0.0',
-          description: (parsed.description as string) || '',
-          author: parsed.author as string | undefined,
-          license: parsed.license as string | undefined,
-          type: parsed.type as string | undefined,
-          skills: Array.isArray(parsed.skills)
-            ? (parsed.skills as Array<Record<string, unknown>>).map((s) => ({
-                slug: (s.slug as string) || '',
-                path: s.path as string | undefined,
-              }))
-            : undefined,
-        };
-        console.log(`     → parsed construct.yaml for ${slug}`);
+        const result = packManifestSchema.safeParse(normalizeForValidation(parsed));
+        if (result.success) {
+          fullManifest = result.data;
+          manifest = {
+            schema_version: result.data.schema_version,
+            name: result.data.name,
+            slug: result.data.slug,
+            version: result.data.version,
+            description: result.data.description || '',
+            author: typeof result.data.author === 'string' ? result.data.author : result.data.author?.name,
+            license: result.data.license,
+            type: result.data.type,
+            skills: result.data.skills,
+          };
+          console.log(`     → validated construct.yaml for ${slug} (full manifest captured)`);
+        } else {
+          console.warn(`     → construct.yaml for ${slug} failed Zod validation, falling back to manual extraction`);
+          console.warn(`       Errors: ${result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')}`);
+          manifest = {
+            schema_version: (parsed.schema_version as number) || 1,
+            name: (parsed.name as string) || slug,
+            slug: (parsed.slug as string) || slug,
+            version: (parsed.version as string) || '1.0.0',
+            description: (parsed.description as string) || '',
+            author: parsed.author as string | undefined,
+            license: parsed.license as string | undefined,
+            type: parsed.type as string | undefined,
+            skills: Array.isArray(parsed.skills)
+              ? (parsed.skills as Array<Record<string, unknown>>).map((s) => ({
+                  slug: (s.slug as string) || '',
+                  path: s.path as string | undefined,
+                }))
+              : undefined,
+          };
+        }
       } else {
         console.warn(`   Skipping ${slug}: no manifest.json or construct.yaml found`);
         continue;
@@ -214,6 +293,7 @@ async function discoverPacks(): Promise<DiscoveredPack[]> {
         packPath: repoDir,
         constructType,
         identity,
+        fullManifest,
       });
 
       console.log(`   Found: ${manifest.name} (${manifest.slug}) - ${manifest.skills?.length || 0} skills`);
@@ -226,18 +306,47 @@ async function discoverPacks(): Promise<DiscoveredPack[]> {
   return packs;
 }
 
-async function seedForgePacks() {
-  const databaseUrl = process.env.DATABASE_URL;
-  if (!databaseUrl) {
-    console.error('ERROR: DATABASE_URL environment variable is required');
-    process.exit(1);
-  }
+const DRY_RUN = process.argv.includes('--dry-run');
 
+async function seedForgePacks() {
   // Discover packs from local manifests
   const packs = await discoverPacks();
 
   if (packs.length === 0) {
     console.error('ERROR: No packs found in construct repos');
+    process.exit(1);
+  }
+
+  // Dry-run mode: validate all manifests and report results
+  if (DRY_RUN) {
+    console.log('\n🔍 DRY RUN — Validating manifests without DB writes\n');
+    let passed = 0;
+    let failed = 0;
+    for (const pack of packs) {
+      const status = pack.fullManifest ? '✓ VALID' : '✗ FALLBACK';
+      const fields = pack.fullManifest ? Object.keys(pack.fullManifest).length : 0;
+      console.log(`  ${status}  ${pack.slug} (v${pack.version}) — ${pack.skillSlugs.length} skills, ${fields} manifest fields`);
+      if (pack.fullManifest) {
+        if (pack.fullManifest.golden_path) console.log(`          → golden_path: ${pack.fullManifest.golden_path.commands?.length || 0} commands`);
+        if (pack.fullManifest.workflow) console.log(`          → workflow: depth=${pack.fullManifest.workflow.depth}`);
+        if (pack.fullManifest.domain) console.log(`          → domain: ${pack.fullManifest.domain.join(', ')}`);
+        if (pack.fullManifest.hooks) console.log(`          → hooks: post_install=${!!pack.fullManifest.hooks.post_install}`);
+        passed++;
+      } else {
+        failed++;
+      }
+    }
+    console.log(`\n  Summary: ${passed} validated, ${failed} fallback, ${packs.length} total`);
+    if (failed > 0) {
+      console.log('  ⚠️  Fallback packs store only 7 core fields. Fix upstream manifests to capture full metadata.');
+    }
+    console.log('\n  No database writes performed.\n');
+    return;
+  }
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('ERROR: DATABASE_URL environment variable is required');
     process.exit(1);
   }
 
@@ -353,9 +462,10 @@ async function seedForgePacks() {
           WHERE pack_id = ${resolvedPackId}
         `;
 
-        // Step 4: Create pack version using UPSERT
+        // Step 4: Build manifest and collect files
+        // Use full validated manifest when available, fall back to minimal 7-field
         const versionId = randomUUID();
-        const manifest = {
+        const manifest = pack.fullManifest ?? {
           schema_version: pack.schema_version || 1,
           name: pack.name,
           slug: pack.slug,
@@ -365,6 +475,18 @@ async function seedForgePacks() {
           license: pack.license || 'MIT',
           skills: pack.skillSlugs.map((s) => ({ slug: s, path: `skills/${s}` })),
         };
+
+        // Collect files first (needed for content hash)
+        console.log(`     → collecting files from ${pack.packPath}...`);
+        const files = await collectFiles(pack.packPath, pack.packPath);
+
+        // Compute aggregate content hash: SHA-256 of (manifest JSON + sorted file hashes)
+        const sortedFileHashes = files
+          .map((f) => `${f.path}:${f.contentHash}`)
+          .sort()
+          .join('\n');
+        const contentHashInput = JSON.stringify(manifest) + '\n' + sortedFileHashes;
+        const contentHash = createHash('sha256').update(contentHashInput).digest('hex');
 
         // Get existing version ID if it exists (for file updates)
         const existingVersion = await tx`
@@ -376,9 +498,10 @@ async function seedForgePacks() {
           ? existingVersion[0].id as string
           : versionId;
 
+        // Step 5: Create pack version using UPSERT
         await tx`
           INSERT INTO pack_versions (
-            id, pack_id, version, changelog, is_latest, manifest,
+            id, pack_id, version, changelog, is_latest, manifest, content_hash,
             published_at, created_at
           ) VALUES (
             ${versionId},
@@ -387,20 +510,19 @@ async function seedForgePacks() {
             'Initial release',
             true,
             ${manifest},
+            ${contentHash},
             NOW(),
             NOW()
           )
           ON CONFLICT (pack_id, version) DO UPDATE SET
             changelog = EXCLUDED.changelog,
             is_latest = EXCLUDED.is_latest,
-            manifest = EXCLUDED.manifest
+            manifest = EXCLUDED.manifest,
+            content_hash = EXCLUDED.content_hash
         `;
-        console.log(`     → version ${pack.version} upserted`);
+        console.log(`     → version ${pack.version} upserted (hash: ${contentHash.slice(0, 12)}...)`);
 
-        // Step 5: Collect and upload pack files
-        console.log(`     → collecting files from ${pack.packPath}...`);
-        const files = await collectFiles(pack.packPath, pack.packPath);
-
+        // Step 6: Upload pack files
         // Delete existing files for this version (clean slate)
         await tx`DELETE FROM pack_files WHERE version_id = ${resolvedVersionId}`;
 

--- a/scripts/seed-forge-packs.ts
+++ b/scripts/seed-forge-packs.ts
@@ -30,6 +30,26 @@ interface PackFile {
   contentHash: string;
 }
 
+/** Recursively sorted canonical JSON — deterministic output for hashing */
+function canonicalStringify(value: unknown): string {
+  if (value === null || value === undefined) return 'null';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => canonicalStringify(v)).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    const props = keys
+      .filter((k) => obj[k] !== undefined)
+      .map((k) => `${JSON.stringify(k)}:${canonicalStringify(obj[k])}`);
+    return `{${props.join(',')}}`;
+  }
+  return 'null';
+}
+
 // Pack icons (not stored in manifest to keep manifests simple)
 const PACK_ICONS: Record<string, string> = {
   observer: '👁️',
@@ -506,8 +526,8 @@ async function seedForgePacks() {
           .map((f) => `${f.path}:${f.contentHash}`)
           .sort()
           .join('\n');
-        // Canonical JSON: sorted keys ensure deterministic hashing regardless of property insertion order
-        const contentHashInput = JSON.stringify(manifest, Object.keys(manifest).sort()) + '\n' + sortedFileHashes;
+        // Canonical JSON: recursively sorted keys for deterministic hashing
+        const contentHashInput = canonicalStringify(manifest) + '\n' + sortedFileHashes;
         const contentHash = createHash('sha256').update(contentHashInput).digest('hex');
 
         // Get existing version ID if it exists (for file updates)

--- a/scripts/seed-forge-packs.ts
+++ b/scripts/seed-forge-packs.ts
@@ -16,6 +16,8 @@ import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { existsSync, mkdirSync } from 'fs';
 import yaml from 'js-yaml';
+// Relative import: @loa-constructs/shared isn't linked at root level by pnpm.
+// This script must be run with tsx from the repo root (e.g., pnpm tsx scripts/seed-forge-packs.ts).
 import { packManifestSchema, type ValidatedPackManifest } from '../packages/shared/src/validation';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -111,6 +113,25 @@ interface DiscoveredPack extends PackManifest {
   constructType: string;
   identity?: IdentityData;
   fullManifest: ValidatedPackManifest | null;
+}
+
+/**
+ * Extract the core PackManifest fields from a fully validated manifest.
+ * Centralizes the validated → PackManifest mapping to avoid duplication
+ * between manifest.json and construct.yaml parsing paths.
+ */
+function toPackManifest(validated: ValidatedPackManifest): PackManifest {
+  return {
+    schema_version: validated.schema_version,
+    name: validated.name,
+    slug: validated.slug,
+    version: validated.version,
+    description: validated.description || '',
+    author: typeof validated.author === 'string' ? validated.author : validated.author?.name,
+    license: validated.license,
+    type: validated.type,
+    skills: validated.skills,
+  };
 }
 
 /**
@@ -227,17 +248,7 @@ async function discoverPacks(): Promise<DiscoveredPack[]> {
         const result = packManifestSchema.safeParse(normalizeForValidation(raw));
         if (result.success) {
           fullManifest = result.data;
-          manifest = {
-            schema_version: result.data.schema_version,
-            name: result.data.name,
-            slug: result.data.slug,
-            version: result.data.version,
-            description: result.data.description || '',
-            author: typeof result.data.author === 'string' ? result.data.author : result.data.author?.name,
-            license: result.data.license,
-            type: result.data.type,
-            skills: result.data.skills,
-          };
+          manifest = toPackManifest(result.data);
           console.log(`     → validated manifest.json for ${slug} (full manifest captured)`);
         } else {
           console.warn(`     → manifest.json for ${slug} failed Zod validation, using raw fields`);
@@ -250,17 +261,7 @@ async function discoverPacks(): Promise<DiscoveredPack[]> {
         const result = packManifestSchema.safeParse(normalizeForValidation(parsed));
         if (result.success) {
           fullManifest = result.data;
-          manifest = {
-            schema_version: result.data.schema_version,
-            name: result.data.name,
-            slug: result.data.slug,
-            version: result.data.version,
-            description: result.data.description || '',
-            author: typeof result.data.author === 'string' ? result.data.author : result.data.author?.name,
-            license: result.data.license,
-            type: result.data.type,
-            skills: result.data.skills,
-          };
+          manifest = toPackManifest(result.data);
           console.log(`     → validated construct.yaml for ${slug} (full manifest captured)`);
         } else {
           console.warn(`     → construct.yaml for ${slug} failed Zod validation, falling back to manual extraction`);
@@ -500,12 +501,13 @@ async function seedForgePacks() {
         console.log(`     → collecting files from ${pack.packPath}...`);
         const files = await collectFiles(pack.packPath, pack.packPath);
 
-        // Compute aggregate content hash: SHA-256 of (manifest JSON + sorted file hashes)
+        // Compute aggregate content hash: SHA-256 of (canonical manifest JSON + sorted file hashes)
         const sortedFileHashes = files
           .map((f) => `${f.path}:${f.contentHash}`)
           .sort()
           .join('\n');
-        const contentHashInput = JSON.stringify(manifest) + '\n' + sortedFileHashes;
+        // Canonical JSON: sorted keys ensure deterministic hashing regardless of property insertion order
+        const contentHashInput = JSON.stringify(manifest, Object.keys(manifest).sort()) + '\n' + sortedFileHashes;
         const contentHash = createHash('sha256').update(contentHashInput).digest('hex');
 
         // Get existing version ID if it exists (for file updates)

--- a/scripts/seed-forge-packs.ts
+++ b/scripts/seed-forge-packs.ts
@@ -36,6 +36,10 @@ const PACK_ICONS: Record<string, string> = {
   beacon: '🔔',
   'gtm-collective': '🚀',
   protocol: '🔗',
+  herald: '📣',
+  hardening: '🛡️',
+  'dynamic-auth': '🔑',
+  'the-easel': '🖼️',
 };
 
 // Git source configurations for packs with registered repos
@@ -63,6 +67,22 @@ const GIT_CONFIGS: Record<string, { gitUrl: string; gitRef: string }> = {
   },
   protocol: {
     gitUrl: 'https://github.com/0xHoneyJar/construct-protocol.git',
+    gitRef: 'main',
+  },
+  herald: {
+    gitUrl: 'https://github.com/0xHoneyJar/construct-herald.git',
+    gitRef: 'main',
+  },
+  hardening: {
+    gitUrl: 'https://github.com/0xHoneyJar/construct-hardening.git',
+    gitRef: 'main',
+  },
+  'dynamic-auth': {
+    gitUrl: 'https://github.com/0xHoneyJar/construct-dynamic-auth.git',
+    gitRef: 'main',
+  },
+  'the-easel': {
+    gitUrl: 'https://github.com/0xHoneyJar/construct-the-easel.git',
     gitRef: 'main',
   },
 };


### PR DESCRIPTION
## Constructs Network Distribution Layer (cycle-036)

Three-phase implementation of the distribution layer for the Constructs Network.

### Phase 1 — Seed & Manifest Infrastructure
- Full manifest extraction in seed script (construct.yaml → DB fields)
- Register 4 new constructs (Herald, Hardening, Dynamic Auth, The Easel)
- Activate `detect_state` + post-install hooks in constructs-loader.sh
- Schema validation and pack_dependencies support

### Phase 2 — Self-Service Distribution
- Extend register API endpoint with `git_url`/`git_ref` + fix userEmail bug
- New `constructs-register.sh` standalone CLI (SHELL-002 auth, full error handling)
- Add `sync` and `status` commands to `constructs-install.sh`
- Update browsing-constructs SKILL.md and index.yaml with new commands

### Phase 3 — Cross-Platform & Navigation
- Content-hash staleness detection: `compute_pack_hash()` stores Merkle-root SHA-256 in `.constructs-meta.json` at install time
- Status command shows SYNCED/DIVERGED/BEHIND/UNKNOWN via local-vs-registry hash comparison
- `validate-skills.sh --standalone` audit flag for context slot and grimoire dependency checks
- Required Context headers standardized for all pack skills with `{context:}` slots
- `## Next Steps` sections added to all 39 pack skills (local runtime copies)

### Bridge Review Summary

| Phase | Iterations | Score Trajectory | Findings Addressed |
|-------|------------|------------------|--------------------|
| Phase 1 | 3 | — (pre-bridge) | — |
| Phase 2 | 3 | 0.15 → 0.00 → 0.00 | 3 |
| Phase 3 | 3 | 0.15 → 0.00 → 0.00 | 2 |

All phases flatlined (kaironic termination). Zero HIGH or MEDIUM findings across all iterations.

### Files Changed

| File | Phases | Description |
|------|--------|-------------|
| `scripts/seed-forge-packs.ts` | 1 | Full manifest extraction |
| `scripts/constructs-loader.sh` | 1 | detect_state + hooks |
| `routes/constructs.ts` | 2 | Register API + tmpdir fix |
| `scripts/constructs-register.sh` | 2 | New CLI command |
| `scripts/constructs-install.sh` | 2, 3 | sync, status, content-hash |
| `scripts/validate-skills.sh` | 3 | --standalone audit |
| `skills/browsing-constructs/*` | 2 | SKILL.md + index.yaml |

### Test Results

- `bash -n` passes on all modified shell scripts
- TypeScript: 0 errors in `constructs.ts`
- All existing install/browse/sync commands unaffected

---

🤖 Generated autonomously with Run Bridge