### PR TITLE
feat(cycle-037): Agent-Native Output Protocol

### DIFF
--- a/.claude/protocols/skill-cta.md
+++ b/.claude/protocols/skill-cta.md
@@ -1,0 +1,44 @@
+# Skill CTA Protocol
+
+> **Source**: cycle-037 SDD §2.4, PRD FR-2.1
+> **Status**: Active (cycle-037 MVP)
+
+## Format
+
+After primary command output, CTA-enabled commands append:
+
+```
+Next:
+<command-1> — <description>
+<command-2> — <description>
+```
+
+## Rules
+
+1. Maximum 3 CTAs per invocation
+2. CTAs appear after main output, before any grimoire writes
+3. Use truenames (e.g., `/implement`) not golden path aliases (e.g., `/build`)
+4. Command-context-based: each CTA-enabled command has a static mapping of relevant next steps (cycle-037 MVP). Dynamic workflow-state-derived CTAs using `golden_path.commands` + `truename_map` are future scope.
+5. Gated by `cta.enabled: true` in `.loa.config.yaml`
+
+## Enabled Commands (cycle-037 MVP)
+
+| Command | Context | CTAs |
+|---------|---------|------|
+| `constructs browse` | browse | install, status, loa |
+| `constructs status` | status | browse, install, loa |
+| `constructs install` | install | quick_start (if available), status, loa |
+
+## Configuration
+
+```yaml
+# .loa.config.yaml
+cta:
+  enabled: false  # default: false
+```
+
+## Implementation
+
+- `emit_cta()` in `constructs-lib.sh`
+- `is_cta_enabled()` in `constructs-lib.sh`
+- Protocol file: `.claude/protocols/skill-cta.md` (this file)

--- a/.claude/scripts/constructs-browse.sh
+++ b/.claude/scripts/constructs-browse.sh
@@ -292,10 +292,26 @@ cmd_list() {
     fi
 
     if [[ "$json_output" == true ]]; then
+        # Explicit --json flag always wins (backwards compat)
         format_packs_json "$packs_json"
     else
-        format_packs_human "$packs_json"
+        # Build flat tabular JSON for TOON/json modes
+        local toon_json
+        toon_json=$(echo "$packs_json" | jq '[
+            .data[]? | {
+                slug: .slug,
+                name: .name,
+                skills: (.skills_count // (.manifest.skills | length?) // 0),
+                version: (.latest_version.version // .version // "1.0.0"),
+                tier: (.tier_required // .tier // "free")
+            }
+        ]' 2>/dev/null)
+        # Route: toon→TOON encoder, json→raw JSON, md→format_packs_human
+        format_tabular_output "packs" "$toon_json" "$packs_json" "format_packs_human"
     fi
+
+    # Append CTAs if enabled
+    emit_cta "browse"
 }
 
 cmd_info() {

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -809,6 +809,9 @@ PYEOF
         done
     fi
 
+    # Append CTAs if enabled (cycle-037)
+    emit_cta "install" "$pack_slug"
+
     return $EXIT_SUCCESS
 }
 
@@ -2015,7 +2018,7 @@ do_status_pack() {
     registry_url=$(get_registry_url)
 
     if [[ -n "$pack_slug" ]]; then
-        # Single pack status
+        # Single pack status — always use detailed format
         show_pack_status "$pack_slug" "$meta_path" "$registry_url"
     else
         # All installed packs
@@ -2026,17 +2029,85 @@ do_status_pack() {
             return $EXIT_SUCCESS
         fi
 
-        echo "Construct Status"
-        echo "════════════════════════════════════════"
-        echo ""
+        local fmt
+        fmt=$(get_output_format)
 
-        while IFS= read -r slug; do
-            show_pack_status "$slug" "$meta_path" "$registry_url"
+        if [[ "$fmt" == "toon" || "$fmt" == "json" ]]; then
+            # Collect all pack data into JSON array for TOON/json routing
+            local status_json="[]"
+            while IFS= read -r slug; do
+                local lv rv sl
+                lv=$(jq -r ".installed_packs[\"$slug\"].version // \"unknown\"" "$meta_path" 2>/dev/null)
+                local lh
+                lh=$(jq -r ".installed_packs[\"$slug\"].content_hash // \"\"" "$meta_path" 2>/dev/null)
+
+                # Fetch registry version (non-blocking)
+                rv="unknown"
+                local tmp_file
+                tmp_file=$(mktemp)
+                chmod 600 "$tmp_file"
+                local http_code
+                http_code=$(curl -s -w "%{http_code}" \
+                    --proto =https --tlsv1.2 --max-time 10 \
+                    "${registry_url}/constructs/${slug}" \
+                    -o "$tmp_file" 2>/dev/null) || http_code="000"
+                if [[ "$http_code" == "200" ]]; then
+                    rv=$(jq -r '.data.version // .data.latest_version.version // "unknown"' "$tmp_file" 2>/dev/null)
+                fi
+                rm -f "$tmp_file"
+
+                # Determine status label
+                sl="UNKNOWN"
+                if [[ -z "$lh" ]]; then
+                    if [[ "$lv" == "$rv" && "$rv" != "unknown" ]]; then sl="UNKNOWN"; else sl="BEHIND"; fi
+                else
+                    sl="SYNCED"
+                    if [[ "$lv" != "$rv" && "$rv" != "unknown" ]]; then sl="BEHIND"; fi
+                fi
+
+                status_json=$(echo "$status_json" | jq --arg s "$slug" \
+                    --arg v "$lv" --arg rv "$rv" --arg st "$sl" \
+                    '. += [{"slug":$s,"local":$v,"registry":$rv,"status":$st}]')
+            done <<< "$slugs"
+
+            format_tabular_output "status" "$status_json" "$status_json" "_show_all_packs_md"
+        else
+            # Default markdown: use existing per-pack output
+            echo "Construct Status"
+            echo "════════════════════════════════════════"
             echo ""
-        done <<< "$slugs"
+
+            while IFS= read -r slug; do
+                show_pack_status "$slug" "$meta_path" "$registry_url"
+                echo ""
+            done <<< "$slugs"
+        fi
     fi
 
+    # Append CTAs if enabled
+    emit_cta "status"
+
     return $EXIT_SUCCESS
+}
+
+# Markdown fallback for format_tabular_output when showing all pack status
+# Args: $1 = JSON array of status objects (unused — re-renders from meta)
+_show_all_packs_md() {
+    local meta_path
+    meta_path=$(get_registry_meta_path)
+    local registry_url
+    registry_url=$(get_registry_url)
+
+    echo "Construct Status"
+    echo "════════════════════════════════════════"
+    echo ""
+
+    local slugs
+    slugs=$(jq -r '.installed_packs | keys[]' "$meta_path" 2>/dev/null)
+    while IFS= read -r slug; do
+        show_pack_status "$slug" "$meta_path" "$registry_url"
+        echo ""
+    done <<< "$slugs"
 }
 
 # Show status for a single pack

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -2029,9 +2029,6 @@ do_status_pack() {
             return $EXIT_SUCCESS
         fi
 
-        local fmt
-        fmt=$(get_output_format)
-
         # Collect all pack data into JSON array (shared data collection)
         local status_json="[]"
         while IFS= read -r slug; do

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -2032,55 +2032,74 @@ do_status_pack() {
         local fmt
         fmt=$(get_output_format)
 
-        if [[ "$fmt" == "toon" || "$fmt" == "json" ]]; then
-            # Collect all pack data into JSON array for TOON/json routing
-            local status_json="[]"
-            while IFS= read -r slug; do
-                local lv rv sl
-                lv=$(jq -r ".installed_packs[\"$slug\"].version // \"unknown\"" "$meta_path" 2>/dev/null)
-                local lh
-                lh=$(jq -r ".installed_packs[\"$slug\"].content_hash // \"\"" "$meta_path" 2>/dev/null)
+        # Collect all pack data into JSON array (shared data collection)
+        local status_json="[]"
+        while IFS= read -r slug; do
+            local lv rv sl
+            lv=$(jq -r ".installed_packs[\"$slug\"].version // \"unknown\"" "$meta_path" 2>/dev/null)
+            local lh
+            lh=$(jq -r ".installed_packs[\"$slug\"].content_hash // \"\"" "$meta_path" 2>/dev/null)
 
-                # Fetch registry version (non-blocking)
-                rv="unknown"
-                local tmp_file
-                tmp_file=$(mktemp)
-                chmod 600 "$tmp_file"
-                local http_code
-                http_code=$(curl -s -w "%{http_code}" \
-                    --proto =https --tlsv1.2 --max-time 10 \
-                    "${registry_url}/constructs/${slug}" \
-                    -o "$tmp_file" 2>/dev/null) || http_code="000"
-                if [[ "$http_code" == "200" ]]; then
-                    rv=$(jq -r '.data.version // .data.latest_version.version // "unknown"' "$tmp_file" 2>/dev/null)
-                fi
-                rm -f "$tmp_file"
+            # Fetch registry version (non-blocking)
+            rv="unknown"
+            local tmp_file
+            tmp_file=$(mktemp)
+            chmod 600 "$tmp_file"
+            local http_code
+            http_code=$(curl -s -w "%{http_code}" \
+                --proto =https --tlsv1.2 --max-time 10 \
+                "${registry_url}/constructs/${slug}" \
+                -o "$tmp_file" 2>/dev/null) || http_code="000"
+            if [[ "$http_code" == "200" ]]; then
+                rv=$(jq -r '.data.version // .data.latest_version.version // "unknown"' "$tmp_file" 2>/dev/null)
+            fi
+            rm -f "$tmp_file"
 
-                # Determine status label
-                sl="UNKNOWN"
-                if [[ -z "$lh" ]]; then
-                    if [[ "$lv" == "$rv" && "$rv" != "unknown" ]]; then sl="UNKNOWN"; else sl="BEHIND"; fi
-                else
+            # Fetch registry hash for divergence detection (bridge-review medium-2)
+            local rh=""
+            local hash_file
+            hash_file=$(mktemp)
+            chmod 600 "$hash_file"
+            local hash_code
+            hash_code=$(curl -s -w "%{http_code}" \
+                --proto =https --tlsv1.2 --max-time 10 \
+                "${registry_url}/packs/${slug}/hash" \
+                -o "$hash_file" 2>/dev/null) || hash_code="000"
+            if [[ "$hash_code" == "200" ]]; then
+                rh=$(jq -r '.data.hash // ""' "$hash_file" 2>/dev/null)
+            fi
+            rm -f "$hash_file"
+
+            # Determine status label (with full hash divergence detection)
+            sl="UNKNOWN"
+            if [[ -z "$lh" ]]; then
+                if [[ "$lv" == "$rv" && "$rv" != "unknown" ]]; then sl="UNKNOWN"; else sl="BEHIND"; fi
+            elif [[ -n "$rh" ]]; then
+                if [[ "$lh" == "$rh" ]]; then
                     sl="SYNCED"
-                    if [[ "$lv" != "$rv" && "$rv" != "unknown" ]]; then sl="BEHIND"; fi
+                elif [[ "$lv" != "$rv" && "$rv" != "unknown" ]]; then
+                    sl="BEHIND"
+                else
+                    sl="DIVERGED"
                 fi
+            else
+                sl="SYNCED"
+                if [[ "$lv" != "$rv" && "$rv" != "unknown" ]]; then sl="BEHIND"; fi
+            fi
 
-                status_json=$(echo "$status_json" | jq --arg s "$slug" \
-                    --arg v "$lv" --arg rv "$rv" --arg st "$sl" \
-                    '. += [{"slug":$s,"local":$v,"registry":$rv,"status":$st}]')
-            done <<< "$slugs"
+            status_json=$(echo "$status_json" | jq --arg s "$slug" \
+                --arg v "$lv" --arg rv "$rv" --arg st "$sl" \
+                '. += [{"slug":$s,"local":$v,"registry":$rv,"status":$st}]')
+        done <<< "$slugs"
 
+        local fmt
+        fmt=$(get_output_format)
+
+        if [[ "$fmt" == "toon" || "$fmt" == "json" ]]; then
             format_tabular_output "status" "$status_json" "$status_json" "_show_all_packs_md"
         else
-            # Default markdown: use existing per-pack output
-            echo "Construct Status"
-            echo "════════════════════════════════════════"
-            echo ""
-
-            while IFS= read -r slug; do
-                show_pack_status "$slug" "$meta_path" "$registry_url"
-                echo ""
-            done <<< "$slugs"
+            # Default markdown: render from collected data
+            _render_status_md "$status_json" "$meta_path" "$registry_url"
         fi
     fi
 
@@ -2090,13 +2109,24 @@ do_status_pack() {
     return $EXIT_SUCCESS
 }
 
-# Markdown fallback for format_tabular_output when showing all pack status
-# Args: $1 = JSON array of status objects (unused — re-renders from meta)
+# Markdown fallback for format_tabular_output — renders from collected status_json
+# Args: $1 = JSON array of status objects
 _show_all_packs_md() {
+    local status_json="$1"
     local meta_path
     meta_path=$(get_registry_meta_path)
     local registry_url
     registry_url=$(get_registry_url)
+
+    _render_status_md "$status_json" "$meta_path" "$registry_url"
+}
+
+# Render markdown status from pre-collected data (shared by both md and TOON-fallback paths)
+# Args: $1 = status_json, $2 = meta_path, $3 = registry_url
+_render_status_md() {
+    local status_json="$1"
+    local meta_path="$2"
+    local registry_url="$3"
 
     echo "Construct Status"
     echo "════════════════════════════════════════"

--- a/.claude/scripts/constructs-lib.sh
+++ b/.claude/scripts/constructs-lib.sh
@@ -1298,3 +1298,132 @@ update_state_shadow() {
 
     secure_write_json "$state_file" "$updated" "600"
 }
+
+# =============================================================================
+# Output Format Routing (cycle-037, SDD §2.2)
+# =============================================================================
+
+# Read output_format.tabular from config
+# Returns: "md" (default), "toon", or "json"
+get_output_format() {
+    local config_file=".loa.config.yaml"
+    local default="md"
+
+    if [[ ! -f "$config_file" ]] || ! command -v yq &>/dev/null; then
+        echo "$default"
+        return 0
+    fi
+
+    local value
+    value=$(yq eval '.output_format.tabular // "md"' "$config_file" 2>/dev/null) || {
+        echo "$default"
+        return 0
+    }
+
+    # Validate enum
+    case "$value" in
+        md|toon|json) echo "$value" ;;
+        *) echo "$default" ;;
+    esac
+}
+
+# Route tabular output through the configured format
+# Args:
+#   $1 = label (e.g., "packs")
+#   $2 = JSON array of uniform objects (TOON-shaped: flat keys, uniform)
+#   $3 = original payload (passed to fallback_fn unchanged — preserves input contract)
+#   $4 = fallback function name (called when format is "md" or TOON fails)
+# Stdout: formatted output
+format_tabular_output() {
+    local label="$1"
+    local tabular_json="$2"
+    local original_payload="$3"
+    local fallback_fn="$4"
+
+    local fmt
+    fmt=$(get_output_format)
+
+    case "$fmt" in
+        toon)
+            # Source toon-lib if not already loaded
+            local script_dir
+            script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+            if [[ -f "$script_dir/lib/toon-lib.sh" ]]; then
+                # shellcheck source=lib/toon-lib.sh
+                source "$script_dir/lib/toon-lib.sh"
+                toon_encode_tabular "$label" "$tabular_json" && return 0
+            fi
+            # Fallback: TOON failed or lib missing — use original payload
+            "$fallback_fn" "$original_payload"
+            ;;
+        json)
+            echo "$tabular_json" | jq '.'
+            ;;
+        md|*)
+            "$fallback_fn" "$original_payload"
+            ;;
+    esac
+}
+
+# =============================================================================
+# CTA Emission (cycle-037, SDD §2.3)
+# =============================================================================
+
+# Check if CTAs are enabled in config
+# Returns: 0 if enabled, 1 if disabled
+is_cta_enabled() {
+    local config_file=".loa.config.yaml"
+
+    if [[ ! -f "$config_file" ]] || ! command -v yq &>/dev/null; then
+        return 1
+    fi
+
+    local enabled
+    enabled=$(yq eval '.cta.enabled // false' "$config_file" 2>/dev/null) || return 1
+
+    [[ "$enabled" == "true" ]]
+}
+
+# Emit context-sensitive CTA block after command output
+# Args:
+#   $1 = current command context (e.g., "browse", "status", "install")
+#   $2 = pack slug (optional — for pack-specific CTAs)
+# Stdout: Next: block with up to 3 CTAs
+emit_cta() {
+    is_cta_enabled || return 0
+
+    local context="$1"
+    local pack_slug="${2:-}"
+
+    echo ""
+    echo "Next:"
+
+    case "$context" in
+        browse)
+            echo "/constructs install <slug> — Install a construct pack"
+            echo "/constructs status — Check installed pack versions"
+            echo "/loa — View workflow status"
+            ;;
+        status)
+            echo "/constructs browse — Browse available packs"
+            echo "/constructs install <slug> — Install or update a pack"
+            echo "/loa — View workflow status"
+            ;;
+        install)
+            # Post-install: suggest the pack's quick_start if available
+            if [[ -n "$pack_slug" ]]; then
+                local pack_dir
+                pack_dir="$(get_registry_install_dir)/$pack_slug"
+                local quick_cmd=""
+                if [[ -f "$pack_dir/construct.yaml" ]] && command -v yq &>/dev/null; then
+                    quick_cmd=$(yq eval '.quick_start.command // ""' "$pack_dir/construct.yaml" 2>/dev/null)
+                fi
+                if [[ -n "$quick_cmd" ]]; then
+                    echo "$quick_cmd — Get started with $pack_slug"
+                fi
+            fi
+            echo "/constructs status — Verify installation"
+            echo "/loa — View workflow status"
+            ;;
+    esac
+}

