### PR TITLE
fix(explorer): bridge deferred ARCH-003 + ARCH-010

### DIFF
--- a/apps/explorer/components/constructs/auth-aware-construct-list.tsx
+++ b/apps/explorer/components/constructs/auth-aware-construct-list.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState, useCallback, type ReactNode } from 'react';
 import { useAuthStore } from '@/lib/stores/auth-store';
 import { DynamicConnectButton } from '@/components/auth/dynamic-connect-button';
 import type { ConstructNode } from '@/lib/types/graph';
+import { resolveShortDescription } from '@/lib/utils/resolve-short-description';
 
 interface AuthAwareConstructListProps {
   /** Constructs from ISR (may be empty since all are internal) */
@@ -60,7 +61,7 @@ export function AuthAwareConstructList({ publicConstructs, children }: AuthAware
           category: (c.category as string) || 'other',
           graduationLevel: (c.graduation_level as string) || 'experimental',
           description: (c.description as string) || '',
-          shortDescription: (c.short_description as string) || (c.description as string || '').split('.')[0].slice(0, 80) || 'No description',
+          shortDescription: resolveShortDescription(c.short_description as string, c.description as string),
           commandCount: (c.command_count as number) || 0,
           skillsCount: (c.skills_count as number) || 0,
           downloads: (c.downloads as number) || 0,

--- a/apps/explorer/components/search/global-search.tsx
+++ b/apps/explorer/components/search/global-search.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
+import { resolveShortDescription } from '@/lib/utils/resolve-short-description';
 
 interface SearchResult {
   id: string;
@@ -36,7 +37,7 @@ export function GlobalSearch() {
             slug: c.slug as string,
             name: c.name as string,
             icon: c.icon as string | undefined,
-            shortDescription: ((c.short_description as string) || (c.description as string || '').split('.')[0].slice(0, 80) || 'No description') as string,
+            shortDescription: resolveShortDescription(c.short_description as string, c.description as string),
             category: c.category as string,
             type: c.type as string,
           }));

--- a/apps/explorer/components/ui/button.tsx
+++ b/apps/explorer/components/ui/button.tsx
@@ -23,7 +23,7 @@ const buttonVariants = cva(
       },
       size: {
         default: 'h-9 px-4',
-        sm: 'h-7 px-3 text-sm',
+        sm: 'h-8 px-3 text-sm',
         lg: 'h-11 px-6',
         icon: 'h-9 w-9',
       },

--- a/apps/explorer/lib/data/fetch-constructs.ts
+++ b/apps/explorer/lib/data/fetch-constructs.ts
@@ -1,5 +1,6 @@
 import type { ConstructArchetype, ConstructDetail, ConstructNode, GraduationLevel, GraphData, CategoryStats, Category, Showcase, AccuracyReport } from '@/lib/types/graph';
 import { fetchCategories, normalizeCategory } from './fetch-categories';
+import { resolveShortDescription } from '@/lib/utils/resolve-short-description';
 
 /** API response shape for a single construct */
 interface APIConstruct {
@@ -69,10 +70,7 @@ function parseConstructType(ct: string | undefined): ConstructArchetype {
 
 function transformToNode(construct: APIConstruct): ConstructNode {
   const commands = construct.manifest?.commands || [];
-  // Fallback chain: short_description → first sentence of description → 'No description'
-  const shortDesc = construct.short_description
-    || (construct.description ? construct.description.split('.')[0].slice(0, 80) : null)
-    || 'No description';
+  const shortDesc = resolveShortDescription(construct.short_description, construct.description);
 
   // Category now comes from API (packs.category column, cycle-041)
   const category = normalizeCategory(construct.category || 'development');

--- a/apps/explorer/lib/utils/resolve-short-description.ts
+++ b/apps/explorer/lib/utils/resolve-short-description.ts
@@ -1,0 +1,16 @@
+/**
+ * Resolve a construct's short description from the three-tier fallback chain:
+ * 1. short_description field (handcrafted tagline)
+ * 2. First sentence of description, capped at 80 chars
+ * 3. 'No description'
+ */
+export function resolveShortDescription(
+  shortDescription: string | null | undefined,
+  description: string | null | undefined,
+): string {
+  return (
+    shortDescription
+    || (description ? description.split('.')[0].slice(0, 80) : null)
+    || 'No description'
+  );
+}


### PR DESCRIPTION
## Summary
- **ARCH-003**: Extract duplicated `short_description` fallback chain into shared `resolveShortDescription()` utility at `lib/utils/resolve-short-description.ts`. Updated 3 call sites: `fetch-constructs.ts`, `auth-aware-construct-list.tsx`, `global-search.tsx`.
- **ARCH-010**: Button `sm` variant height `h-7` → `h-8` for better touch target sizing.

## Test plan
- [x] `bun run build` passes in explorer
- [ ] Verify button sizing on `/constructs` page
- [ ] Verify short descriptions render correctly across catalog, search, and auth-aware list

🤖 Generated with [Claude Code](https://claude.com/claude-code)