--- a/.claude/scripts/constructs-lib.sh
+++ b/.claude/scripts/constructs-lib.sh
@@ -1345,12 +1345,15 @@ format_tabular_output() {
 
     case "$fmt" in
         toon)
-            # Source toon-lib if not already loaded
+            # Source toon-lib if not already loaded (guard prevents re-parsing)
             local script_dir
             script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
             if [[ -f "$script_dir/lib/toon-lib.sh" ]]; then
-                # shellcheck source=lib/toon-lib.sh
-                source "$script_dir/lib/toon-lib.sh"
+                if [[ -z "${_TOON_LIB_LOADED:-}" ]]; then
+                    # shellcheck source=lib/toon-lib.sh
+                    source "$script_dir/lib/toon-lib.sh"
+                    _TOON_LIB_LOADED=1
+                fi
                 toon_encode_tabular "$label" "$tabular_json" && return 0
             fi
             # Fallback: TOON failed or lib missing — use original payload

--- a/.claude/scripts/constructs-loader.sh
+++ b/.claude/scripts/constructs-loader.sh
@@ -1207,7 +1207,46 @@ do_check_updates() {
                 ((updates_available++))
                 ;;
             0)
-                # Up to date
+                # Up to date — check content hash for fork-drift (cycle-037, FR-4.2)
+                local local_hash=""
+                local pack_slug_for_skill=""
+                # Derive pack slug from skill path (skills are under packs/<slug>/skills/)
+                if [[ -d "$skill_dir" ]]; then
+                    local skill_parent
+                    skill_parent=$(dirname "$(dirname "$skill_dir")")
+                    pack_slug_for_skill=$(basename "$skill_parent")
+                fi
+                if [[ -n "$pack_slug_for_skill" ]]; then
+                    local_hash=$(jq -r ".installed_packs[\"$pack_slug_for_skill\"].content_hash // \"\"" "$meta_path" 2>/dev/null)
+                fi
+
+                if [[ -n "$local_hash" ]]; then
+                    # Fetch registry hash for divergence detection
+                    local registry_url
+                    registry_url=$(get_registry_url 2>/dev/null || echo "")
+                    if [[ -n "$registry_url" ]]; then
+                        local hash_file
+                        hash_file=$(mktemp)
+                        chmod 600 "$hash_file"
+                        local hash_code
+                        hash_code=$(curl -s -w "%{http_code}" \
+                            --proto =https --tlsv1.2 --max-time 10 \
+                            "${registry_url}/packs/${pack_slug_for_skill}/hash" \
+                            -o "$hash_file" 2>/dev/null) || hash_code="000"
+                        local registry_hash=""
+                        if [[ "$hash_code" == "200" ]]; then
+                            registry_hash=$(jq -r '.data.hash // ""' "$hash_file" 2>/dev/null)
+                        fi
+                        rm -f "$hash_file"
+
+                        if [[ -n "$registry_hash" && "$local_hash" != "$registry_hash" ]]; then
+                            print_status "$icon_warning" "$skill_slug ($current_version) [DIVERGED] — local files modified"
+                            ((skills_checked++))
+                            continue
+                        fi
+                    fi
+                fi
+
                 print_status "$icon_valid" "$skill_slug ($current_version) [up to date]"
                 ;;
             -1)

--- a/.claude/scripts/lib/toon-lib.sh
+++ b/.claude/scripts/lib/toon-lib.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# =============================================================================
+# TOON (Token-Oriented Object Notation) — Tabular Encoder
+# =============================================================================
+# Converts JSON arrays of uniform objects to TOON tabular format.
+# Achieves ~39.6% fewer tokens than JSON for uniform array output.
+#
+# Usage:
+#   source "$(dirname "$0")/lib/toon-lib.sh"
+#   toon_encode_tabular "packs" "$json_array"
+#
+# Sources: sdd.md:§2.1 (TOON Encoder Library), prd.md:FR-1.1
+# =============================================================================
+
+# Detect if a JSON array is uniform (all objects have same keys)
+# Args: $1 = JSON array string
+# Returns: 0 if uniform, 1 if not
+# Stdout: comma-separated key list if uniform
+toon_detect_uniform() {
+    local json="$1"
+
+    # Requires jq
+    if ! command -v jq &>/dev/null; then
+        return 1
+    fi
+
+    # Extract keys from first object, compare against all objects
+    local first_keys
+    first_keys=$(echo "$json" | jq -r '
+        if (type == "array" and length > 0 and (.[0] | type) == "object")
+        then [.[0] | keys[]] | join(",")
+        else empty
+        end
+    ' 2>/dev/null) || return 1
+
+    [[ -z "$first_keys" ]] && return 1
+
+    # Verify all objects have identical keys
+    local all_same
+    all_same=$(echo "$json" | jq -r --arg fk "$first_keys" '
+        [.[] | [keys[]] | join(",")] | all(. == $fk)
+    ' 2>/dev/null) || return 1
+
+    [[ "$all_same" == "true" ]] || return 1
+    echo "$first_keys"
+    return 0
+}
+
+# Encode a JSON array to TOON tabular format
+# Args:
+#   $1 = label (e.g., "packs")
+#   $2 = JSON array string (uniform objects)
+# Stdout: TOON tabular output
+# Returns: 0 on success, 1 on non-uniform/non-array input
+toon_encode_tabular() {
+    local label="$1"
+    local json="$2"
+
+    # Requires jq
+    if ! command -v jq &>/dev/null; then
+        return 1
+    fi
+
+    # Handle empty array as valid case — emit header-only
+    local count
+    count=$(echo "$json" | jq 'if type == "array" then length else -1 end' 2>/dev/null) || return 1
+    [[ "$count" == "-1" ]] && return 1
+
+    if [[ "$count" == "0" ]]; then
+        echo "${label}[0]{}:"
+        return 0
+    fi
+
+    # Detect uniformity and get keys
+    local keys
+    keys=$(toon_detect_uniform "$json") || {
+        # Non-uniform: caller handles fallback
+        return 1
+    }
+
+    # Header: label[count]{field1,field2,...}:
+    echo "${label}[${count}]{${keys}}:"
+
+    # Value rows: CSV-style, 2-space indent
+    echo "$json" | jq -r --arg keys "$keys" '
+        ($keys | split(",")) as $fields |
+        .[] | [.[$fields[]]] | map(tostring) | "  " + join(",")
+    '
+}

--- a/.claude/skills/browsing-constructs/SKILL.md
+++ b/.claude/skills/browsing-constructs/SKILL.md
@@ -434,11 +434,15 @@ Installation metadata tracked in `.constructs-meta.json`:
   "installed_packs": {
     "observer": {
       "version": "1.0.0",
-      "installed_at": "2026-01-31T12:00:00Z"
+      "content_hash": "sha256:a3f2c1...",
+      "installed_at": "2026-01-31T12:00:00Z",
+      "source_type": "git"
     }
   }
 }
 ```
+
+The `content_hash` field (added in cycle-036) is a Merkle-root SHA-256 of all pack files, computed at install time by `compute_pack_hash()`. Used for staleness detection: `[SYNCED]` when hashes match, `[DIVERGED]` when local files differ from registry.
 
 ## Related Scripts
 

--- a/.loa.config.yaml
+++ b/.loa.config.yaml
@@ -1644,3 +1644,19 @@ run_bridge:
       - sprint
   defaults:
     timeout_hours: 24
+
+# =============================================================================
+# Output Format (cycle-037)
+# =============================================================================
+# Tabular CLI output encoding for agent consumption
+# Values: md (default — markdown tables), toon (Token-Oriented Object Notation), json
+output_format:
+  tabular: md
+
+# =============================================================================
+# Call-to-Action Navigation (cycle-037)
+# =============================================================================
+# When enabled, CLI commands append a "Next:" block with suggested next steps
+# See .claude/protocols/skill-cta.md for protocol spec
+cta:
+  enabled: false

--- a/docs/integration/runtime-contract.md
+++ b/docs/integration/runtime-contract.md
@@ -451,6 +451,58 @@ When features are disabled (default), runtimes should:
 - **Context Editing**: Standard context management (no compaction signals)
 - **Memory**: Ignore memory directory (file operations are optional)
 
+## Skill Loading Contract
+
+> **Source**: cycle-037 PRD FR-3, SDD §2.6
+> **Status**: Normative
+
+### Session-Start Behavior
+
+At session start, the runtime loads ONLY lightweight metadata:
+
+1. `CLAUDE.loa.md` framework instructions (skill command table)
+2. Pack `index.yaml` files (name, description, capabilities per skill)
+
+Full `SKILL.md` files are NOT loaded at session start. This is the optimal pattern for token efficiency — loading all skill bodies eagerly wastes context window capacity on instructions the agent may never need.
+
+### On-Demand Loading Trigger
+
+When the agent decides to invoke a skill:
+
+1. Runtime reads the full `SKILL.md` for that skill
+2. Skill body is injected into the agent's context
+3. Skill executes with full instructions available
+4. Subsequent invocations of the same skill reuse the already-loaded body
+
+### Token Baseline
+
+| Component | Approximate Size | Notes |
+|-----------|-----------------|-------|
+| Skill entry in command table | ~40 tokens/skill | Name + description in CLAUDE.loa.md |
+| Full SKILL.md body | ~300-2000 tokens/skill | Varies by skill complexity |
+| index.yaml metadata | ~50 tokens/skill | Capabilities, model_tier, etc. |
+
+**Session-start cost** (49 skills): ~2,000 tokens (index only)
+**Eager loading cost** (49 skills): ~15,000-100,000 tokens (wasteful)
+
+### Output Format Contract
+
+When `output_format.tabular` is configured in `.loa.config.yaml`:
+
+| Value | Behavior |
+|-------|----------|
+| `md` (default) | Markdown tables and plain-text labels |
+| `toon` | TOON tabular encoding (header + CSV rows) |
+| `json` | Raw JSON array output |
+
+Runtimes SHOULD respect this config when rendering tabular data from CLI commands (`constructs browse`, `constructs status`).
+
+### Defer Loading (Non-Normative — Future Extension)
+
+> **Note**: This section documents a future capability. The `defer_loading` config key exists but is not implemented in any runtime as of cycle-037. Runtimes are not expected to implement this behavior yet.
+
+When `defer_loading: true` is set in `.loa.config.yaml`, the runtime MAY defer even `index.yaml` loading until a skill discovery command (`/constructs browse`, `/loa`) is invoked. This further reduces session-start token cost at the expense of requiring an explicit discovery step.
+
 ## Related Documents
 
 - [Separation of Concerns](../architecture/separation-of-concerns.md) - Layer model

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "active_cycle": "cycle-036",
+  "active_cycle": "cycle-037",
   "global_sprint_counter": 36,
   "cycles": [
     {
@@ -412,26 +412,42 @@
     {
       "id": "cycle-036",
       "label": "Constructs Network Distribution Layer",
-      "status": "active",
+      "status": "archived",
       "created": "2026-02-27T21:45:00Z",
+      "archived": "2026-02-28T00:00:00Z",
+      "archive_path": "grimoires/loa/archive/cycle-036-distribution-layer",
       "prd": "grimoires/loa/prd.md",
       "source_issues": [131, 120, 89, 127, 122],
       "sdd": "grimoires/loa/sdd.md",
       "sprint_plan": "grimoires/loa/sprint.md",
+      "pr": 143,
+      "release": "v2.8.0",
       "sprints": [
         {
           "local_id": "sprint-1",
-          "label": "Seed Script Foundation + Dry-Run Validation"
+          "label": "Seed Script Foundation + Dry-Run Validation",
+          "status": "completed"
         },
         {
           "local_id": "sprint-2",
-          "label": "Register 4 New Constructs + The Easel Extraction"
+          "label": "Register 4 New Constructs + The Easel Extraction",
+          "status": "completed"
         },
         {
           "local_id": "sprint-3",
-          "label": "CLI detect_state + Post-Install Hooks"
+          "label": "CLI detect_state + Post-Install Hooks",
+          "status": "completed"
         }
       ]
+    },
+    {
+      "id": "cycle-037",
+      "label": "Agent-Native Output Protocol — TOON, CTAs, Lazy-Loading Contract",
+      "status": "active",
+      "created": "2026-02-28T00:00:00Z",
+      "prd": "grimoires/loa/prd.md",
+      "source_issues": [131],
+      "sprints": []
     }
   ]
 }

--- a/grimoires/loa/prd.md
+++ b/grimoires/loa/prd.md
@@ -1,553 +1,279 @@
-# PRD: Constructs Network Distribution Layer
+# PRD: Agent-Native Output Protocol — TOON, CTAs, Lazy-Loading Contract
 
-**Cycle**: cycle-036
-**Created**: 2026-02-27
+**Cycle**: cycle-037
+**Created**: 2026-02-28
 **Status**: Draft
-**Source**: 4-agent R&D team (org-auditor, dx-analyst, incur-researcher, landscape-researcher)
-**Linked Issues**: [#131](https://github.com/0xHoneyJar/loa-constructs/issues/131) (Construct Lifecycle RFC), [#120](https://github.com/0xHoneyJar/loa-constructs/issues/120) (Skill Discovery Breaks Post-Install), [#89](https://github.com/0xHoneyJar/loa-constructs/issues/89) (Pack Autosync), [#127](https://github.com/0xHoneyJar/loa-constructs/issues/127) (Golden Path Leveling), [#122](https://github.com/0xHoneyJar/loa-constructs/issues/122) (MoE Routing)
+**Source**: incur research synthesis (`grimoires/bridgebuilder/incur-cli-vs-mcp-research.md`)
+**Linked Issues**: [#131](https://github.com/0xHoneyJar/loa-constructs/issues/131) (Construct Lifecycle RFC)
 **Research artifacts**:
 - `grimoires/bridgebuilder/incur-cli-vs-mcp-research.md` (incur architecture, TOON, CLI-vs-MCP thesis)
-- `grimoires/bridgebuilder/agent-native-cli-landscape-research.md` (MCP, Skills.sh, TOON, market positioning)
-- `grimoires/bridgebuilder/ARCHETYPE.md` (Bridgebuilder design philosophy)
+- `grimoires/bridgebuilder/agent-native-cli-landscape-research.md` (MCP, Skills.sh, market positioning)
+**Upstream**: [loa#427](https://github.com/0xHoneyJar/loa/issues/427) (bug+protocol consolidated report)
 **Grounded in**:
-- Codebase scan: `scripts/seed-forge-packs.ts`, `packages/shared/src/types.ts`, `packages/shared/src/validation.ts`, `apps/api/src/routes/constructs.ts`, `apps/api/src/services/constructs.ts`, `apps/api/src/db/schema.ts`, `.claude/scripts/constructs-install.sh`, `.claude/scripts/golden-path.sh`
-- Full 0xHoneyJar org audit: 50+ repos scanned, all construct-* repos inventoried
-- Founder direction: CLI framework as distributable construct, surface unsurfaced constructs, cross-repo sync, structured foundation
+- `.claude/scripts/constructs-install.sh` (compute_pack_hash, show_pack_status)
+- `.claude/scripts/golden-path.sh` (golden_detect_construct_journeys, golden_menu_options)
+- `.claude/skills/browsing-constructs/SKILL.md` (pack table rendering, install report)
+- `docs/integration/runtime-contract.md` (no lazy-loading section exists)
+- `packages/shared/src/types.ts` (PackManifest, golden_path, quick_start)
+- `.loa.config.yaml` (defer_loading: false, no output_format, no cta config)
 
 ---
 
 ## 1. Problem Statement
 
-The Constructs Network has 80+ skills of domain expertise scattered across 10+ repos, but only 67 are installable. The distribution layer — the mechanism that turns expertise into something a builder can discover, install, and compose — has five concrete failures grounded in code:
+The Constructs Network already implements the optimal agent-tool integration pattern (frontmatter index + on-demand SKILL.md loading), but doesn't capitalize on it. Three measurable inefficiencies exist:
 
-### P1: The Seed Script Bottleneck
+### P1: Tabular Output Wastes Tokens
 
-`scripts/seed-forge-packs.ts` is the **only** way constructs enter the registry. It has 6 hardcoded Git URLs (lines 42-67). Adding a construct requires modifying source code and running a script with `DATABASE_URL`. There is no self-service registration, no webhook sync, no CLI-driven onboarding.
+Every `constructs browse`, `/loa` status, and `beads-health` invocation emits markdown tables. The incur research quantifies the cost: **TOON format achieves 39.6% fewer tokens than JSON and 26% fewer than YAML for uniform array output** — the exact shape of pack listings, skill inventories, and sprint task tables.
 
-The `POST /v1/constructs/register` endpoint (constructs.ts:257-339) reserves slugs but does not populate pack files. The `POST /v1/packs/:slug/versions` publishing flow exists but isn't the operational path. The DB schema has `pack_sync_events`, `github_repo_id`, and `content_hash` columns — all empty. The infrastructure is half-built.
+Current state: All CLI output paths use plain-text `echo` or markdown tables. No `output_format` config exists. No TOON encoder exists in the codebase.
 
-> **Impact**: 3 constructs with valid `construct.yaml` v3 manifests (Herald/3 skills, Hardening/7 skills, Dynamic Auth/3 skills) sit in repos unable to be installed. The seed script is the single point of failure for the entire distribution story.
+> **Impact**: At 20+ tool invocations per session, tabular output overhead compounds. The incur benchmark shows total session cost of $0.0131 with TOON vs $0.0325 with MCP JSON — a 60% savings. Even partial adoption (just pack listings and status output) would reduce per-session token cost measurably.
 
-### P2: Manifest Data Loss
+### P2: No Per-Invocation Navigation
 
-The seed script stores **7 of ~30** manifest fields. It constructs a minimal object (`schema_version, name, slug, version, description, author, license, skills`) and drops everything else: `golden_path`, `workflow`, `events`, `pack_dependencies`, `methodology`, `domain`, `expertise`, `quick_start`, `hooks.post_install`, `tier`.
+When a skill finishes executing, the agent has no structured guidance on what to do next. The existing `quick_start` and `golden_path.commands` fields in pack manifests are static, install-time suggestions. incur's CTA (Call-to-Action) pattern returns **context-sensitive next steps after every command execution**, creating pull-based discovery where each command output declares valid next steps.
 
-Every downstream consumer — the explorer, the CLI browse output, the golden path journey bar, the workflow gate reader — already knows how to read these fields. The Zod schema validates them. The TypeScript types declare them. **The data simply never reaches the database.**
+Current state: 39 pack skills now have `## Next Steps` sections (added in v2.8.0), but these are static markdown — not dynamic, not typed, not machine-readable. The `truename_map` in `golden_path.commands` already contains the state-machine edge data needed for CTAs but it is never surfaced as output.
 
-> **Impact**: `detect_state` is a dead field (declared in types.ts:303, validated by Zod, never evaluated by `golden-path.sh`). `workflow.gates` can't be read from registry data. Golden path journey bars show command names but can't show "you are here." The entire progressive disclosure system from ARCHETYPE.md Section 3 is blocked by a 20-line seed script function.
+> **Impact**: Agents must independently reason about workflow order. Users unfamiliar with the skill tree invoke skills in wrong order or miss complementary skills entirely.
 
-### P3: Fork Drift Invisibility
+### P3: Lazy-Loading Contract Is Undocumented
 
-midi-interface's Observer has **29 skills** (5 unique: `correlating-temporal`, `diagramming-states`, `enriching-temporal`, `grounding-code`, `triaging-signals`). The registry Observer has 24. The `packs` table has no `forked_from` column. The `content_hash` column exists but is never populated. There is no mechanism to detect, measure, or resolve divergence between installed packs and their registry versions.
+The CLAUDE.loa.md framework instructions state "Skills auto-load their SKILL.md when invoked" — this is the correct behavior and matches incur's optimal pattern. But `runtime-contract.md` has **zero documentation** on skill loading semantics. The `defer_loading: false` config key exists in `.loa.config.yaml` with a comment "Phase 2, not yet implemented."
 
-> **Impact**: The most valuable product signal in the ecosystem — Observer evolving from 6→24→29 skills through real-world usage in midi-interface — is untraceable. Skills born from actual builder friction have no path back to the canonical construct.
+Without a formal contract, runtime implementors (Cursor, Windsurf, custom runtimes) cannot replicate the lazy-loading behavior, and the token efficiency advantage is lost outside Claude Code.
 
-### P4: No Cross-Platform Degradation
-
-The SKILL.md standard has been adopted by **37+ agent platforms** (Claude Code, Cursor, GitHub Copilot, Gemini CLI, Windsurf, Google Antigravity). Vercel's Skills.sh publishes 147 new skills per day. Individual construct skills ARE SKILL.md-compatible, but the pack-level abstractions (`construct.yaml`, `persona.yaml`, events, capability metadata) require a construct-aware runtime.
-
-A construct skill cannot currently be consumed outside the Loa/Claude Code ecosystem. The addressable market is artificially constrained.
-
-> **Impact**: The construct model's unique value (expertise bundling, 4-tier progressive disclosure, capability routing, inter-construct events) is invisible to the 37-platform SKILL.md ecosystem. Builders on Cursor, Copilot, or Windsurf cannot access any of the 80+ skills.
-
-### P5: No "What Next?" After Skill Execution
-
-When a builder runs `/observe` or `/inscribe`, the skill produces output and... stops. There is no per-invocation call-to-action telling the agent what to do next. The `golden_path.commands` field exists in manifests but is pack-level and static. The `detect_state` field was designed for this but is never evaluated.
-
-incur solves this with typed CTAs returned from every command execution — dynamic, context-sensitive, referencing the next command based on output state. Constructs have the manifest schema for this but zero runtime implementation.
-
-> **Impact**: Agents guess what to do next or ask the user. This breaks flow state — the Bridgebuilder's highest-priority protection (ARCHETYPE.md: "Never pull builders out of their CLI to learn, configure, or troubleshoot").
+> **Impact**: Multi-runtime portability — the core value proposition of the construct/runtime separation — is undermined when the most important performance behavior is undocumented folklore.
 
 ---
 
-## 2. Vision
+## 2. Goals & Success Metrics
 
-**Every construct in the 0xHoneyJar ecosystem is discoverable, installable, syncable, and composable via `/constructs` — with graceful degradation to standalone SKILL.md for any of the 37+ agent platforms.**
+### G1: Token Efficiency
+- **Metric**: Measure token count of `constructs browse` output before and after TOON adoption
+- **Target**: ≥30% reduction in tokens for tabular CLI output paths
+- **Measurement**: Compare byte count and estimated token count of identical pack listings in markdown vs TOON format
 
-The construct model occupies a genuinely novel position in the agent tooling landscape:
+### G2: Agent Navigation
+- **Metric**: When `cta.enabled: true`, targeted CLI output paths emit a structured `Next:` block
+- **Target**: 100% of the following commands emit CTAs when enabled: `constructs browse`, `constructs status`, `constructs install`
+- **Measurement**: Run each command with `cta.enabled: true` and verify `Next:` block appears in output
 
+### G3: Runtime Contract Completeness
+- **Metric**: `runtime-contract.md` has a Skill Loading Contract section with formal specification
+- **Target**: Covers session-start behavior, on-demand loading trigger, token baseline, and output format contract
+- **Measurement**: Section exists and is referenced from CLAUDE.loa.md
+
+### G4: Config Surface
+- **Metric**: All new behaviors are gated behind `.loa.config.yaml` flags
+- **Target**: `output_format`, `cta`, and lazy-loading config sections exist with sensible defaults
+- **Measurement**: Config validation passes, features disabled by default, zero breaking changes
+
+---
+
+## 3. User & Stakeholder Context
+
+### Primary Persona: Construct Author
+A developer building or maintaining a construct (pack of skills). They want their construct's output to be token-efficient and their workflow to guide users to the right next step. They author `SKILL.md` files and `construct.yaml` manifests.
+
+### Secondary Persona: Construct Consumer
+A developer who installs constructs and uses skills in their projects. They benefit from reduced token costs (cheaper sessions) and CTA navigation (fewer wasted invocations). They don't author constructs — they consume them.
+
+### Tertiary Persona: Runtime Implementor
+An engineer building a runtime (Cursor extension, Windsurf plugin, custom agent) that hosts Loa constructs. They need the lazy-loading contract to replicate Claude Code's performance behavior.
+
+---
+
+## 4. Functional Requirements
+
+### FR-1: TOON Output Format
+
+#### FR-1.1: TOON Encoder Library
+Create a bash TOON encoder function that converts JSON arrays of uniform objects to TOON tabular format. This cycle implements **tabular arrays only** — the high-value case for agent output. Simple arrays and nested structures remain in their current format.
+
+Tabular format: Header declares fields once, then CSV-style value rows:
 ```
-npm:          "Here's code. Import it."
-MCP:          "Here's a tool. Call it."
-Skills.sh:    "Here's how to do this task. Follow these instructions."
-Constructs:   "Here's a domain expert. It knows what to do, how to do it,
-               when to use which tools, what quality looks like, and how
-               to coordinate with other experts."
+packs[5]{slug,name,skills,version,status}:
+  artisan,Artisan,14,1.2.0,Free
+  observer,Observer,6,1.0.2,Installed
 ```
 
-This PRD does not invent a new system. It completes the existing one — connecting the half-built infrastructure (DB schema, API endpoints, manifest validation) to the half-surfaced constructs (Herald, Hardening, Dynamic Auth, The Easel, midi-interface Observer extensions) through a self-service distribution layer.
+Input: JSON array of uniform objects (piped from `jq`).
+Output: TOON tabular string.
 
----
+#### FR-1.2: Output Format Config
+Add `output_format.tabular` to `.loa.config.yaml` with values: `md` (default), `toon`, `json`.
 
-## 3. Goals & Success Metrics
+#### FR-1.3: MVP Integration Targets (This Cycle)
+Apply TOON output to exactly these 2 paths:
 
-### Business Objectives
+| Target | Script | Current Format |
+|--------|--------|----------------|
+| Pack listing | `constructs-browse.sh` | Markdown table |
+| Pack status | `constructs-install.sh show_pack_status` | Plain-text labels |
 
-| Objective | Target | Measurement |
-|-----------|--------|-------------|
-| Surface all ready constructs | 10 packs installable (from 6) | `/constructs browse` returns 10+ packs |
-| Full manifest fidelity | 30/30 fields stored | Seed script stores complete validated manifest |
-| Self-service registration | < 5 min to register new construct | Time from `construct.yaml` creation to registry appearance |
-| Fork drift detection | 100% of installed packs have content hash | `content_hash` populated for all `pack_versions` rows |
-| Cross-platform compatibility | Every skill degrades to standalone SKILL.md | Skills usable in Cursor/Copilot without construct runtime |
+**Future targets** (not this cycle): `constructs-loader.sh list`, `beads-health.sh`, `golden-path.sh golden_menu_options`.
 
-### Human-Connected Metrics (per ARCHETYPE.md Section 4)
+#### FR-1.4: Fallback
+When TOON format is configured but the target data is non-uniform (deeply nested, semi-structured), fall back to the current format with no error. TOON is advisory, not mandatory.
 
-| Metric | What It Captures | Baseline | Target |
-|--------|-----------------|----------|--------|
-| First-invocation success | Does trying a construct deliver on its description? | Unknown | > 80% of installs lead to first skill invocation |
-| Construct depth | How far through a construct's golden path | 1.2 steps avg (estimated) | 3+ steps avg |
-| Flow state preservation | Does the system keep builders in the zone? | No CTAs → agents ask user | CTAs guide next step without interruption |
-| Friction-to-resolution | Time from "I'm stuck" to "I understand" | No measurement | < 2 min for installation friction |
+### FR-2: CTA Protocol
 
----
+#### FR-2.1: Protocol Specification
+Create `.claude/protocols/skill-cta.md` defining the CTA output format:
 
-## 4. User & Stakeholder Context
-
-### Persona 1: Internal Builder (Primary)
-
-Team members using constructs within 0xHoneyJar products (midi-interface, hub-interface, set-and-forgetti, score-api). They have constructs installed via Loa framework mounts. Their pain: constructs evolve in their repos but those improvements don't flow back to the registry, and new constructs from other repos aren't installable.
-
-### Persona 2: Construct Author (Secondary)
-
-Someone creating a new construct (e.g., Envio Indexer from #122, or a community contributor). Their pain: the only path to registry presence requires modifying the seed script and having `DATABASE_URL` access. No documentation on how to author a construct that the registry can consume.
-
-### Persona 3: External Agent User (Tertiary — Phase 3)
-
-Someone using Cursor, Copilot, or another SKILL.md-compatible agent. They want individual skills without the full construct runtime. Their pain: skills are locked inside the construct packaging and can't be consumed standalone.
-
----
-
-## 5. Functional Requirements
-
-### Phase 1: Fix the Plumbing (Foundation)
-
-*Goal: Full manifest fidelity + surface ready constructs.*
-
-#### F1.1: Full Manifest Extraction in Seed Script
-
-**Current**: `seed-forge-packs.ts` constructs a minimal manifest (7 fields).
-**Target**: Store the full `construct.yaml` parsed to JSON, validated by `packManifestSchema.safeParse()`.
-
-Fields that will newly reach the database:
-- `golden_path` (commands, detect_state, truename_map)
-- `workflow` (depth, gates)
-- `events` (emits, consumes)
-- `pack_dependencies`
-- `methodology` (references, principles, knowledge_base)
-- `domain`, `expertise`
-- `quick_start`
-- `hooks` (post_install, pre_uninstall)
-- `tier`
-- `type` (pack, tool-pack, codex)
-
-**Acceptance criteria**:
-- Seed script uses Zod validation for all manifests
-- All 30+ manifest fields stored in `pack_versions.manifest` JSONB
-- Existing API responses (`GET /v1/constructs/:slug`) automatically surface new fields (they already destructure from manifest)
-- `content_hash` (SHA-256 of manifest + skill contents) populated for every `pack_versions` row
-
-#### F1.2: Register 3 Ready Constructs
-
-Add Herald, Hardening, and Dynamic Auth to the seed script:
-
-| Construct | Repo | Skills | Schema |
-|-----------|------|--------|--------|
-| Herald | `construct-herald` | 3 (grounding-announcements, synthesizing-voice, chronicling-changes) | v3 |
-| Hardening | `construct-hardening` | 7 (postmortem, triage, blast-radius, harden, regression-check, signal-audit, correlating) | v3 |
-| Dynamic Auth | `construct-dynamic-auth` | 3 (resolving-wallet-identity, enforcing-primary-wallet, backfilling-identity-links) | v3 |
-
-**Acceptance criteria**:
-- All 3 appear in `/constructs browse` output
-- All 3 installable via `/constructs install <slug>`
-- Total registered: 9 packs, 80 skills
-
-#### F1.5: Extract The Easel to Standalone Construct
-
-**Current**: The Easel (4 skills, `manifest.json` schema_version 1) lives embedded in `rektdrop-interface/.claude/constructs/packs/the-easel/`. It has 16 Taste Decision Records, a full vocabulary atlas (86 terms, 8 domains), and is actively used for cyberpunk aesthetic direction. Issue #131 incorrectly attributed it to hub-interface — it was always in rektdrop-interface. The Cartograph and The Mint (also attributed to hub-interface in #131) never existed anywhere in the org.
-
-**Target**: Extract the **core DNA** of The Easel to a standalone `construct-the-easel` repo — the universal creative studio workflow (vocabulary grounding → visual exploration → result capture → taste decisions). All rektdrop/cyberpunk-specific content (TDRs, aesthetic-direction.md, the cyberpunk vocabulary atlas) stays in rektdrop-interface as project-level grimoire content. The extracted construct is domain-agnostic creative tooling that any project can install and populate with its own aesthetic vocabulary.
-
-**Critical distinction**: The Easel's *process* (ground → explore → capture → record) is the construct. The rektdrop *content* (cyberpunk FUI terms, CRT emulation TDRs, Freeside Divergence aesthetics) is project state produced BY that process. The extraction ships the machine, not the output.
-
-**Extraction steps**:
-
-| Step | Detail | Effort |
-|------|--------|--------|
-| Create `construct-the-easel` repo | New repo with clean pack structure — NOT a copy of rektdrop's embedded version | Small |
-| Write domain-agnostic SKILL.md files | Generalize the 4 skills: remove cyberpunk references, use context slots for vocabulary domain | Medium |
-| Write `construct.yaml` v3 | Capabilities, events (`forge.easel.taste_recorded`, `forge.easel.vocabulary_grounded`), pack_dependencies (optional: Artisan for taste token handoff) | Small |
-| Add `index.yaml` per skill | All `model_tier: sonnet`, `danger_level: safe`, `effort_hint: medium` | Small |
-| Context slots for grimoire paths | `{{grimoire_path}}` instead of hardcoded `grimoires/the-easel/` | Small |
-| Ship empty templates only | `tdr-template.md` (blank), `vocabulary-template.md` (empty 8-domain structure), `quality-gates.md` (generic phase gates) | Small |
-| Add `identity/` directory | `persona.yaml` (creative studio voice — domain-agnostic) and `expertise.yaml` (design vocabulary, visual direction, taste documentation) | Small |
-| Register in seed script | Add to GIT_CONFIGS + PACK_ICONS | Trivial |
-| Update rektdrop-interface | Install construct from registry, keep existing `grimoires/the-easel/` content (TDRs, atlas, aesthetic-direction) as project state | Small |
-
-**What ships with the construct** (domain-agnostic):
-- 4 skill SKILL.md files with context slots
-- `tdr-template.md` — empty Taste Decision Record template
-- `vocabulary-template.md` — empty vocabulary atlas structure (8 domains, no terms)
-- `quality-gates.md` — generic Ground → Visualize → Tokenize → Implement phase gates
-
-**What stays in rektdrop** (project-specific):
-- 16 Taste Decision Records (TDR-001 through TDR-016)
-- `vocabulary/atlas.md` — 86 cyberpunk terms across 8 domains
-- `aesthetic-direction.md` — Freeside Divergence visual language
-- All exploration session artifacts, prompts, reviews
-
-**Skills** (generalized):
-- `grounding-creative` — Reviews project vocabulary and TDRs for a design area, identifies tensions and gaps
-- `exploring-visuals` — Generates prompts for image generation tools grounded in project vocabulary
-- `capturing-results` — Annotates generation results with vocabulary terms and TDR criteria
-- `recording-taste` — Taste Decision Record CRUD operations
-
-**Acceptance criteria**:
-- `construct-the-easel` repo exists with `construct.yaml` v3
-- All 4 skills are domain-agnostic — zero cyberpunk/rektdrop references in the construct
-- Skills use context slots for vocabulary paths, grimoire paths, and generation tool names
-- Installing on a fresh project produces empty templates ready to populate with any aesthetic vocabulary
-- rektdrop-interface installs from registry and its existing `grimoires/the-easel/` TDRs/atlas continue working
-- Registered on constructs.network, installable via `/constructs install the-easel`
-- Total registered after this + F1.2: **10 packs, 84 skills**
-
-#### F1.3: Activate detect_state in Golden Path
-
-**Current**: `golden-path.sh`'s `golden_detect_construct_journeys()` reads `golden_path.commands` but never evaluates `detect_state`.
-**Target**: If a pack declares `golden_path.detect_state` (a script path), execute it and use the returned state to highlight the current position in the journey bar.
-
-**Acceptance criteria**:
-- `/loa` shows "you are here" indicator per installed construct
-- detect_state scripts execute in the construct's directory context
-- Fallback: if no detect_state declared, show command names without position indicator (current behavior)
-
-#### F1.4: Post-Install Hook Execution
-
-**Current**: `hooks.post_install` is declared in manifests and validated by Zod but never executed by `constructs-install.sh`.
-**Target**: After pack extraction, execute `hooks.post_install` if declared.
-
-**Acceptance criteria**:
-- Post-install scripts run after file extraction
-- Scripts execute in the pack's installation directory
-- Failures are non-blocking (warn, don't abort install)
-- Security: scripts must be within the pack directory (no path traversal)
-
-### Phase 2: Self-Service Distribution
-
-*Goal: Construct authors can register, sync, and publish without modifying source code.*
-
-#### F2.1: Self-Service Registration API
-
-**Endpoint**: `POST /v1/constructs/register` (extend existing)
-
-Add `git_url` and `git_ref` fields to the registration schema. On registration:
-1. Validate caller identity (JWT auth)
-2. Clone the repo, read `construct.yaml`
-3. Validate manifest with Zod
-4. Create pack row with `source_type='git'`, populate `git_url`, `github_repo_id`
-5. Create first `pack_version` with full validated manifest
-6. Populate `construct_identities` from `identity/` directory
-
-**Acceptance criteria**:
-- `POST /v1/constructs/register { slug, git_url }` creates a fully populated registry entry
-- No seed script modification required
-- Response includes the construct's registry page URL
-
-#### F2.2: Sync Endpoint
-
-**Endpoint**: `POST /v1/packs/:slug/sync`
-
-Trigger re-sync from the registered `git_url`:
-1. Validate caller is pack owner
-2. Clone repo at latest `git_ref`
-3. Compare `content_hash` — skip if unchanged
-4. Parse manifest, validate with Zod
-5. Create new `pack_version` if version bumped, or update current if content changed
-6. Log to `pack_sync_events` (existing table, currently empty)
-
-**Acceptance criteria**:
-- Sync detects content changes via hash comparison
-- Sync is idempotent (running twice with no changes produces no new versions)
-- `pack_sync_events` table populated for audit trail
-- Rate limited per existing DB index
-
-#### F2.3: CLI Registration Commands
-
-Extend the `browsing-constructs` skill and install scripts:
-
-- `/constructs register <slug> --git-url <url>` — calls `POST /v1/constructs/register`
-- `/constructs sync <slug>` — calls `POST /v1/packs/:slug/sync`
-- `/constructs status <slug>` — shows installed version vs registry version + content hash comparison
-
-**Acceptance criteria**:
-- All three commands work from CLI within a Claude Code session
-- `constructs status` shows divergence indicator when hashes differ
-
-#### F2.4: GitHub Webhook Receiver
-
-**Endpoint**: `POST /v1/webhooks/github`
-
-Automated sync on push:
-1. Validate GitHub webhook signature (HMAC-SHA256)
-2. Match `github_repo_id` to a registered pack
-3. Trigger the same sync logic as F2.2
-4. Rate limit via `pack_sync_events`
-
-**Acceptance criteria**:
-- Webhook fires on push to default branch
-- Sync completes within 60 seconds of push
-- Failed syncs logged but don't break the webhook response
-
-### Phase 3: Cross-Platform Compatibility & Agent Navigation
-
-*Goal: Skills work standalone on 37+ platforms. Agents always know what to do next.*
-
-#### F3.1: Graceful SKILL.md Degradation
-
-Every skill within a construct must function as a standalone SKILL.md when consumed outside the construct runtime. This means:
-
-- Skill SKILL.md files must be self-contained (no hard references to construct.yaml, persona.yaml, or other pack-level files)
-- Context slots (`{{project_name}}`, etc.) should have sensible defaults or degrade to placeholders
-- The construct layer (identity, events, capability routing) is enrichment, not a dependency
-
-**Acceptance criteria**:
-- Any skill file copied to `~/.claude/commands/` or another SKILL.md-compatible agent works without the construct runtime
-- Skill audit script validates standalone compatibility
-
-#### F3.2: Per-Invocation Call-to-Actions
-
-After each skill execution, the runtime emits a `## Next Steps` section with context-sensitive suggestions based on the construct's `golden_path.commands` and the current `detect_state` output.
-
-**Example**: After running `/observe` (Observer's listening skill):
 ```
 Next:
-/see — Synthesize what you've captured (5 canvases ready)
-/shape — Shape patterns into journey definitions (if 3+ canvases share themes)
-/loa — Check your full journey status
+<command-1> — <description>
+<command-2> — <description>
 ```
 
-**Acceptance criteria**:
-- CTAs appear after skill execution for packs that declare `golden_path`
-- CTAs are dynamic (reference current state, not static command lists)
-- CTAs are optional — packs without golden_path show no CTAs
-- CTA format is a simple markdown `## Next Steps` section appended to skill output
+The protocol specifies:
+- CTAs appear after main output, before any grimoire writes
+- Maximum 3 CTAs per invocation (avoid choice paralysis)
+- CTAs are context-sensitive: derived from current workflow state + pack's `golden_path.commands`
+- CTAs use truenames (e.g., `/implement`) not golden path aliases (e.g., `/build`)
 
-#### F3.3: Content-Hash Staleness Detection
+#### FR-2.2: CTA Emission in CLI Scripts
+Add a `emit_cta()` helper function to `constructs-lib.sh` that:
+1. Reads current workflow state from golden-path state detection
+2. Looks up the active pack's `golden_path.commands` + `truename_map`
+3. Emits a `Next:` block with up to 3 contextually relevant commands
 
-Extend `constructs-install.sh` and `constructs-loader.sh`:
+#### FR-2.3: CTA Config
+Add `cta.enabled` to `.loa.config.yaml` (default: `false`). When disabled, no `Next:` blocks are emitted. When enabled, the following CLI commands append CTAs: `constructs browse`, `constructs status`, `constructs install`. Broader rollout to additional commands is deferred to a follow-up cycle.
 
-- On install: compute SHA-256 of manifest + all skill file contents, store in `.constructs-meta.json`
-- On `check-updates`: compare installed hash against registry hash
-- Surface drift: `/constructs status` shows `[SYNCED]`, `[BEHIND]`, or `[DIVERGED]` per pack
+#### FR-2.4: Manifest Extension
+Add `workflow_next` field to `PackManifest` in `packages/shared/src/types.ts`:
 
-**Acceptance criteria**:
-- Every installed pack has a `content_hash` in `.constructs-meta.json`
-- `check-updates` catches changes even without version bumps
-- Divergence detection feeds into the proposed Merkle-tree system from RFC #131
-
----
-
-## 6. Technical & Non-Functional Requirements
-
-### Architecture Principles
-
-1. **Construct/Runtime Boundary preserved**: Skills define expertise. Runtime executes. No skill may assume a specific runtime.
-2. **Hand-authored SKILL.md**: Skills are expertise documents, not API references. Do NOT auto-generate from schemas (per incur research finding).
-3. **Per-repo installation**: Constructs install to `.claude/constructs/packs/` (gitignored, project-scoped). No global installation.
-4. **MCP stays external**: MCP servers are for external integrations (GitHub, Linear). Skills are the primary agent-expertise channel.
-5. **4-tier progressive disclosure preserved**: Pack manifest → skill metadata → skill instructions → resources.
-
-### Performance
-
-- Seed script sync: < 30 seconds per construct
-- API sync endpoint: < 60 seconds per construct
-- Install + post-install hooks: < 90 seconds
-- detect_state script execution: < 5 seconds
-- CTA generation: < 1 second (reads cached state)
-
-### Security
-
-- Post-install hooks: sandboxed to pack directory, no network access, timeout after 30 seconds
-- Webhook signature validation: HMAC-SHA256 with per-pack secret
-- Registration: requires authenticated JWT (construct author)
-- Path traversal prevention: maintained from existing `constructs-install.sh` validation
-
-### Compatibility
-
-- construct.yaml (YAML) and manifest.json (JSON) both supported for input
-- All manifests stored as validated JSON in `pack_versions.manifest`
-- Zod schema is the single source of truth for validation
-- Skills must degrade to standalone SKILL.md (F3.1)
-
----
-
-## 7. Scope & Prioritization
-
-### MVP (Phase 1 — Foundation)
-
-| Item | Priority | Effort |
-|------|----------|--------|
-| F1.1 Full manifest extraction | P0 | Small — ~50 lines of seed script |
-| F1.2 Register 3 ready constructs | P0 | Small — add to GIT_CONFIGS + icons |
-| F1.5 Extract The Easel | P0 | Medium — extract from rektdrop, upgrade v1→v3, register |
-| F1.3 Activate detect_state | P1 | Medium — golden-path.sh extension |
-| F1.4 Post-install hook execution | P1 | Small — constructs-install.sh extension |
-
-### Phase 2 — Self-Service
-
-| Item | Priority | Effort |
-|------|----------|--------|
-| F2.1 Self-service registration API | P1 | Medium — ~200 lines API route |
-| F2.2 Sync endpoint | P1 | Medium — ~150 lines API route |
-| F2.3 CLI registration commands | P2 | Small — ~150 lines shell script |
-| F2.4 GitHub webhook receiver | P2 | Medium — ~300 lines API route |
-
-### Phase 3 — Cross-Platform & Navigation
-
-| Item | Priority | Effort |
-|------|----------|--------|
-| F3.1 SKILL.md graceful degradation | P1 | Medium — audit + fix across 80 skills |
-| F3.2 Per-invocation CTAs | P2 | Medium — runtime extension + protocol |
-| F3.3 Content-hash staleness | P2 | Small — hash computation + comparison |
-
-### Explicitly Out of Scope
-
-- **TOON output format**: Valuable (39.6% token savings) but additive optimization, not structural. Deferred.
-- **Dynamic cross-pack discovery**: Needed at 500+ skills. Current 80 skills are manageable. Deferred.
-- **Billing / pricing tiers**: L1/L2/L3 tiers are metadata only, not pricing. Deferred.
-- **MCP bridge for constructs**: Constructs should not be served via MCP. Skills are the channel.
-- **Auto-generated SKILL.md**: Conflicts with hand-authored expertise model. Rejected.
-- **Global skill installation**: Per-repo is architecturally correct. Rejected.
-- **Supply-chain security scanning**: Important at scale but premature for 9 first-party packs. Deferred to Phase 4.
-
----
-
-## 8. Risks & Dependencies
-
-### Technical Risks
-
-| Risk | Likelihood | Impact | Mitigation |
-|------|-----------|--------|------------|
-| Seed script Zod validation rejects existing manifests | Medium | High — breaks current packs | Run validation in dry-run mode first, fix manifests before switching |
-| detect_state scripts have side effects | Low | Medium | Sandbox execution, read-only filesystem access, 5s timeout |
-| Post-install hooks fail on different OSes | Medium | Low | Non-blocking, warn-only. Document OS requirements in manifest. |
-| Webhook sync creates version spam | Low | Medium | Rate limiting via `pack_sync_events` index. Deduplicate on content_hash. |
-
-### External Dependencies
-
-| Dependency | Status | Risk |
-|------------|--------|------|
-| GitHub API (for webhook configuration) | Stable | Low |
-| Supabase DB (for new rows/queries) | Active | Low |
-| construct-* repos (Herald, Hardening, Dynamic Auth) | Exist, valid manifests | Low — need icon assets |
-| rektdrop-interface (The Easel source) | Active, 16 TDRs produced | Low — extraction is pure copy + upgrade |
-| Railway API service | Deployed | Low |
-
-### Business Risks
-
-| Risk | Mitigation |
-|------|------------|
-| Construct authors don't adopt self-service | Internal team uses it first for all 9+ packs, proving the flow before external promotion |
-| Cross-platform degradation reduces construct value prop | Frame as expansion, not dilution — standalone skills are the on-ramp, full constructs are the graduation |
-| Fork drift resolution creates merge conflicts | Hash detection is informational first — surface drift, don't auto-merge |
-
----
-
-## 9. Construct Inventory (Current State)
-
-### Registered (6 packs, 67 skills)
-
-| Pack | Skills | Version | Status |
-|------|--------|---------|--------|
-| Observer | 24 | 2.0.0 | Active |
-| Artisan | 14 | 1.0.0 | Active |
-| Protocol | 10 | 1.0.0 | Active |
-| GTM Collective | 8 | 1.0.0 | Active |
-| Beacon | 6 | 2.0.0 | Active |
-| Crucible | 5 | 1.0.0 | Active |
-
-### Ready to Register (3 packs, 13 skills)
-
-| Pack | Skills | Repo | Schema | Readiness |
-|------|--------|------|--------|-----------|
-| Hardening | 7 | construct-hardening | v3 | HIGH — complete construct.yaml, identity, 7 domain skills |
-| Herald | 3 | construct-herald | v3 | HIGH — complete construct.yaml, identity, 3 skills |
-| Dynamic Auth | 3 | construct-dynamic-auth | v3 | HIGH — complete construct.yaml, identity, knowledge, 3 skills |
-
-### Needs Migration (2 packs, ~17 domain skills)
-
-| Pack | Domain Skills | Repo | Format | Issue |
-|------|--------------|------|--------|-------|
-| Rune/Sigil | ~15 | rune | manifest.json v4 | Old schema + Loa workflow skill contamination |
-| Ruggy Security | ~2 | ruggy-security | manifest.json v1.2 | Old schema + mostly Loa workflow clones |
-
-### Embedded — Extraction Target (1 pack, 4 skills)
-
-| Pack | Skills | Location | Issue | Extraction |
-|------|--------|----------|-------|------------|
-| The Easel | 4 | rektdrop-interface/.claude/constructs/packs/ | Not standalone repo | F1.5 — extract to `construct-the-easel`, upgrade manifest v1→v3 |
-
-### Fork Drift (1 case)
-
-| Source | Registry | Fork Location | Delta |
-|--------|----------|---------------|-------|
-| Observer (24) | construct-observer | midi-interface | +5 unique skills (correlating-temporal, diagramming-states, enriching-temporal, grounding-code, triaging-signals) |
-
-### Not Found
-
-- The Cartograph — referenced in issue #131 as hub-interface construct, not found in any repo
-- The Mint — referenced in issue #131 as hub-interface construct, not found in any repo
-
----
-
-## 10. Market Positioning Context
-
-### The Agent Tooling Stack (Feb 2026)
-
-```
-EXPERTISE LAYER  ← Constructs (packs + identity + events + quality gates)
-   contains
-SKILL LAYER      ← SKILL.md / Skills.sh (behavioral instructions, 37+ platforms)
-   invokes
-TOOL LAYER       ← MCP servers / CLI tools / APIs (executable capabilities)
+```typescript
+workflow_next?: Array<{
+  construct: string;  // slug of suggested next construct
+  reason: string;     // why this construct complements the current one
+  trigger?: string;   // workflow state that activates this suggestion
+}>;
 ```
 
-### Key Market Data
+This enables registry-level cross-construct CTAs (e.g., "After installing Observer, consider Protocol for contract verification").
 
-- **MCP**: 97M monthly SDK downloads, 5,500+ servers. Suffers context pollution (50+ tools = 55-134K tokens before reasoning). Anthropic's Tool Search reduces by 85%.
-- **Skills.sh**: Launched Jan 20, 2026. 147 new skills/day. npm as transport. Snyk security scanning. ClawHavoc incident: 341 malicious skills.
-- **TOON**: 39.6% fewer tokens than JSON, 4.2 percentage points higher accuracy. TypeScript SDK available.
-- **incur (wevm)**: CLI-as-skills framework. Auto-registration via `skills add`. Type-safe with Zod. TOON output. 3x cheaper than MCP per session.
+### FR-3: Lazy-Loading Contract
 
-### What Constructs Do That Nothing Else Does
+#### FR-3.1: Runtime Contract Section
+Add `## Skill Loading Contract` to `docs/integration/runtime-contract.md` specifying:
 
-1. **Expertise bundling**: Persona + skills + events + capability routing + quality gates in a distributable unit
-2. **4-tier progressive disclosure**: Pack manifest → skill metadata → instructions → resources (most granular in the landscape)
-3. **Capability-aware routing**: `model_tier`, `danger_level`, `effort_hint` enable intelligent dispatch
-4. **Inter-construct events**: `emits`/`consumes` for loose coupling between domains
-5. **Quality gates as structural concern**: Implement → review → audit with circuit breaker
+1. **Session-start**: Only `index.yaml` metadata loads (name, description, capabilities). Full `SKILL.md` body is NOT read.
+2. **On-demand trigger**: When agent decides to invoke a skill, runtime reads the full `SKILL.md` for that skill.
+3. **Token baseline**: Reference incur benchmarks — frontmatter index ~40 tokens/skill vs full schema ~300+ tokens/skill.
+4. **Output format**: When `output_format.tabular: toon` is configured, skill tabular output uses TOON encoding.
+5. **Defer loading**: When `defer_loading: true` is set, runtime may defer even `index.yaml` loading until a skill discovery command is invoked.
 
-### What Constructs Should NOT Do
+#### FR-3.2: Token Baseline Measurement
+Measure and document the current session-start token cost:
+- Size of `CLAUDE.loa.md` skill command table
+- Size of all pack `index.yaml` files combined
+- Compare against incur's published benchmarks
 
-1. Auto-generate SKILL.md from code — hand-authored expertise is the differentiator
-2. Serve constructs via MCP — skills are the primary channel, MCP is for external integrations
-3. Install globally — per-repo installation enables project-scoped topology
-4. Compete with Skills.sh — instead, ensure every skill degrades to a standalone SKILL.md that can be published there
+### FR-4: Hash Staleness Refinement
 
----
+#### FR-4.1: SKILL.md Schema Update
+Update the `.constructs-meta.json` example in `browsing-constructs/SKILL.md` to include the `content_hash` field that already exists in the runtime implementation.
 
-## 11. Implementation Sequence
+#### FR-4.2: Check-Updates Hash Path
+Ensure `constructs-loader.sh check-updates` uses content hash comparison in addition to version string comparison. If the version matches but the hash diverges, report `[DIVERGED]` (fork-drift case from RFC #131).
 
-```
-Phase 1: Foundation (fix seed → register 3 + extract Easel → activate detect_state → post-install hooks)
-    ↓
-Phase 2: Self-Service (register API → sync endpoint → CLI commands → webhook)
-    ↓
-Phase 3: Reach (SKILL.md degradation → CTAs → content-hash staleness)
-```
+### ~FR-5: Bridge Format~ (DEFERRED — not a cycle-037 deliverable)
 
-Each phase is independently shippable. Phase 1 is the highest-impact, lowest-effort change — it unblocks everything downstream by getting full manifest data into the database and 3 new constructs into the registry.
+> Moved to Future Work. The bridge format for converting incur-generated SKILL.md into Loa construct definitions is a design exploration, not a cycle-037 acceptance criterion. See Section 6 (Future Scope) for details.
 
 ---
 
-*"The best network doesn't add features. It removes the barriers between what exists and what's possible."*
+## 5. Technical & Non-Functional Requirements
+
+### NFR-1: Zero Breaking Changes
+All new features are additive and gated behind config flags. Default behavior is unchanged. Existing scripts produce identical output unless the user opts in.
+
+### NFR-2: Bash-Only Implementation
+TOON encoder and CTA emission must be implemented in bash (matching the existing script architecture). No TypeScript runtime dependency for CLI output paths.
+
+### NFR-3: Cross-Platform
+All new bash code follows the cross-platform shell protocol (`.claude/protocols/cross-platform-shell.md`). Use compat-lib.sh wrappers. No bare `sed -i`, `readlink -f`, `grep -P`, or `timeout`.
+
+### NFR-4: Config Validation
+New config sections must pass schema validation. The canonical config schema for this cycle:
+
+```yaml
+# Canonical Config Schema (cycle-037)
+output_format:
+  tabular: md          # enum: md | toon | json — default: md
+cta:
+  enabled: false       # boolean — default: false
+```
+
+No new config key is needed for hash staleness — it is already implemented in `constructs-install.sh` and controlled by `compute_merkle_hash` availability.
+
+### NFR-5: Default Output Regression
+When config flags are at their defaults (`output_format.tabular: md`, `cta.enabled: false`), all CLI commands must produce byte-identical output to their pre-cycle-037 behavior. Verify with snapshot comparison on `constructs browse` and `constructs status`.
+
+---
+
+## 6. Scope & Prioritization
+
+### MVP (This Cycle)
+
+| Priority | Feature | Effort |
+|----------|---------|--------|
+| P1 | TOON tabular encoder library (`toon-lib.sh`) | Medium |
+| P1 | Output format config + integration in `constructs-browse.sh` and `show_pack_status` (2 targets only) | Medium |
+| P1 | Lazy-loading contract in `runtime-contract.md` | Small |
+| P1 | Config surface (`output_format`, `cta`) | Small |
+| P2 | CTA protocol file (`.claude/protocols/skill-cta.md`) | Small |
+| P2 | `emit_cta()` helper + integration in golden-path and constructs CLI | Medium |
+| P2 | `workflow_next` field in `PackManifest` types | Small |
+| P2 | SKILL.md schema update for `content_hash` | Small |
+
+### Future Scope
+
+| Feature | Cycle | Notes |
+|---------|-------|-------|
+| Bridge format spec (incur → Loa conversion) | cycle-038+ | Convert incur SKILL.md → Loa construct definitions (add capabilities, context slots, workflow phases). Relevant to Tool Pack archetype from RFC #131. NOT auto-generation — hand-authored SKILL.md remains primary. |
+| `defer_loading: true` runtime implementation | Upstream Loa Phase 2 | Config key exists, runtime doesn't honor it yet |
+| TOON for beads-health, golden_menu_options, constructs-loader | Follow-up | Additional integration targets beyond the MVP 2 |
+| Token baseline measurement tool | Follow-up | Measure session-start token cost of CLAUDE.loa.md + index.yaml files |
+| CTA rollout to additional commands | Follow-up | Extend beyond browse/status/install to all skill output paths |
+| TOON escaping rules + fixture tests | Follow-up | Handle commas, newlines in field values |
+
+### Out of Scope (Explicit)
+
+- Auto-generating SKILL.md from code definitions — hand-authored expertise documents are a core differentiator
+- Global skill installation — per-repo is correct
+- Serving constructs via MCP — skills are primary channel, MCP is for external integrations
+- Zod schema validation for skill I/O — requires TypeScript runtime layer that doesn't exist
+- Replacing exit codes with incur's sentinel pattern — same purpose, exit codes already implemented
+
+---
+
+## 7. Risks & Dependencies
+
+### R1: TOON Parsing by LLMs
+**Risk**: LLMs may not parse TOON as reliably as markdown tables.
+**Mitigation**: incur's benchmarks show 73.9% accuracy vs JSON's 69.7%. Gate behind config flag so users can revert to markdown if issues arise.
+
+### R2: CTA Noise
+**Risk**: Per-invocation CTAs could add unwanted output to every command.
+**Mitigation**: Default to `cta.enabled: false`. Limit to 3 CTAs. Use truenames only (no aliases that could confuse agents).
+
+### R3: Bash TOON Encoder Complexity
+**Risk**: Implementing a full TOON encoder in bash could be fragile.
+**Mitigation**: Implement only tabular array format (the high-value case). Simple arrays and nested structures stay in their current format. The encoder takes JSON input (from jq) and produces TOON output — jq does the heavy lifting.
+
+### R4: Runtime Contract Adoption
+**Risk**: Documenting the lazy-loading contract doesn't guarantee other runtimes implement it.
+**Mitigation**: The contract is informational and normative. Claude Code already implements it. The documentation makes the behavior discoverable for other runtime authors.
+
+### D1: Upstream Loa
+**Dependency**: loa#427 reports the `gpt-review-api.sh` verdict parsing bug and cross-platform gaps. These are framework issues, not blockers for this cycle.
+
+### D2: Construct Lifecycle RFC
+**Dependency**: Issue #131. The `workflow_next` field and hash staleness refinements extend the RFC's proposed features. Not blocked by RFC completion.

--- a/grimoires/loa/sdd.md
+++ b/grimoires/loa/sdd.md
@@ -1,209 +1,710 @@
-# SDD: Constructs Network Distribution Layer — Phase 3 Cross-Platform & Navigation
+# SDD: Agent-Native Output Protocol — TOON, CTAs, Lazy-Loading Contract
 
-**Cycle**: cycle-036
-**Created**: 2026-02-27
+**Cycle**: cycle-037
+**Created**: 2026-02-28
 **Status**: Draft
-**PRD**: `grimoires/loa/prd.md` (Constructs Network Distribution Layer)
-**Scope**: Phase 3 — F3.1, F3.2, F3.3
-**Depends on**: Phase 1 (complete), Phase 2 (complete)
+**PRD**: `grimoires/loa/prd.md` (Agent-Native Output Protocol)
+**Grounded in**:
+- `.claude/scripts/constructs-browse.sh` (`format_packs_human`, `format_packs_json`)
+- `.claude/scripts/constructs-install.sh` (`show_pack_status`, `compute_pack_hash`, `update_pack_meta`)
+- `.claude/scripts/constructs-lib.sh` (`compute_merkle_hash`, `get_registry_config`, print helpers)
+- `.claude/scripts/golden-path.sh` (`golden_detect_construct_journeys`, `golden_menu_options`)
+- `docs/integration/runtime-contract.md` (exit codes, checkpoint schema — no loading contract)
+- `packages/shared/src/types.ts` (`PackManifest`, `golden_path`, `workflow`)
+- `packages/shared/src/validation.ts` (Zod schemas)
+- `.loa.config.yaml` (existing config surface)
 
 ---
 
-## 1. Overview
+## 1. Architecture Overview
 
-Phase 3 closes the distribution layer with three features: standalone skill compatibility, per-invocation navigation, and local content-hash divergence detection.
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Config Layer                          │
+│  .loa.config.yaml                                       │
+│    output_format.tabular: md|toon|json                  │
+│    cta.enabled: false                                   │
+└────────┬────────────────────────┬───────────────────────┘
+         │                        │
+         ▼                        ▼
+┌─────────────────┐    ┌────────────────────┐
+│  toon-lib.sh    │    │  constructs-lib.sh │
+│  (NEW)          │    │  (MODIFIED)        │
+│                 │    │                    │
+│ toon_encode_    │    │ emit_cta()         │
+│   tabular()     │    │ get_output_format()│
+│ toon_detect_    │    │ format_tabular_    │
+│   uniform()     │    │   output()         │
+└────────┬────────┘    └───────┬────────────┘
+         │                     │
+         ▼                     ▼
+┌─────────────────────────────────────────────────────────┐
+│              Integration Points                         │
+│                                                         │
+│  constructs-browse.sh    format_packs_human() + TOON    │
+│  constructs-install.sh   show_pack_status() + TOON/CTA  │
+│  constructs-install.sh   install completion + CTA       │
+└─────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────────────────────┐
+│              Type & Contract Layer                       │
+│                                                         │
+│  types.ts          workflow_next field on PackManifest   │
+│  validation.ts     Zod schema update                    │
+│  runtime-contract  Skill Loading Contract section        │
+│  skill-cta.md      CTA protocol specification           │
+└─────────────────────────────────────────────────────────┘
+```
 
-### Key Discovery: Skills Are Already 90% Standalone
+### Design Principles
 
-The Loa framework skills (55 skills in `.claude/skills/`) have **zero** hard pack-level dependencies. The installed construct pack skills (23 skills across 5 packs) have two categories of non-standalone patterns:
-
-| Pattern | Count | Severity | Fix |
-|---------|-------|----------|-----|
-| `{context:...}` slots without fallback defaults | 23 skills | Medium — verbatim literal in output | Add default values in SKILL.md |
-| `grimoires/` read-dependencies | ~5 skills | Low — skills create the files they need | Document as optional |
-| `resources/` template refs | 2 skills | Low — bundled with pack | Note standalone limitation |
-| `persona.yaml` / `construct.yaml` refs | 0 skills | N/A | Already clean |
-
-### Existing Infrastructure
-
-| Feature | Status | File |
-|---------|--------|------|
-| `golden_path.detect_state` execution | Complete | `golden-path.sh:323` |
-| `GET /v1/packs/:slug/hash` | Complete | `packs.ts:1596` |
-| `compute_file_sha256` | Complete | `constructs-install.sh:1530` |
-| `update_pack_meta()` with git fields | Complete | `constructs-install.sh:913` |
-| Static "Next Steps" in skill outputs | Exists (6 skills) | Various SKILL.md files |
-| `validate-skills.sh` | Complete but no standalone check | `scripts/validate-skills.sh` |
-
-### What Needs Building
-
-| Feature | Type | Effort |
-|---------|------|--------|
-| F3.1: Standalone audit check in validate-skills.sh | Script extension | Small (~40 lines) |
-| F3.1: Context slot default documentation | Doc updates | Small (23 skills need headers) |
-| F3.2: `## Next Steps` output section standard | Spec + SKILL.md updates | Medium (~30 lines per skill) |
-| F3.2: golden_path declarations in construct.yaml | Manifest updates | Small (~10 lines per pack) |
-| F3.3: Local content hash at install time | Script extension | Small (~30 lines) |
-| F3.3: Hash comparison in status command | Script extension | Small (~20 lines) |
-
-Total new code: ~300 lines across scripts + doc updates across skills.
+1. **Config-gated**: All new behaviors default to OFF. Existing output is byte-identical.
+2. **jq does the heavy lifting**: TOON encoder receives JSON from `jq`, never parses raw text.
+3. **Additive only**: No functions removed, no signatures changed, no exit codes altered.
+4. **Cross-platform**: All bash follows `.claude/protocols/cross-platform-shell.md`.
 
 ---
 
-## 2. Detailed Design
+## 2. Component Design
 
-### 2.1 F3.1: Standalone SKILL.md Audit
+### 2.1 TOON Encoder Library (`toon-lib.sh`)
 
-#### 2.1a: Extend validate-skills.sh
+**File**: `.claude/scripts/lib/toon-lib.sh` (NEW)
 
-**File**: `.claude/scripts/validate-skills.sh`
+The encoder converts JSON arrays of uniform objects to TOON tabular format. "Uniform" means every object has the same set of keys.
 
-Add a `--standalone` flag that checks each skill SKILL.md for:
-1. `{context:...}` slots without documented defaults
-2. Hard file reads from `grimoires/` without "if exists" guards
-3. References to pack-level files (`persona.yaml`, `construct.yaml`) as runtime deps
-
-Report format:
-```
-STANDALONE AUDIT
-================
-PASS: 55/78 skills are fully standalone
-WARN: 23/78 skills have context slots needing defaults
-  - beacon/accepting-payments: {context:chain_config.default_token} (no default)
-  - crucible/validating-journeys: {context:qa_fixtures} (no default)
-  ...
-```
-
-#### 2.1b: Context Slot Default Documentation
-
-For each of the 23 skills using `{context:...}` slots, add a **Required Context** header at the top of the SKILL.md that documents:
-1. Which context keys are needed
-2. What the slot does
-3. A sensible placeholder/default when context is unavailable
-
-This is documentation only — the Loa runtime already handles context resolution. The goal is that an agent on Cursor/Copilot can read the SKILL.md and understand what values to substitute.
-
-**Pattern** (already used by beacon skills like `accepting-payments`):
-```markdown
-> **Required context:** `chain_config` overlay
-> Provide `chain_config.default_token`, `chain_config.network_id`, etc.
-> Without context, slots appear as `{context:...}` literals.
-```
-
-Scope: Review and document the 23 skills. Many already have partial documentation — standardize the format.
-
----
-
-### 2.2 F3.2: Per-Invocation Call-to-Actions
-
-#### Approach: SKILL.md Output Spec Enrichment
-
-Rather than building new runtime infrastructure, standardize the existing pattern where skills include `## Next Steps` in their output format spec. This is the lowest-infrastructure approach and works across all 37+ SKILL.md-compatible platforms.
-
-**Why not a runtime hook?** No packs currently declare `golden_path.commands` or `golden_path.detect_state`. Building a `constructs-loader.sh post-execution` hook would be dead code. Instead, formalize the static pattern that 6 skills already use.
-
-#### Standard
-
-Every skill that belongs to a pack with multiple skills SHOULD include a `## Next Steps` section at the end of its output format spec. The section:
-
-1. Lists 2-3 logical next commands from the same pack
-2. Uses conditional phrasing when suggestions depend on output state
-3. Always includes `/loa` as a fallback orientation command
-
-**Example** (for observer/analyzing-gaps):
-```markdown
-## Next Steps
-
-- `/file-gap` — File issues from gaps identified above
-- `/diagram` — Update state diagrams with new findings
-- `/loa` — Check your full workflow status
-```
-
-#### Scope
-
-Add `## Next Steps` sections to skills that don't already have them and belong to multi-skill packs. Prioritize the 5 installed packs (observer, artisan, crucible, beacon, gtm-collective).
-
-**Already have Next Steps** (6 skills): grounding-code, validating-journeys, analyzing-gaps, diagramming-states, accepting-payments, auditing-content
-
-**Need Next Steps**: Remaining skills in multi-skill packs (~15-20 skills).
-
-This is a documentation task, not a code change.
-
----
-
-### 2.3 F3.3: Content-Hash Staleness Detection
-
-#### 2.3a: Compute Local Hash at Install Time
-
-**File**: `constructs-install.sh` — modify `update_pack_meta()`
-
-After pack installation, compute the Merkle-root SHA-256 hash (same algorithm as the API):
+#### Core Functions
 
 ```bash
-compute_pack_hash() {
-    local pack_dir="$1"
-    # Compute SHA-256 of each file, sort by path, then hash the concatenation
-    find "$pack_dir" -type f -not -name '.license.json' -not -name '.constructs-meta.json' | \
-        sort | \
-        while read -r file; do
-            local rel_path="${file#$pack_dir/}"
-            local file_hash
-            file_hash=$(sha256sum "$file" | cut -d' ' -f1)
-            echo "$rel_path:$file_hash"
-        done | sha256sum | cut -d' ' -f1
+# Detect if a JSON array is uniform (all objects have same keys)
+# Args: $1 = JSON array string
+# Returns: 0 if uniform, 1 if not
+# Stdout: comma-separated key list if uniform
+toon_detect_uniform() {
+    local json="$1"
+
+    # Extract keys from first object, compare against all objects
+    local first_keys
+    first_keys=$(echo "$json" | jq -r '
+        if (type == "array" and length > 0 and (.[0] | type) == "object")
+        then [.[0] | keys[]] | join(",")
+        else empty
+        end
+    ' 2>/dev/null) || return 1
+
+    [[ -z "$first_keys" ]] && return 1
+
+    # Verify all objects have identical keys
+    local all_same
+    all_same=$(echo "$json" | jq -r --arg fk "$first_keys" '
+        [.[] | [keys[]] | join(",")] | all(. == $fk)
+    ' 2>/dev/null) || return 1
+
+    [[ "$all_same" == "true" ]] || return 1
+    echo "$first_keys"
+    return 0
+}
+
+# Encode a JSON array to TOON tabular format
+# Args:
+#   $1 = label (e.g., "packs")
+#   $2 = JSON array string (uniform objects)
+# Stdout: TOON tabular output
+# Returns: 0 on success, 1 on non-uniform/non-array input
+toon_encode_tabular() {
+    local label="$1"
+    local json="$2"
+
+    # Handle empty array as valid case — emit header-only
+    local count
+    count=$(echo "$json" | jq 'if type == "array" then length else -1 end' 2>/dev/null) || return 1
+    [[ "$count" == "-1" ]] && return 1
+
+    if [[ "$count" == "0" ]]; then
+        echo "${label}[0]{}:"
+        return 0
+    fi
+
+    # Detect uniformity and get keys
+    local keys
+    keys=$(toon_detect_uniform "$json") || {
+        # Non-uniform: return empty (caller handles fallback)
+        return 1
+    }
+
+    # Header: label[count]{field1,field2,...}:
+    echo "${label}[${count}]{${keys}}:"
+
+    # Value rows: CSV-style, 2-space indent
+    echo "$json" | jq -r --arg keys "$keys" '
+        ($keys | split(",")) as $fields |
+        .[] | [.[$fields[]]] | map(tostring) | "  " + join(",")
+    '
 }
 ```
 
-Store result in `.constructs-meta.json`:
+#### Design Decisions
+
+- **jq dependency**: Required. Already used by every constructs script. No new dependency.
+- **No escaping in MVP**: Field values containing commas are not escaped. PRD defers escaping rules to a follow-up cycle. MVP data (pack slugs, names, versions, status) contains no commas.
+- **Return code convention**: `toon_encode_tabular` returns 1 on non-uniform data. Callers fall back to their current format.
+- **Label convention**: The label describes the collection (e.g., `packs`, `skills`, `tasks`).
+
+---
+
+### 2.2 Output Format Routing (`constructs-lib.sh`)
+
+**File**: `.claude/scripts/constructs-lib.sh` (MODIFIED — add 3 functions)
+
+```bash
+# Read output_format.tabular from config
+# Returns: "md" (default), "toon", or "json"
+get_output_format() {
+    local config_file=".loa.config.yaml"
+    local default="md"
+
+    if [[ ! -f "$config_file" ]] || ! command -v yq &>/dev/null; then
+        echo "$default"
+        return 0
+    fi
+
+    local value
+    value=$(yq eval '.output_format.tabular // "md"' "$config_file" 2>/dev/null) || {
+        echo "$default"
+        return 0
+    }
+
+    # Validate enum
+    case "$value" in
+        md|toon|json) echo "$value" ;;
+        *) echo "$default" ;;
+    esac
+}
+
+# Route tabular output through the configured format
+# Args:
+#   $1 = label (e.g., "packs")
+#   $2 = JSON array of uniform objects (TOON-shaped: flat keys, uniform)
+#   $3 = original payload (passed to fallback_fn unchanged — preserves input contract)
+#   $4 = fallback function name (called when format is "md" or TOON fails)
+# Stdin: not used
+# Stdout: formatted output
+#
+# IMPORTANT: The $2 (tabular JSON) and $3 (original payload) are distinct.
+# TOON encodes from $2 (flat, uniform). Fallback calls $4 with $3 (original shape).
+# This ensures TOON failure never passes incompatible data to markdown formatters.
+format_tabular_output() {
+    local label="$1"
+    local tabular_json="$2"
+    local original_payload="$3"
+    local fallback_fn="$4"
+
+    local fmt
+    fmt=$(get_output_format)
+
+    case "$fmt" in
+        toon)
+            # Source toon-lib if not already loaded
+            local script_dir
+            script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+            if [[ -f "$script_dir/lib/toon-lib.sh" ]]; then
+                # shellcheck source=lib/toon-lib.sh
+                source "$script_dir/lib/toon-lib.sh"
+                toon_encode_tabular "$label" "$tabular_json" && return 0
+            fi
+            # Fallback: TOON failed or lib missing — use original payload
+            "$fallback_fn" "$original_payload"
+            ;;
+        json)
+            echo "$tabular_json" | jq '.'
+            ;;
+        md|*)
+            "$fallback_fn" "$original_payload"
+            ;;
+    esac
+}
+```
+
+---
+
+### 2.3 CTA Emission (`constructs-lib.sh`)
+
+**File**: `.claude/scripts/constructs-lib.sh` (MODIFIED — add 2 functions)
+
+```bash
+# Check if CTAs are enabled in config
+# Returns: 0 if enabled, 1 if disabled
+is_cta_enabled() {
+    local config_file=".loa.config.yaml"
+
+    if [[ ! -f "$config_file" ]] || ! command -v yq &>/dev/null; then
+        return 1
+    fi
+
+    local enabled
+    enabled=$(yq eval '.cta.enabled // false' "$config_file" 2>/dev/null) || return 1
+
+    [[ "$enabled" == "true" ]]
+}
+
+# Emit context-sensitive CTA block after command output
+# Args:
+#   $1 = current command context (e.g., "browse", "status", "install")
+#   $2 = pack slug (optional — for pack-specific CTAs)
+# Stdout: Next: block with up to 3 CTAs
+emit_cta() {
+    is_cta_enabled || return 0
+
+    local context="$1"
+    local pack_slug="${2:-}"
+
+    echo ""
+    echo "Next:"
+
+    case "$context" in
+        browse)
+            echo "/constructs install <slug> — Install a construct pack"
+            echo "/constructs status — Check installed pack versions"
+            echo "/loa — View workflow status"
+            ;;
+        status)
+            echo "/constructs browse — Browse available packs"
+            echo "/constructs install <slug> — Install or update a pack"
+            echo "/loa — View workflow status"
+            ;;
+        install)
+            # Post-install: suggest the pack's quick_start if available
+            if [[ -n "$pack_slug" ]]; then
+                local pack_dir
+                pack_dir="$(get_registry_install_dir)/$pack_slug"
+                local quick_cmd=""
+                if [[ -f "$pack_dir/construct.yaml" ]] && command -v yq &>/dev/null; then
+                    quick_cmd=$(yq eval '.quick_start.command // ""' "$pack_dir/construct.yaml" 2>/dev/null)
+                fi
+                if [[ -n "$quick_cmd" ]]; then
+                    echo "$quick_cmd — Get started with $pack_slug"
+                fi
+            fi
+            echo "/constructs status — Verify installation"
+            echo "/loa — View workflow status"
+            ;;
+    esac
+}
+```
+
+#### CTA Design Decisions
+
+- **Static mapping in MVP**: CTAs are hardcoded per command context. Dynamic lookup from `golden_path.commands` + `truename_map` is deferred — the existing `detect_state` infrastructure would need to be extended to support per-invocation state, which is out of scope.
+- **Truenames only**: CTAs use `/constructs install`, not `/build` or golden path aliases.
+- **Max 3**: Each case emits exactly 2-3 CTAs.
+- **No-op when disabled**: `emit_cta` returns immediately when `cta.enabled: false`.
+
+---
+
+### 2.4 CTA Protocol Specification
+
+**File**: `.claude/protocols/skill-cta.md` (NEW)
+
+Content defines the output protocol:
+
+```markdown
+# Skill CTA Protocol
+
+## Format
+
+After primary command output, CTA-enabled commands append:
+
+    Next:
+    <command-1> — <description>
+    <command-2> — <description>
+
+## Rules
+
+1. Maximum 3 CTAs per invocation
+2. CTAs appear after main output, before any grimoire writes
+3. Use truenames (e.g., `/implement`) not golden path aliases (e.g., `/build`)
+4. Command-context-based: each CTA-enabled command has a static mapping of
+   relevant next steps (cycle-037 MVP). Dynamic workflow-state-derived CTAs
+   using `golden_path.commands` + `truename_map` are future scope.
+5. Gated by `cta.enabled: true` in `.loa.config.yaml`
+
+## Enabled Commands (cycle-037 MVP)
+
+- `constructs browse`
+- `constructs status`
+- `constructs install`
+```
+
+---
+
+### 2.5 Config Surface
+
+**File**: `.loa.config.yaml` (MODIFIED)
+
+Add two new top-level sections after existing config:
+
+```yaml
+# Output format for tabular CLI data (cycle-037)
+# Values: md (default), toon, json
+output_format:
+  tabular: md
+
+# Per-invocation call-to-action navigation (cycle-037)
+# When enabled, CLI commands append a "Next:" block with suggested next steps
+cta:
+  enabled: false
+```
+
+**Config validation**: Enum validation for `output_format.tabular` happens in `get_output_format()` (returns default on invalid value). Boolean validation for `cta.enabled` happens in `is_cta_enabled()`.
+
+---
+
+### 2.6 Lazy-Loading Contract
+
+**File**: `docs/integration/runtime-contract.md` (MODIFIED)
+
+Add new section `## Skill Loading Contract` after the existing Checkpoint Schema section:
+
+```markdown
+## Skill Loading Contract
+
+### Session-Start Behavior
+
+At session start, the runtime loads ONLY lightweight metadata:
+1. `CLAUDE.loa.md` framework instructions (skill command table)
+2. Pack `index.yaml` files (name, description, capabilities per skill)
+
+Full `SKILL.md` files are NOT loaded at session start.
+
+### On-Demand Loading Trigger
+
+When the agent decides to invoke a skill:
+1. Runtime reads the full `SKILL.md` for that skill
+2. Skill body is injected into the agent's context
+3. Skill executes with full instructions available
+
+### Token Baseline
+
+| Component | Approximate Size |
+|-----------|-----------------|
+| Skill entry in command table | ~40 tokens/skill |
+| Full SKILL.md body | ~300-2000 tokens/skill |
+| index.yaml metadata | ~50 tokens/skill |
+
+Loading 49 skills at session start: ~2,000 tokens (index only)
+Loading 49 skills eagerly: ~15,000-100,000 tokens (wasteful)
+
+### Output Format Contract
+
+When `output_format.tabular` is configured in `.loa.config.yaml`:
+- `md` (default): Markdown tables and plain-text labels
+- `toon`: TOON tabular encoding (header + CSV rows)
+- `json`: Raw JSON array output
+
+Runtimes SHOULD respect this config when rendering tabular data.
+
+### Defer Loading (Non-Normative — Future Extension)
+
+> **Note**: This section documents a future capability. The `defer_loading`
+> config key exists but is not implemented in any runtime as of cycle-037.
+> Runtimes are not expected to implement this behavior yet.
+
+When `defer_loading: true` is set in `.loa.config.yaml`, the runtime MAY
+defer even `index.yaml` loading until a skill discovery command
+(`/constructs browse`, `/loa`) is invoked. This further reduces session-start
+token cost at the expense of requiring an explicit discovery step.
+```
+
+---
+
+### 2.7 Type System Extension
+
+**File**: `packages/shared/src/types.ts` (MODIFIED)
+
+Add `workflow_next` field to `PackManifest` after the existing `methodology` field:
+
+```typescript
+  /** Cross-construct navigation hints (cycle-037, FR-2.4) */
+  workflow_next?: Array<{
+    /** Slug of suggested next construct */
+    construct: string;
+    /** Why this construct complements the current one */
+    reason: string;
+    /** Workflow state that activates this suggestion (optional) */
+    trigger?: string;
+  }>;
+```
+
+**File**: `packages/shared/src/validation.ts` (MODIFIED)
+
+Add corresponding Zod schema alongside existing pack manifest validation:
+
+```typescript
+const workflowNextSchema = z.array(z.object({
+  construct: z.string(),
+  reason: z.string(),
+  trigger: z.string().optional(),
+})).optional();
+```
+
+Add `workflow_next: workflowNextSchema` to the pack manifest Zod schema.
+
+---
+
+### 2.8 Hash Staleness Refinement
+
+#### End-to-End Data Flow
+
+The hash staleness feature requires content hashes at two points: **local** (computed at install time) and **registry** (fetched from API). Both paths already exist in the codebase — this section documents the full contract and adds the missing `check-updates` comparison.
+
+```
+INSTALL TIME:
+  compute_pack_hash() → compute_merkle_hash() → sha256:...
+      ↓
+  update_pack_meta() → .constructs-meta.json { content_hash: "sha256:..." }
+
+STATUS/CHECK-UPDATES TIME:
+  LOCAL:    jq '.installed_packs["slug"].content_hash' .constructs-meta.json
+  REGISTRY: curl ${registry_url}/packs/${slug}/hash → .data.hash
+
+  COMPARE:
+    both present + match     → SYNCED
+    both present + mismatch  → DIVERGED
+    local missing            → UNKNOWN (reinstall to compute)
+    registry missing         → UNKNOWN (API unavailable)
+```
+
+**Already implemented** (cycle-036):
+- `compute_pack_hash()` in `constructs-install.sh:934` — calls `compute_merkle_hash()`
+- `update_pack_meta()` in `constructs-install.sh:951` — persists `content_hash` in `.constructs-meta.json`
+- `show_pack_status()` in `constructs-install.sh:2047` — reads both hashes, displays SYNCED/DIVERGED/BEHIND/UNKNOWN
+- `GET /packs/:slug/hash` API endpoint (API side)
+
+**New in this cycle**:
+
+**File**: `.claude/skills/browsing-constructs/SKILL.md` (MODIFIED)
+
+Update the `.constructs-meta.json` documentation example to include the `content_hash` field:
+
 ```json
 {
   "installed_packs": {
     "artisan": {
-      "version": "1.0.0",
+      "version": "1.2.0",
       "content_hash": "sha256:a3f2c1...",
-      ...
+      "installed_at": "2026-02-28T00:00:00Z",
+      "source_type": "git"
     }
   }
 }
 ```
 
-#### 2.3b: Compare Hashes in Status Command
+**File**: `.claude/scripts/constructs-loader.sh` (MODIFIED)
 
-**File**: `constructs-install.sh` — modify `show_pack_status()`
+In the `check-updates` subcommand, add content hash comparison after version comparison. The `check-updates` path currently only compares version strings. Add hash retrieval and comparison:
 
-Read local `content_hash` from meta, compare against registry hash (already fetched). Display:
+```bash
+# After existing version comparison:
+# 1. Read local hash from meta (already persisted by update_pack_meta)
+local local_hash
+local_hash=$(jq -r ".installed_packs[\"$slug\"].content_hash // \"\"" "$meta_path" 2>/dev/null)
 
-| Local Hash | Registry Hash | Display |
-|-----------|--------------|---------|
-| Match | Match | `[SYNCED]` |
-| Different | Present | `[DIVERGED]` — local files modified |
-| Present | Different version | `[BEHIND]` — registry has newer version |
-| Missing | Present | `[UNKNOWN]` — reinstall to compute hash |
+# 2. Fetch registry hash (same endpoint used by show_pack_status)
+local registry_hash=""
+local hash_file
+hash_file=$(mktemp)
+chmod 600 "$hash_file"
+local hash_code
+hash_code=$(curl -s -w "%{http_code}" \
+    --proto =https --tlsv1.2 --max-time 10 \
+    "${registry_url}/packs/${slug}/hash" \
+    -o "$hash_file" 2>/dev/null) || hash_code="000"
+if [[ "$hash_code" == "200" ]]; then
+    registry_hash=$(jq -r '.data.hash // ""' "$hash_file" 2>/dev/null)
+fi
+rm -f "$hash_file"
 
----
+# 3. Compare: version match + hash divergence = DIVERGED
+if [[ "$local_version" == "$registry_version" ]]; then
+    if [[ -n "$local_hash" && -n "$registry_hash" && "$local_hash" != "$registry_hash" ]]; then
+        status="DIVERGED"
+    fi
+fi
+```
 
-## 3. Files Modified
-
-| File | Change Type | Description |
-|------|------------|-------------|
-| `.claude/scripts/validate-skills.sh` | Modified | Add `--standalone` audit flag |
-| `.claude/scripts/constructs-install.sh` | Modified | `compute_pack_hash()` + store in meta + compare in status |
-| `.claude/constructs/packs/*/skills/*/SKILL.md` | Modified | Context slot defaults + Next Steps sections |
-
-**No API changes needed** — all infrastructure exists.
-
----
-
-## 4. Testing Strategy
-
-| Test | Type | Validates |
-|------|------|-----------:|
-| `validate-skills.sh --standalone` passes | Unit | F3.1 — standalone audit |
-| Context slot documentation present for all 23 skills | Manual audit | F3.1 — degradation docs |
-| `## Next Steps` present in all multi-pack skills | Manual audit | F3.2 — CTA coverage |
-| `content_hash` written to meta on install | Integration | F3.3 — hash computation |
-| `status` shows SYNCED/DIVERGED correctly | Integration | F3.3 — hash comparison |
+This surfaces fork-drift (same version, different content) which is the case study from RFC #131 (Observer in midi-interface: 23 skills forked from 6).
 
 ---
 
-*"Standalone compatibility is not about removing the construct layer. It's about making it optional."*
+## 3. Integration Points
+
+### 3.1 `constructs-browse.sh` — Pack Listing
+
+**Current**: `format_packs_human()` outputs icon + name + description in plain text.
+
+**Change**: ALL tabular output routes through `format_tabular_output()`. The existing `--json` flag takes precedence (explicit user request), otherwise the config-driven router handles `md|toon|json`:
+
+```bash
+# In cmd_list(), replace the direct format call:
+if [[ "$json_output" == true ]]; then
+    # Explicit --json flag always wins (backwards compat)
+    format_packs_json "$packs_json"
+else
+    # Build flat tabular JSON for TOON/json modes
+    local toon_json
+    toon_json=$(echo "$packs_json" | jq '[
+        .data[]? | {
+            slug: .slug,
+            name: .name,
+            skills: (.skills_count // (.manifest.skills | length?) // 0),
+            version: (.latest_version.version // .version // "1.0.0"),
+            tier: (.tier_required // .tier // "free")
+        }
+    ]')
+    # Route: toon→TOON encoder, json→raw JSON, md→format_packs_human
+    # Note: $toon_json is the flat shape for TOON/json, $packs_json is the
+    # original API envelope passed to format_packs_human on fallback
+    format_tabular_output "packs" "$toon_json" "$packs_json" "format_packs_human"
+fi
+
+# Append CTAs
+emit_cta "browse"
+```
+
+**TOON output example**:
+```
+packs[6]{slug,name,skills,version,tier}:
+  artisan,Artisan,14,1.2.0,free
+  observer,Observer,6,1.0.2,free
+  crucible,Crucible,5,1.0.0,free
+  beacon,Beacon,6,1.0.0,free
+  gtm-collective,GTM Collective,8,1.0.0,free
+  protocol,Protocol,10,1.0.0,free
+```
+
+### 3.2 `constructs-install.sh` — Pack Status
+
+**Current**: `show_pack_status()` outputs label-value pairs as plain text per pack.
+
+**Change**: Collect all pack status data into a JSON array first, then route through `format_tabular_output()`. The existing `show_pack_status()` function is preserved as the markdown fallback:
+
+```bash
+# In the status command handler:
+# Step 1: Collect status data for ALL packs into a JSON array
+local status_json="[]"
+for slug in "${installed_slugs[@]}"; do
+    local local_version registry_version status_label local_hash registry_hash
+    # ... existing fetch logic for local + registry data ...
+    # ... existing hash comparison logic (SYNCED/DIVERGED/BEHIND/UNKNOWN) ...
+    status_json=$(echo "$status_json" | jq --arg s "$slug" \
+        --arg v "$local_version" --arg rv "$registry_version" \
+        --arg st "$status_label" \
+        '. += [{"slug":$s,"local":$v,"registry":$rv,"status":$st}]')
+done
+
+# Step 2: Route through format_tabular_output
+# _show_all_packs_md() iterates status_json and calls show_pack_status() per pack
+# This is a new wrapper that preserves the existing per-pack output format
+format_tabular_output "status" "$status_json" "$status_json" "_show_all_packs_md"
+
+# Step 3: Append CTAs
+emit_cta "status"
+```
+
+The `_show_all_packs_md()` wrapper iterates the JSON array and calls the existing `show_pack_status()` for each entry, preserving byte-identical markdown output when `output_format.tabular: md`.
+
+### 3.3 `constructs-install.sh` — Install Completion
+
+**Current**: `execute_post_install_hook()` displays quick_start suggestion.
+
+**Change**: After existing post-install output, append CTA:
+
+```bash
+# At end of install command:
+emit_cta "install" "$pack_slug"
+```
+
+---
+
+## 4. Files Manifest
+
+| File | Action | Description |
+|------|--------|-------------|
+| `.claude/scripts/lib/toon-lib.sh` | CREATE | TOON tabular encoder (2 functions) |
+| `.claude/protocols/skill-cta.md` | CREATE | CTA output protocol specification |
+| `.claude/scripts/constructs-lib.sh` | MODIFY | Add `get_output_format()`, `format_tabular_output()`, `is_cta_enabled()`, `emit_cta()` |
+| `.claude/scripts/constructs-browse.sh` | MODIFY | Route through `format_tabular_output()` + `emit_cta()` |
+| `.claude/scripts/constructs-install.sh` | MODIFY | TOON in `show_pack_status()` + CTA in install/status |
+| `.claude/scripts/constructs-loader.sh` | MODIFY | Hash divergence comparison in `check-updates` |
+| `docs/integration/runtime-contract.md` | MODIFY | Add Skill Loading Contract section |
+| `packages/shared/src/types.ts` | MODIFY | Add `workflow_next` to `PackManifest` |
+| `packages/shared/src/validation.ts` | MODIFY | Add `workflow_next` Zod schema |
+| `.loa.config.yaml` | MODIFY | Add `output_format` and `cta` sections |
+| `.claude/skills/browsing-constructs/SKILL.md` | MODIFY | Add `content_hash` to meta example |
+
+**Total**: 2 new files, 9 modified files.
+
+---
+
+## 5. Testing Strategy
+
+### 5.1 Unit: TOON Encoder
+
+- Uniform JSON array → correct TOON header + CSV rows
+- Non-uniform JSON array → return code 1 (fallback)
+- Empty array → `label[0]{}: ` (no rows)
+- Single-element array → correct output
+- Nested values → `tostring` produces flat representation
+
+### 5.2 Integration: Output Format Routing
+
+- `output_format.tabular: md` → identical output to pre-cycle-037 (snapshot comparison)
+- `output_format.tabular: toon` → TOON format for `constructs browse` and `constructs status`
+- `output_format.tabular: json` → raw JSON for both targets
+- Missing config → defaults to `md`
+- Invalid config value → defaults to `md`
+
+### 5.3 Integration: CTA Emission
+
+- `cta.enabled: false` → no `Next:` block in any command output
+- `cta.enabled: true` + `constructs browse` → `Next:` block with 3 CTAs
+- `cta.enabled: true` + `constructs status` → `Next:` block with 3 CTAs
+- `cta.enabled: true` + `constructs install <slug>` → `Next:` block with quick_start + 2 CTAs
+- Missing config → no CTAs (default: false)
+
+### 5.4 Regression: Default Output
+
+- Capture current `constructs browse` output as snapshot
+- Capture current `constructs status` output as snapshot
+- After changes, verify byte-identical output with default config
+
+### 5.5 Type System
+
+- `workflow_next` field accepts valid array of `{construct, reason, trigger?}`
+- Zod validation rejects malformed `workflow_next` entries
+- Existing manifests without `workflow_next` pass validation (field is optional)
+
+---
+
+## 6. Risks & Mitigations
+
+### R1: jq Availability
+
+**Risk**: `toon-lib.sh` requires `jq`.
+**Mitigation**: `jq` is already required by all constructs scripts. `constructs-lib.sh` checks for `jq` at load time. If missing, TOON encoding silently falls back to markdown.
+
+### R2: Large Pack Listings
+
+**Risk**: TOON output for 50+ packs could be long.
+**Mitigation**: Current markdown output is longer for the same data. TOON is strictly more compact.
+
+### R3: Config Parsing Overhead
+
+**Risk**: `get_output_format()` reads `.loa.config.yaml` on every tabular output call.
+**Mitigation**: `yq eval` is fast (~10ms). Only 2 integration points in MVP. Caching could be added later if needed.
+
+### R4: CTA Staleness
+
+**Risk**: Hardcoded CTA suggestions may become stale as commands change.
+**Mitigation**: CTAs reference core constructs commands that are stable. The protocol spec in `skill-cta.md` documents which commands are CTA-enabled. Dynamic CTAs from `golden_path.commands` are future scope.

--- a/grimoires/loa/sprint.md
+++ b/grimoires/loa/sprint.md
@@ -1,75 +1,121 @@
-# Sprint Plan: Distribution Layer Phase 3 — Cross-Platform & Navigation
+# Sprint Plan: Agent-Native Output Protocol — TOON, CTAs, Lazy-Loading Contract
 
-**Cycle**: cycle-036 (Phase 3)
-**SDD**: `grimoires/loa/sdd.md` (Phase 3 Cross-Platform & Navigation)
-**Branch**: `feat/cycle-036-distribution-layer`
-**Depends on**: Phase 1 (merged to feature branch), Phase 2 (merged to feature branch)
-
----
-
-## Sprint 1: Content-Hash Staleness Detection (3 tasks)
-
-### T1.1: Add compute_pack_hash() function
-**File**: `.claude/scripts/constructs-install.sh`
-**Change**: Add function that computes Merkle-root SHA-256 of all pack files (same algorithm as API)
-**AC**: Function returns consistent hash for same file set
-
-### T1.2: Store content_hash in .constructs-meta.json at install time
-**File**: `.claude/scripts/constructs-install.sh`
-**Change**: Call `compute_pack_hash()` in `update_pack_meta()`, write `content_hash` field
-**AC**: After `constructs-install.sh pack <slug>`, meta file has `content_hash` for installed pack
-
-### T1.3: Compare local vs registry hash in status command
-**File**: `.claude/scripts/constructs-install.sh`
-**Change**: In `show_pack_status()`, read local `content_hash` from meta and compare against registry hash (already fetched). Show SYNCED/DIVERGED/BEHIND/UNKNOWN indicators.
-**AC**: `constructs-install.sh status` shows hash comparison results
+**Cycle**: cycle-037
+**PRD**: `grimoires/loa/prd.md`
+**SDD**: `grimoires/loa/sdd.md`
+**Branch**: `feat/cycle-037-agent-native-output`
 
 ---
 
-## Sprint 2: Standalone Audit (2 tasks)
+## Sprint 1: TOON Encoder + Output Format Routing (5 tasks)
 
-### T2.1: Add --standalone flag to validate-skills.sh
-**File**: `.claude/scripts/validate-skills.sh`
-**Change**: Add audit that checks SKILL.md files for:
-1. `{context:...}` slots without documented defaults
-2. Hard reads from grimoires/ without guards
-3. Pack-level file references as runtime deps
-Report PASS/WARN/FAIL per skill with actionable details.
-**AC**: `validate-skills.sh --standalone` reports on all installed skills
+### T1.1: Create `toon-lib.sh` encoder library
+**File**: `.claude/scripts/lib/toon-lib.sh` (NEW)
+**Change**: Implement `toon_detect_uniform()` and `toon_encode_tabular()` per SDD §2.1. Handle empty arrays (`label[0]{}:`), non-uniform arrays (return 1), and standard tabular encoding.
+**AC**:
+- `toon_detect_uniform '[]'` returns 1 (empty handled in encoder)
+- `toon_detect_uniform '[{"a":1,"b":2},{"a":3,"b":4}]'` returns `a,b`
+- `toon_detect_uniform '[{"a":1},{"b":2}]'` returns 1
+- `toon_encode_tabular "packs" '[{"slug":"artisan","skills":14}]'` outputs `packs[1]{slug,skills}:\n  artisan,14`
+- `toon_encode_tabular "test" '[]'` outputs `test[0]{}:`
 
-### T2.2: Standardize Required Context headers in construct pack skills
-**Files**: `.claude/constructs/packs/*/skills/*/SKILL.md` (23 skills with context slots)
-**Change**: Ensure each skill using `{context:...}` has a standardized Required Context header documenting needed keys, purpose, and standalone degradation behavior.
-**AC**: All 23 context-slot skills have documented defaults; `validate-skills.sh --standalone` shows 0 WARN
+### T1.2: Add `get_output_format()` to `constructs-lib.sh`
+**File**: `.claude/scripts/constructs-lib.sh` (MODIFY)
+**Change**: Add `get_output_format()` function per SDD §2.2. Reads `output_format.tabular` from `.loa.config.yaml`, validates enum (`md|toon|json`), defaults to `md`.
+**AC**: Returns `md` when config missing, `md` when key missing, `toon` when set to `toon`, `md` when set to invalid value.
 
----
+### T1.3: Add `format_tabular_output()` to `constructs-lib.sh`
+**File**: `.claude/scripts/constructs-lib.sh` (MODIFY)
+**Change**: Add `format_tabular_output()` router per SDD §2.2. Takes label, tabular JSON, original payload, fallback function. Routes to TOON encoder / JSON / fallback based on config.
+**AC**:
+- With `output_format.tabular: md` → calls fallback with original payload
+- With `output_format.tabular: toon` → outputs TOON format
+- With `output_format.tabular: toon` + non-uniform data → falls back to fallback with original payload
+- With `output_format.tabular: json` → outputs formatted JSON
 
-## Sprint 3: Per-Invocation CTAs (2 tasks)
+### T1.4: Integrate TOON in `constructs-browse.sh`
+**File**: `.claude/scripts/constructs-browse.sh` (MODIFY)
+**Change**: In `cmd_list()`, build flat tabular JSON and route through `format_tabular_output()` per SDD §3.1. Preserve `--json` flag precedence.
+**AC**:
+- Default config (`md`): Output byte-identical to pre-change behavior
+- `output_format.tabular: toon`: Pack listing renders as TOON table
+- `--json` flag: Still works regardless of config
 
-### T3.1: Add ## Next Steps to skills that lack them
-**Files**: `.claude/constructs/packs/*/skills/*/SKILL.md`
-**Change**: Add `## Next Steps` output section to multi-pack skills that don't already have one. Each section lists 2-3 logical next commands from the same pack + `/loa` fallback.
-**AC**: All skills in multi-skill packs have Next Steps sections
-
-### T3.2: End-to-end validation
-**Validation steps**:
-1. Verify `validate-skills.sh --standalone` passes
-2. Verify `bash -n` on all modified scripts
-3. Verify content_hash field present in meta schema
-4. Verify existing install/browse/sync commands unaffected
-**AC**: All features work, no regressions
-
----
-
-## Task Summary
-
-| Sprint | Tasks | Files | Est. Lines |
-|--------|-------|-------|-----------:|
-| 1 | 3 | 1 modified (constructs-install.sh) | ~60 |
-| 2 | 2 | 1 modified + ~23 SKILL.md updates | ~80 + docs |
-| 3 | 2 | ~15 SKILL.md updates + validation | docs |
-| **Total** | **7** | **2 scripts + ~38 SKILL.md files** | **~140 + docs** |
+### T1.5: Integrate TOON in `constructs-install.sh` status
+**File**: `.claude/scripts/constructs-install.sh` (MODIFY)
+**Change**: Refactor status command to collect pack data into JSON array, route through `format_tabular_output()` per SDD §3.2. Create `_show_all_packs_md()` wrapper for markdown fallback.
+**AC**:
+- Default config (`md`): Output byte-identical to pre-change behavior
+- `output_format.tabular: toon`: Status renders as TOON table with slug, local, registry, status columns
 
 ---
 
-*"Cross-platform compatibility is not about the lowest common denominator. It's about graceful enrichment — each platform gets the best it can use."*
+## Sprint 2: CTA Protocol + Emission (4 tasks)
+
+### T2.1: Create `skill-cta.md` protocol file
+**File**: `.claude/protocols/skill-cta.md` (NEW)
+**Change**: Write the CTA protocol specification per SDD §2.4. Document format, rules (max 3, truenames only, command-context-based), and enabled commands.
+**AC**: Protocol file exists with Format, Rules, and Enabled Commands sections.
+
+### T2.2: Add `is_cta_enabled()` and `emit_cta()` to `constructs-lib.sh`
+**File**: `.claude/scripts/constructs-lib.sh` (MODIFY)
+**Change**: Implement `is_cta_enabled()` (reads `cta.enabled` from config) and `emit_cta()` (static CTA mapping per command context) per SDD §2.3.
+**AC**:
+- `cta.enabled: false` → `emit_cta` returns immediately (no output)
+- `cta.enabled: true` + context `browse` → outputs `Next:` block with 3 CTAs
+- `cta.enabled: true` + context `install` + pack slug → outputs quick_start CTA if available
+
+### T2.3: Integrate CTAs in browse, status, install
+**Files**: `constructs-browse.sh`, `constructs-install.sh` (MODIFY)
+**Change**: Call `emit_cta "browse"` at end of `cmd_list()`, `emit_cta "status"` at end of status command, `emit_cta "install" "$pack_slug"` at end of install command.
+**AC**:
+- Default config (`cta.enabled: false`): No `Next:` blocks in any output
+- `cta.enabled: true`: All 3 commands append `Next:` block
+
+### T2.4: Add config sections to `.loa.config.yaml`
+**File**: `.loa.config.yaml` (MODIFY)
+**Change**: Add `output_format.tabular: md` and `cta.enabled: false` sections per SDD §2.5.
+**AC**: Config file has both new sections with correct defaults. Existing config unchanged.
+
+---
+
+## Sprint 3: Contract, Types, Hash Refinement (5 tasks)
+
+### T3.1: Add Skill Loading Contract to `runtime-contract.md`
+**File**: `docs/integration/runtime-contract.md` (MODIFY)
+**Change**: Add `## Skill Loading Contract` section per SDD §2.6. Includes session-start behavior, on-demand trigger, token baseline table, output format contract, and defer_loading (marked non-normative).
+**AC**: Section exists with all 5 subsections. `defer_loading` is marked as non-normative future extension.
+
+### T3.2: Add `workflow_next` to `PackManifest` types
+**File**: `packages/shared/src/types.ts` (MODIFY)
+**Change**: Add `workflow_next` optional field to `PackManifest` interface per SDD §2.7.
+**AC**: Field accepts `Array<{construct: string, reason: string, trigger?: string}>`. Existing manifests compile without changes.
+
+### T3.3: Add `workflow_next` Zod schema
+**File**: `packages/shared/src/validation.ts` (MODIFY)
+**Change**: Add `workflowNextSchema` and include in pack manifest Zod schema per SDD §2.7.
+**AC**: Zod validation accepts manifests with and without `workflow_next`. Invalid shapes rejected.
+
+### T3.4: Hash divergence in `constructs-loader.sh` check-updates
+**File**: `.claude/scripts/constructs-loader.sh` (MODIFY)
+**Change**: In `check-updates`, after version comparison, add content hash fetch + comparison per SDD §2.8. Same version + different hash = `DIVERGED`.
+**AC**: `check-updates` reports `DIVERGED` when versions match but content hashes differ.
+
+### T3.5: Update SKILL.md schema documentation
+**File**: `.claude/skills/browsing-constructs/SKILL.md` (MODIFY)
+**Change**: Update `.constructs-meta.json` example to include `content_hash` field per SDD §2.8.
+**AC**: Documentation example shows `content_hash: "sha256:a3f2c1..."` in installed_packs entry.
+
+---
+
+## Verification Checklist
+
+- [ ] `output_format.tabular: md` → all commands produce byte-identical output (snapshot comparison)
+- [ ] `output_format.tabular: toon` → `constructs browse` and `constructs status` produce TOON output
+- [ ] `cta.enabled: false` → no `Next:` blocks anywhere
+- [ ] `cta.enabled: true` → browse, status, install all have `Next:` blocks
+- [ ] `workflow_next` in types.ts compiles
+- [ ] `workflow_next` in validation.ts validates
+- [ ] `runtime-contract.md` has Skill Loading Contract section
+- [ ] `check-updates` detects hash divergence
+- [ ] No `sed -i`, `readlink -f`, `grep -P`, or `timeout` in new code

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -327,6 +327,18 @@ export interface PackManifest {
   /** Construct capability tier (#128) */
   tier?: 'L1' | 'L2' | 'L3';
 
+  // === Agent-Native Output fields (cycle-037) ===
+
+  /** Cross-construct navigation hints for CTA protocol */
+  workflow_next?: Array<{
+    /** Slug of suggested next construct */
+    construct: string;
+    /** Why this construct complements the current one */
+    reason: string;
+    /** Workflow state that activates this suggestion (optional) */
+    trigger?: string;
+  }>;
+
   // === Construct Lifecycle fields (FR-1, cycle-032) ===
 
   /** Construct archetype — determines scaffold template and validation rules */

--- a/packages/shared/src/validation.ts
+++ b/packages/shared/src/validation.ts
@@ -255,6 +255,15 @@ export const methodologySchema = z.object({
 
 export const tierSchema = z.enum(['L1', 'L2', 'L3']);
 
+// ── Agent-Native Output schemas (cycle-037) ────────────────────────
+
+/** Cross-construct navigation hint for CTA protocol */
+export const workflowNextSchema = z.array(z.object({
+  construct: z.string().min(1).max(100),
+  reason: z.string().min(1).max(500),
+  trigger: z.string().max(200).optional(),
+})).max(10).optional();
+
 // ── Construct Lifecycle schemas (cycle-032, FR-1) ──────────────────
 
 /** Construct archetype */
@@ -373,6 +382,9 @@ export const packManifestSchema = z.object({
   workflow: workflowSchema.optional(),
   methodology: methodologySchema.optional(),
   tier: tierSchema.optional(),
+
+  // Agent-Native Output fields (cycle-037)
+  workflow_next: workflowNextSchema,
 
   // Construct Lifecycle fields (cycle-032, FR-1)
   type: constructTypeSchema.optional(),


### PR DESCRIPTION
## Summary

Agent-Native Output Protocol for the Loa Constructs Network. Introduces TOON (Token-Oriented Object Notation) encoding, per-invocation CTA protocol, hash-based divergence detection, and lazy-loading contract documentation.

### Changes

- **TOON encoder** (`toon-lib.sh`): Header+CSV tabular format achieving ~39.6% token reduction for agent consumers
- **4-arg format router** (`constructs-lib.sh`): `format_tabular_output(label, tabular_json, original_payload, fallback_fn)` — separates data shapes to prevent fallback mismatch
- **CTA protocol** (`skill-cta.md`): Per-invocation `Next:` block with up to 3 context-sensitive command suggestions
- **Hash divergence detection** (`constructs-loader.sh`): Reports `[DIVERGED]` when version matches but content hash differs
- **Lazy-loading contract** (`runtime-contract.md`): Formal specification — skills auto-load on invocation, only index.yaml at session start
- **`workflow_next` field** (`types.ts`, `validation.ts`): Cross-construct navigation hints in PackManifest
- **Shared status data collection** (`constructs-install.sh`): Single collection pass feeds both TOON and markdown rendering paths
- All new behaviors default to OFF — config-gated, additive-only

### Bridge Review Summary

| Metric | Value |
|--------|-------|
| Iterations | 3 (2 reviewed + 1 flatline) |
| Findings discovered | 5 (2 MEDIUM, 2 LOW, 1 cosmetic) |
| Findings addressed | 3 |
| Findings deferred | 2 (by design) |
| PRAISE findings | 4 |

**Iteration 1**: Identified duplicated HTTP fetches in TOON status path, missing divergence detection in non-markdown output, and toon-lib re-sourcing overhead.

**Iteration 2**: All 3 actionable findings resolved — shared data collection (Monarch pattern), registry hash fetch added, source guard implemented. 0 new actionable findings.

**Iteration 3**: Flatline confirmed — no code changes since iteration 2.

### Files Changed

15 files (+1,465 / -662)

### Test Plan

- [x] Default config produces byte-identical output (no behavior change)
- [x] `output.format: toon` produces TOON-encoded tabular output
- [x] `cta.enabled: true` appends Next: block after status/install
- [x] Hash divergence detection reports [DIVERGED] correctly
- [x] TypeScript compilation clean (shared package)
- [x] TOON fallback on encoding failure produces markdown output

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) | Bridgebuilder reviewed