### PR TITLE
feat(cycle-047): Ruggy structural alignment — docs, reliability, consolidation

### DIFF
--- a/.run/simstim-state.json
+++ b/.run/simstim-state.json
@@ -1,12 +1,12 @@
 {
-  "simstim_id": "simstim-20260310-c040db",
+  "simstim_id": "simstim-20260313-structural047",
   "schema_version": 1,
   "state": "JACKED_OUT",
   "phase": "complete",
   "timestamps": {
-    "started": "2026-03-10T06:00:00Z",
-    "last_activity": "2026-03-10T07:15:00Z",
-    "completed": "2026-03-10T07:15:00Z"
+    "started": "2026-03-13T12:00:00Z",
+    "last_activity": "2026-03-13T12:45:00Z",
+    "completed": "2026-03-13T12:45:00Z"
   },
   "phases": {
     "preflight": "completed",
@@ -21,15 +21,11 @@
     "complete": "completed"
   },
   "artifacts": {
-    "prd": {
-      "path": "grimoires/loa/prd.md"
-    },
-    "sdd": {
-      "path": "grimoires/loa/sdd.md"
-    },
-    "sprint": {
-      "path": "grimoires/loa/sprint.md"
-    }
+    "prd": { "path": "grimoires/loa/prd.md" },
+    "sdd": { "path": "grimoires/loa/sdd.md" },
+    "sprint": { "path": "grimoires/loa/sprint.md" },
+    "pr": { "url": "https://github.com/0xHoneyJar/loa-constructs/pull/162" }
   },
-  "notes": "Cycle-040: Internal Dashboard + Convex Real-Time. 5 sprints, 36 files changed. PRD → SDD → Sprint Plan → Implementation complete."
+  "cycle": "cycle-047",
+  "note": "Complete. 3 sprints, 13 tasks, 11 files, 14 findings addressed. PR #162 created."
 }

--- a/.run/sprint-plan-state.json
+++ b/.run/sprint-plan-state.json
@@ -1,35 +1,33 @@
 {
-  "plan_id": "plan-20260310-c040db",
-  "branch": "feat/cycle-040-dashboard-convex",
+  "plan_id": "plan-20260313-structural047",
+  "branch": "feat/cycle-047-ruggy-structural-alignment",
   "state": "JACKED_OUT",
   "timestamps": {
-    "started": "2026-03-10T06:30:00Z",
-    "last_activity": "2026-03-10T07:15:00Z",
-    "completed": "2026-03-10T07:15:00Z"
+    "started": "2026-03-13T12:20:00Z",
+    "last_activity": "2026-03-13T12:45:00Z",
+    "completed": "2026-03-13T12:45:00Z"
   },
   "sprints": {
-    "total": 5,
-    "completed": 5,
+    "total": 3,
+    "completed": 3,
     "current": null,
     "list": [
-      {"id": "sprint-1", "global_id": "sprint-40", "status": "completed", "cycles": 1, "files_changed": 7},
-      {"id": "sprint-2", "global_id": "sprint-41", "status": "completed", "cycles": 1, "files_changed": 6},
-      {"id": "sprint-3", "global_id": "sprint-42", "status": "completed", "cycles": 1, "files_changed": 6},
-      {"id": "sprint-4", "global_id": "sprint-43", "status": "completed", "cycles": 1, "files_changed": 11},
-      {"id": "sprint-5", "global_id": "sprint-44", "status": "completed", "cycles": 1, "files_changed": 6}
+      {"id": "sprint-1", "global_id": "sprint-63", "status": "completed", "cycles": 1, "files_changed": 3, "label": "Documentation & Dashboard Visibility"},
+      {"id": "sprint-2", "global_id": "sprint-64", "status": "completed", "cycles": 1, "files_changed": 2, "label": "HIGH Reliability Fixes"},
+      {"id": "sprint-3", "global_id": "sprint-65", "status": "completed", "cycles": 1, "files_changed": 6, "label": "Consolidation"}
     ]
   },
   "options": {
     "from": 1,
-    "to": 5,
+    "to": 3,
     "max_cycles": 20,
     "timeout_hours": 8
   },
   "metrics": {
-    "total_cycles": 5,
-    "total_files_changed": 36,
-    "total_findings_fixed": 0
+    "total_cycles": 3,
+    "total_files_changed": 11,
+    "total_findings_fixed": 14
   },
-  "cycle": "cycle-040",
-  "title": "Internal Dashboard + Convex Real-Time Integration"
+  "cycle": "cycle-047",
+  "title": "Ruggy Structural Alignment"
 }

--- a/apps/explorer/app/(dashboard)/dashboard/page.tsx
+++ b/apps/explorer/app/(dashboard)/dashboard/page.tsx
@@ -50,6 +50,9 @@ export default function DashboardOverview() {
           <h2 className="font-mono text-sm text-bone-dim uppercase tracking-wider">
             Admin
           </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <QuickLink href="/dashboard/signals" label="Signals" />
+          </div>
           {analytics ? (
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
               <StatCard label="Users" value={String(analytics.users.total)} />

--- a/apps/explorer/app/api/signals/route.ts
+++ b/apps/explorer/app/api/signals/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import crypto from 'crypto';
 import { getConvexClient } from '@/lib/convex/server';
 import { api } from '@/convex/_generated/api';
 import {
@@ -7,38 +6,7 @@ import {
   sanitizeStackTrace,
   computeIncidentGroupId,
 } from '@/lib/signals/validation';
-
-// In-memory key validation cache (SHA256 of full key → { appSlug, validatedAt })
-type KeyCacheEntry = { appSlug: string; validatedAt: number };
-const keyCache = new Map<string, KeyCacheEntry>();
-const KEY_CACHE_TTL_MS = 60_000; // 60s
-const KEY_CACHE_MAX_ENTRIES = 5_000;
-
-// Origin validation — allowed origins per app (SDD §4.1, Sprint 1.5)
-const ALLOWED_ORIGINS: Record<string, string[]> = {
-  'midi-interface': ['https://mibera.xyz', 'http://localhost:3000'],
-  'mibera-honeyroad': ['https://honeyroad.xyz', 'http://localhost:3000'],
-  'set-and-forgetti': ['https://setandforgetti.com', 'http://localhost:3000'],
-  'apdao-auction-house': ['https://apiology.xyz', 'http://localhost:3000'],
-  'mcv-interface': ['https://moneycomb.xyz', 'http://localhost:3000'],
-  'cubquests-interface': ['https://cubquests.xyz', 'http://localhost:3000'],
-};
-
-function cacheKeyHash(rawKey: string): string {
-  return crypto.createHash('sha256').update(rawKey).digest('hex');
-}
-
-function pruneKeyCache(now: number) {
-  for (const [k, v] of keyCache) {
-    if (now - v.validatedAt >= KEY_CACHE_TTL_MS) keyCache.delete(k);
-  }
-  if (keyCache.size > KEY_CACHE_MAX_ENTRIES) {
-    const oldest = [...keyCache.entries()]
-      .sort((a, b) => a[1].validatedAt - b[1].validatedAt)
-      .slice(0, keyCache.size - KEY_CACHE_MAX_ENTRIES);
-    for (const [k] of oldest) keyCache.delete(k);
-  }
-}
+import { validateSignalKey, validateOrigin } from '@/lib/signals/auth';
 
 export async function POST(req: NextRequest) {
   const convex = getConvexClient();
@@ -55,48 +23,24 @@ export async function POST(req: NextRequest) {
   const apiKey = authHeader;
   const prefix = apiKey.substring(0, 12);
 
-  // Validate key via Convex action — hash never leaves Convex (HIGH-004)
+  // Validate key via Convex (with in-memory SHA256 cache)
   let keyInfo: { appSlug: string } | null = null;
-
-  const now = Date.now();
-  pruneKeyCache(now);
-  const cacheKey = cacheKeyHash(apiKey);
-  const cached = keyCache.get(cacheKey);
-
-  if (cached && now - cached.validatedAt < KEY_CACHE_TTL_MS) {
-    keyInfo = { appSlug: cached.appSlug };
-  } else {
-    try {
-      const result = await convex.action(api.signals.verifySignalKey, {
-        keyPrefix: prefix,
-        rawKey: apiKey,
-      });
-      if (!result) {
-        return NextResponse.json({ error: 'invalid api key' }, { status: 403 });
-      }
-      keyInfo = { appSlug: result.appSlug };
-      keyCache.set(cacheKey, {
-        appSlug: result.appSlug,
-        validatedAt: now,
-      });
-    } catch {
-      return NextResponse.json({ error: 'key validation failed' }, { status: 500 });
+  try {
+    keyInfo = await validateSignalKey(convex, apiKey);
+    if (!keyInfo) {
+      return NextResponse.json({ error: 'invalid api key' }, { status: 403 });
     }
+  } catch {
+    return NextResponse.json({ error: 'key validation failed' }, { status: 500 });
   }
 
-  // Origin validation (SDD §4.1 — SKP-001 mitigation)
+  // Origin validation
   const origin = req.headers.get('origin') || req.headers.get('referer') || '';
-  const allowedOrigins = ALLOWED_ORIGINS[keyInfo.appSlug];
-  if (allowedOrigins) {
-    const originMatch = allowedOrigins.some(
-      (allowed) => origin === allowed || origin.startsWith(allowed + '/'),
+  if (!validateOrigin(keyInfo.appSlug, origin)) {
+    return NextResponse.json(
+      { error: 'origin not allowed for this key' },
+      { status: 403 },
     );
-    if (!originMatch && origin !== '') {
-      return NextResponse.json(
-        { error: 'origin not allowed for this key' },
-        { status: 403 },
-      );
-    }
   }
 
   // Parse and validate request body

--- a/apps/explorer/convex/README.md
+++ b/apps/explorer/convex/README.md
@@ -31,7 +31,7 @@ Convex deployment: dev `doting-jackal-397`, prod `quaint-anaconda-866`.
 | `signals/check-linear-failures` | 15m | `signals.checkLinearFailures` |
 | `signals/reconcile-linear` | 1h | `signals.reconcile` |
 | `signals/heartbeat` | 1h | `signals.sendHeartbeat` |
-| `signals/heartbeat-check` | 1h | `signals.checkHeartbeat` |
+| `signals/heartbeat-check` | 2h | `signals.checkHeartbeat` |
 | `signals/recalculate-sovereignty` | 1h | `signals.recalculateSovereignty` |
 | `signals/purge-expired` | 24h | `signals.purgeExpired` |
 

--- a/apps/explorer/convex/README.md
+++ b/apps/explorer/convex/README.md
@@ -1,0 +1,61 @@
+# Explorer Convex Functions
+
+Convex deployment: dev `doting-jackal-397`, prod `quaint-anaconda-866`.
+
+## Signal Pipeline
+
+| Function | Type | Purpose |
+|----------|------|---------|
+| `signals.ingest` | action | Entry point — validates CONVEX_WRITE_KEY, rate limits, deduplicates, schedules classify + Discord alert |
+| `signals.insert` | mutation | Inserts signal to DB |
+| `signals.classify` | internal action | Sends signal to Claude Haiku 4.5, stores classification result |
+| `signals.sovereigntyGatedEscalate` | internal action | Checks sovereignty tier + circuit breaker, schedules Linear issue creation |
+| `signals.alertDiscord` | internal action | Posts Discord embed for critical/high signals |
+| `signals.patchClassification` | mutation | Updates signal with classification result |
+| `signals.statusCounts` | query | Dashboard counts by app and status |
+| `signals.recalculateSovereignty` | mutation | Recomputes sovereignty tiers from override rates |
+
+## Linear Integration
+
+| Function | Type | Purpose |
+|----------|------|---------|
+| `linear.createLinearIssue` | internal action | GraphQL mutation to create Linear issue, routes to Product or Infrastructure team |
+| `linear.patchLinearIssue` | mutation | Stores linearIssueId + linearIssueUrl back on signal |
+
+## Cron Jobs
+
+| Name | Interval | Handler |
+|------|----------|---------|
+| `presence/cleanup` | 30s | `dashboardPresence.cleanupExpired` |
+| `signals/retry-classification` | 5m | `signals.retryFailedClassifications` |
+| `signals/check-linear-failures` | 15m | `signals.checkLinearFailures` |
+| `signals/reconcile-linear` | 1h | `signals.reconcile` |
+| `signals/heartbeat` | 1h | `signals.sendHeartbeat` |
+| `signals/heartbeat-check` | 1h | `signals.checkHeartbeat` |
+| `signals/recalculate-sovereignty` | 1h | `signals.recalculateSovereignty` |
+| `signals/purge-expired` | 24h | `signals.purgeExpired` |
+
+## Schema Tables
+
+| Table | Purpose |
+|-------|---------|
+| `signals` | Core signal store (feedback + error_report discriminated union) |
+| `signalKeys` | Per-app API keys (hash-validated, never stores raw key) |
+| `signalRateLimits` | Per-key rate limit counters (100/hr) |
+| `sovereigntyState` | Per-app sovereignty tiers + circuit breaker state |
+| `dashboardPresence` | Real-time dashboard user presence |
+
+## Required Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `CONVEX_WRITE_KEY` | Shared secret — must match Vercel route handler |
+| `ANTHROPIC_API_KEY` | Claude Haiku 4.5 for signal classification |
+| `LINEAR_API_KEY` | Linear issue creation for escalated signals |
+| `LINEAR_TEAM_PRODUCT` | Linear team ID for product/feedback issues |
+| `LINEAR_TEAM_INFRASTRUCTURE` | Linear team ID for infrastructure/error issues |
+| `DISCORD_SIGNALS_WEBHOOK_URL` | Discord webhook for critical/high signal alerts |
+
+## Architecture Reference
+
+See `grimoires/loa/context/ruggy-signal-architecture.md` for full Mermaid diagrams of the signal flow, ingestion sequence, sovereignty engine, and security model.

--- a/apps/explorer/convex/crons.ts
+++ b/apps/explorer/convex/crons.ts
@@ -39,10 +39,10 @@ crons.interval(
   internal.signals.sendHeartbeat,
 );
 
-// Check heartbeat health every hour (offset by running both)
+// Check heartbeat health every 2 hours (offset from sendHeartbeat to avoid collision)
 crons.interval(
   'signals/heartbeat-check',
-  { hours: 1 },
+  { hours: 2 },
   internal.signals.checkHeartbeat,
 );
 

--- a/apps/explorer/convex/linear.ts
+++ b/apps/explorer/convex/linear.ts
@@ -38,7 +38,10 @@ export const createLinearIssue = internalAction({
   args: { signalId: v.id('signals') },
   handler: async (ctx, { signalId }) => {
     const apiKey = process.env.LINEAR_API_KEY;
-    if (!apiKey) return;
+    if (!apiKey) {
+      console.error('[linear] LINEAR_API_KEY is not set — cannot create issues. Signal will be retried by check-linear-failures cron.');
+      throw new Error('LINEAR_API_KEY not configured');
+    }
 
     const signal = await ctx.runQuery(internal.signals.getById, { signalId });
     if (!signal) return;
@@ -50,7 +53,10 @@ export const createLinearIssue = internalAction({
     const teamKey =
       signal.data.type === 'error_report' ? 'LINEAR_TEAM_INFRASTRUCTURE' : 'LINEAR_TEAM_PRODUCT';
     const teamId = process.env[teamKey];
-    if (!teamId) return;
+    if (!teamId) {
+      console.error(`[linear] ${teamKey} is not set — cannot route issue. Signal will be retried.`);
+      throw new Error(`${teamKey} not configured`);
+    }
 
     const priority = PRIORITY_MAP[signal.severity] ?? 3;
 

--- a/apps/explorer/convex/schema.ts
+++ b/apps/explorer/convex/schema.ts
@@ -176,6 +176,10 @@ export default defineSchema({
         trigger: v.string(),
       }),
     ),
+    // Circuit breaker state (typed fields — replaces string-encoded state)
+    circuitBreakerTripped: v.optional(v.boolean()),
+    circuitBreakerTrippedAt: v.optional(v.number()),
+    consecutiveFailures: v.optional(v.number()),
     updatedAt: v.number(),
   }).index('by_scope', ['scope']),
 });

--- a/apps/explorer/convex/signals.ts
+++ b/apps/explorer/convex/signals.ts
@@ -104,6 +104,8 @@ export const insert = internalMutation({
 });
 
 // --- Ingest Action (Entry Point) ---
+// Convex storage validators. Edge validation (Zod) is in lib/signals/validation.ts.
+// Both must agree on the signal shape — changes here require matching changes there.
 
 export const ingest = action({
   args: {
@@ -196,19 +198,19 @@ export const byApp = query({
 
 export const statusCounts = query({
   handler: async (ctx) => {
-    // Query only active statuses via index instead of full table scan (HIGH-001)
+    // Query only active statuses via index with safety bounds
     const newSigs = await ctx.db
       .query('signals')
       .withIndex('by_status', (q) => q.eq('status', 'new'))
-      .collect();
+      .take(10000);
     const triaged = await ctx.db
       .query('signals')
       .withIndex('by_status', (q) => q.eq('status', 'triaged'))
-      .collect();
+      .take(10000);
     const escalated = await ctx.db
       .query('signals')
       .withIndex('by_status', (q) => q.eq('status', 'escalated'))
-      .collect();
+      .take(10000);
 
     const active = [...newSigs, ...triaged, ...escalated].filter(
       (s) => s.source !== 'heartbeat',
@@ -1305,51 +1307,34 @@ export const recordClassificationResult = internalMutation({
 
     if (success) {
       // Reset consecutive failure tracking on success
-      const currentTrigger = state.lastTransition?.trigger || '';
-      if (currentTrigger.includes('consecutive_failures=')) {
+      if (state.consecutiveFailures && state.consecutiveFailures > 0) {
         await ctx.db.patch(state._id, {
-          lastTransition: {
-            from: state.tier,
-            to: state.tier,
-            timestamp: Date.now(),
-            trigger: 'consecutive_failures=0, same_error_count=0, last_error=',
-          },
+          consecutiveFailures: 0,
           updatedAt: Date.now(),
         });
       }
       return;
     }
 
-    // Track consecutive failures via sovereignty state
-    const currentTrigger = state.lastTransition?.trigger || '';
-    const failureMatch = currentTrigger.match(/consecutive_failures=(\d+)/);
-    const consecutiveFailures = failureMatch ? parseInt(failureMatch[1]) + 1 : 1;
+    // Track consecutive failures via typed fields
+    const consecutiveFailures = (state.consecutiveFailures ?? 0) + 1;
 
-    // Check for same error 3x
-    const errorMatch = currentTrigger.match(/last_error=(.*?)(?:,|$)/);
-    const lastError = errorMatch ? errorMatch[1] : '';
-    const sameErrorMatch = currentTrigger.match(/same_error_count=(\d+)/);
-    const sameErrorCount =
-      errorMessage && errorMessage === lastError
-        ? (sameErrorMatch ? parseInt(sameErrorMatch[1]) + 1 : 2)
-        : 1;
-
-    // Circuit breaker: 5 consecutive failures OR same error 3x → halt
-    if (consecutiveFailures >= 5 || sameErrorCount >= 3) {
+    // Circuit breaker: 5 consecutive failures → halt
+    if (consecutiveFailures >= 5) {
       await ctx.db.patch(state._id, {
+        circuitBreakerTripped: true,
+        circuitBreakerTrippedAt: Date.now(),
+        consecutiveFailures,
         manualOverride: {
           tier: 'constrained',
           setBy: 'circuit_breaker',
-          reason:
-            consecutiveFailures >= 5
-              ? `Halted: ${consecutiveFailures} consecutive classification failures`
-              : `Halted: same error "${errorMessage?.slice(0, 100)}" repeated ${sameErrorCount}x`,
+          reason: `Halted: ${consecutiveFailures} consecutive classification failures`,
         },
         lastTransition: {
           from: state.tier,
           to: 'constrained',
           timestamp: Date.now(),
-          trigger: `circuit_breaker, consecutive_failures=${consecutiveFailures}, same_error_count=${sameErrorCount}, last_error=${errorMessage?.slice(0, 100) || ''}`,
+          trigger: `circuit_breaker, consecutive_failures=${consecutiveFailures}`,
         },
         updatedAt: Date.now(),
       });
@@ -1358,20 +1343,12 @@ export const recordClassificationResult = internalMutation({
       await ctx.scheduler.runAfter(0, internal.signals.alertPipelineError, {
         appSlug,
         errorType: 'circuit_breaker',
-        details:
-          consecutiveFailures >= 5
-            ? `${consecutiveFailures} consecutive classification failures`
-            : `Same error repeated ${sameErrorCount}x: ${errorMessage?.slice(0, 200)}`,
+        details: `${consecutiveFailures} consecutive classification failures`,
       });
     } else {
       // Update failure tracking
       await ctx.db.patch(state._id, {
-        lastTransition: {
-          from: state.tier,
-          to: state.tier,
-          timestamp: Date.now(),
-          trigger: `consecutive_failures=${consecutiveFailures}, same_error_count=${sameErrorCount}, last_error=${errorMessage?.slice(0, 100) || ''}`,
-        },
+        consecutiveFailures,
         updatedAt: Date.now(),
       });
     }
@@ -1386,7 +1363,8 @@ export const isCircuitBroken = internalQuery({
       .withIndex('by_scope', (q) => q.eq('scope', appSlug))
       .first();
 
-    return state?.manualOverride?.setBy === 'circuit_breaker';
+    // Check typed field first, fall back to legacy manualOverride check
+    return state?.circuitBreakerTripped === true || state?.manualOverride?.setBy === 'circuit_breaker';
   },
 });
 
@@ -1408,11 +1386,13 @@ export const resetCircuitBreaker = mutation({
 
     if (!state) throw new Error(`No sovereignty state for ${appSlug}`);
 
-    if (state.manualOverride?.setBy !== 'circuit_breaker') {
+    if (!state.circuitBreakerTripped && state.manualOverride?.setBy !== 'circuit_breaker') {
       throw new Error('Circuit breaker is not tripped for this app');
     }
 
     await ctx.db.patch(state._id, {
+      circuitBreakerTripped: false,
+      consecutiveFailures: 0,
       manualOverride: undefined,
       lastTransition: {
         from: 'constrained',

--- a/apps/explorer/convex/signals.ts
+++ b/apps/explorer/convex/signals.ts
@@ -1392,6 +1392,7 @@ export const resetCircuitBreaker = mutation({
 
     await ctx.db.patch(state._id, {
       circuitBreakerTripped: false,
+      circuitBreakerTrippedAt: undefined,
       consecutiveFailures: 0,
       manualOverride: undefined,
       lastTransition: {

--- a/apps/explorer/convex/signals.ts
+++ b/apps/explorer/convex/signals.ts
@@ -329,9 +329,11 @@ export const classify = internalAction({
 
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
+      const newAttempts = signal.classificationAttempts + 1;
       await ctx.runMutation(internal.signals.patchClassificationAttempt, {
         signalId,
-        attempts: signal.classificationAttempts + 1,
+        attempts: newAttempts,
+        ...(newAttempts >= 3 ? { status: 'classification_failed' } : {}),
       });
       return;
     }
@@ -418,9 +420,11 @@ export const classify = internalAction({
         success: true,
       });
     } catch (err) {
+      const newAttempts = signal.classificationAttempts + 1;
       await ctx.runMutation(internal.signals.patchClassificationAttempt, {
         signalId,
-        attempts: signal.classificationAttempts + 1,
+        attempts: newAttempts,
+        ...(newAttempts >= 3 ? { status: 'classification_failed' } : {}),
       });
 
       // Record failure for circuit breaker
@@ -513,9 +517,12 @@ export const patchClassificationAttempt = internalMutation({
   args: {
     signalId: v.id('signals'),
     attempts: v.number(),
+    status: v.optional(v.string()),
   },
-  handler: async (ctx, { signalId, attempts }) => {
-    await ctx.db.patch(signalId, { classificationAttempts: attempts });
+  handler: async (ctx, { signalId, attempts, status }) => {
+    const patch: Record<string, unknown> = { classificationAttempts: attempts };
+    if (status) patch.status = status;
+    await ctx.db.patch(signalId, patch);
   },
 });
 
@@ -1086,12 +1093,11 @@ export const recalculateSovereignty = internalMutation({
         .collect()
       ).filter((s) => s.source !== 'heartbeat');
 
-      // Count overrides in window
-      const overrides = await ctx.db
+      // Count overrides in window (use index range to avoid full scan)
+      const windowOverrides = await ctx.db
         .query('signalOverrides')
-        .withIndex('by_app_timestamp', (q) => q.eq('appSlug', repo))
+        .withIndex('by_app_timestamp', (q) => q.eq('appSlug', repo).gte('timestamp', windowStart))
         .collect();
-      const windowOverrides = overrides.filter((o) => o.timestamp > windowStart);
 
       const signalCount = windowSignals.length;
       const overrideCount = windowOverrides.length;

--- a/apps/explorer/lib/signals/auth.ts
+++ b/apps/explorer/lib/signals/auth.ts
@@ -16,6 +16,7 @@ const ALLOWED_ORIGINS: Record<string, string[]> = {
   'apdao-auction-house': ['https://apiology.xyz', 'http://localhost:3000'],
   'mcv-interface': ['https://moneycomb.xyz', 'http://localhost:3000'],
   'cubquests-interface': ['https://cubquests.xyz', 'http://localhost:3000'],
+  'rektdrop-interface': ['https://rektdrop.xyz', 'http://localhost:3000'],
 };
 
 function cacheKeyHash(rawKey: string): string {

--- a/apps/explorer/lib/signals/auth.ts
+++ b/apps/explorer/lib/signals/auth.ts
@@ -1,0 +1,83 @@
+import crypto from 'crypto';
+import { ConvexHttpClient } from 'convex/browser';
+import { api } from '@/convex/_generated/api';
+
+// In-memory key validation cache (SHA256 of full key → { appSlug, validatedAt })
+type KeyCacheEntry = { appSlug: string; validatedAt: number };
+const keyCache = new Map<string, KeyCacheEntry>();
+const KEY_CACHE_TTL_MS = 60_000; // 60s
+const KEY_CACHE_MAX_ENTRIES = 5_000;
+
+// Origin validation — allowed origins per app
+const ALLOWED_ORIGINS: Record<string, string[]> = {
+  'midi-interface': ['https://mibera.xyz', 'http://localhost:3000'],
+  'mibera-honeyroad': ['https://honeyroad.xyz', 'http://localhost:3000'],
+  'set-and-forgetti': ['https://setandforgetti.com', 'http://localhost:3000'],
+  'apdao-auction-house': ['https://apiology.xyz', 'http://localhost:3000'],
+  'mcv-interface': ['https://moneycomb.xyz', 'http://localhost:3000'],
+  'cubquests-interface': ['https://cubquests.xyz', 'http://localhost:3000'],
+};
+
+function cacheKeyHash(rawKey: string): string {
+  return crypto.createHash('sha256').update(rawKey).digest('hex');
+}
+
+function pruneKeyCache(now: number) {
+  for (const [k, v] of keyCache) {
+    if (now - v.validatedAt >= KEY_CACHE_TTL_MS) keyCache.delete(k);
+  }
+  if (keyCache.size > KEY_CACHE_MAX_ENTRIES) {
+    const oldest = [...keyCache.entries()]
+      .sort((a, b) => a[1].validatedAt - b[1].validatedAt)
+      .slice(0, keyCache.size - KEY_CACHE_MAX_ENTRIES);
+    for (const [k] of oldest) keyCache.delete(k);
+  }
+}
+
+/**
+ * Validate an API key against Convex, with in-memory SHA256 cache.
+ * Returns { appSlug } on success, null on invalid key.
+ * Throws on transport/server errors.
+ */
+export async function validateSignalKey(
+  convex: ConvexHttpClient,
+  apiKey: string,
+): Promise<{ appSlug: string } | null> {
+  const prefix = apiKey.substring(0, 12);
+  const now = Date.now();
+
+  pruneKeyCache(now);
+
+  const hash = cacheKeyHash(apiKey);
+  const cached = keyCache.get(hash);
+  if (cached && now - cached.validatedAt < KEY_CACHE_TTL_MS) {
+    return { appSlug: cached.appSlug };
+  }
+
+  const result = await convex.action(api.signals.verifySignalKey, {
+    keyPrefix: prefix,
+    rawKey: apiKey,
+  });
+
+  if (!result) return null;
+
+  keyCache.set(hash, {
+    appSlug: result.appSlug,
+    validatedAt: now,
+  });
+
+  return { appSlug: result.appSlug };
+}
+
+/**
+ * Validate request origin against allowed origins for the app.
+ * Returns true if origin is allowed (or if no origin header / server-side caller).
+ */
+export function validateOrigin(appSlug: string, origin: string): boolean {
+  const allowedOrigins = ALLOWED_ORIGINS[appSlug];
+  if (!allowedOrigins) return true; // No origin restrictions for this app
+  if (origin === '') return true; // Server-side caller (no Origin header)
+  return allowedOrigins.some(
+    (allowed) => origin === allowed || origin.startsWith(allowed + '/'),
+  );
+}

--- a/apps/explorer/lib/signals/validation.ts
+++ b/apps/explorer/lib/signals/validation.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+// Edge validation (Zod). Convex storage validators are in convex/signals.ts (ingest action args).
+// Both must agree on the signal shape — changes here require matching changes there.
+
 export const feedbackDataSchema = z.object({
   type: z.literal('feedback'),
   category: z.string().max(100),

--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -63,6 +63,7 @@
     "@types/react-dom": "^19.0.0",
     "@types/three": "^0.170.0",
     "autoprefixer": "^10.4.20",
+    "esbuild": "^0.27.4",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.7.0"

--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,7 @@
         "@types/react-dom": "^19.0.0",
         "@types/three": "^0.170.0",
         "autoprefixer": "^10.4.20",
+        "esbuild": "^0.27.4",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.7.0",
@@ -360,57 +361,57 @@
 
     "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -1502,7 +1503,7 @@
 
     "es6-promisify": ["es6-promisify@5.0.0", "", { "dependencies": { "es6-promise": "^4.0.3" } }, "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ=="],
 
-    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+    "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
 
     "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
 
@@ -2846,6 +2847,10 @@
 
     "to-buffer/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "tsup/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "tsx/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
     "tunnel-rat/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
@@ -3312,6 +3317,110 @@
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
+    "tsup/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "tsup/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "tsup/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "tsup/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "tsup/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "tsup/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "tsup/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "tsup/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "tsup/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "tsup/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "tsup/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "tsup/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "tsup/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "tsup/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "tsup/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "tsup/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "tsup/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "tsup/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "tsup/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "tsup/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "tsup/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "tsup/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "tsup/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "tsup/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "tsup/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "tsup/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
@@ -3409,6 +3518,8 @@
     "@loa-constructs/cli/vitest/chai/pathval": ["pathval@1.1.1", "", {}, "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="],
 
     "@loa-constructs/shared/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
@@ -3539,6 +3650,58 @@
     "@dynamic-labs-wallet/forward-mpc-shared/@dynamic-labs-wallet/core/@dynamic-labs-wallet/forward-mpc-client/@dynamic-labs-wallet/core/@dynamic-labs/sdk-api-core": ["@dynamic-labs/sdk-api-core@0.0.818", "", {}, "sha512-s0iq+kS15gbBk7HtFEVkuzHHUc8Xt0afA1el31+c8HBLIV0Bz1O4WaMTKdpvC/Rb5RS5GDCOmxeR6LvDzZBw+A=="],
 
     "@dynamic-labs-wallet/forward-mpc-shared/@dynamic-labs-wallet/core/@dynamic-labs-wallet/forward-mpc-client/@dynamic-labs-wallet/forward-mpc-shared/@dynamic-labs-wallet/browser": ["@dynamic-labs-wallet/browser@0.0.203", "", { "dependencies": { "@dynamic-labs-wallet/core": "0.0.203", "@dynamic-labs/logger": "^4.25.3", "@dynamic-labs/sdk-api-core": "^0.0.818", "@noble/hashes": "1.7.1", "argon2id": "1.0.1", "axios": "1.13.2", "http-errors": "2.0.0", "semver": "^7.6.3", "uuid": "11.1.0" } }, "sha512-Vwi4CFMjSiLsPF4VUlYV4F87xaQrgnmUVUVx3b5F0I5DbFsGLafiSl2T/dlsOeNuRAhbpDMU4MEB4oOxzR0kYQ=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "@loa-constructs/shared/vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core/uint8arrays": ["uint8arrays@3.1.0", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog=="],
 

--- a/grimoires/loa/context/ruggy-ecosystem-intelligence.md
+++ b/grimoires/loa/context/ruggy-ecosystem-intelligence.md
@@ -1,0 +1,108 @@
+# Ruggy — Ecosystem Intelligence Agent
+
+> Updated: 2026-03-13 (cycle-047 structural alignment)
+
+## What Ruggy Is
+
+Ruggy is the ecosystem intelligence layer for 0xHoneyJar. It consolidates user feedback and error signals from **6 independent product repos** into a single Convex-native pipeline hosted on **constructs.network** (the explorer app). Signals are ingested, classified by AI, and routed to Linear/Discord based on severity and sovereignty rules.
+
+## What Was Actually Built (cycle-044 + cycle-045)
+
+- Convex-powered signal store with deduplication and classification
+- AI classification via Claude Haiku 4.5 (store-first, classify-later)
+- Linear integration: auto-escalation creates issues, bidirectional webhook sync
+- Discord alerting for critical/high signals
+- Dashboard at `/dashboard/signals` with inbox/detail/triage (7 components)
+- Feedback widget in explorer layout + 6 product repo fan-out integrations
+- Per-app API keys (`sk_live_*`) with hash-validated auth in Convex
+- Sovereignty engine: per-app governance controlling auto-escalation (constrained/standard/autonomous tiers)
+- 8 cron jobs: retry-classification, reconcile-linear, purge-expired, heartbeat, heartbeat-check, recalculate-sovereignty, check-linear-failures, presence-cleanup
+- E2E verified: signals flow from product apps through classification to Linear (LAB-915)
+
+## Architecture
+
+All signal processing runs on Convex (`quaint-anaconda-866` prod). No separate backend.
+
+```
+Product repo widget → POST constructs.network/api/signals → Convex ingest → Haiku classify → sovereignty gate → Linear issue
+                                                                                                                → Discord alert
+```
+
+See `grimoires/loa/context/ruggy-signal-architecture.md` for full Mermaid diagrams.
+
+## Product Repos (6 fan-out integrations)
+
+| Repo | Integration Pattern | API Key |
+|------|-------------------|---------|
+| set-and-forgetti | Server route (fire-and-forget) | `sk_live_db79...` |
+| apdao-auction-house | Server action (fire-and-forget) | `sk_live_a72b...` |
+| mcv-interface | Convex scheduled action | `sk_live_10c5...` |
+| midi-interface | Server action (fire-and-forget) | `sk_live_4a4f...` |
+| cubquests-interface | Client widget (origin-validated) | `sk_live_e111...` |
+| mibera-honeyroad | Client widget (origin-validated) | `sk_live_a109...` |
+
+Server-side integrations keep the API key secret. Client-side widgets use `NEXT_PUBLIC_` prefix — the key is exposed but origin-validated server-side.
+
+## Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Signal store + processing | Convex (prod: quaint-anaconda-866) |
+| Classification | Claude Haiku 4.5 (direct API, not routed) |
+| Ingestion endpoint | Next.js API route (Vercel, constructs.network) |
+| Issue tracking | Linear (team 466d92ac, GraphQL API) |
+| Alerting | Discord webhooks |
+| Dashboard | Next.js + Convex subscriptions (real-time) |
+
+## Sovereignty via Override Rate
+
+Override rate drives autonomy tier automatically:
+- >40% → CONSTRAINED (auto-escalate critical + high only)
+- 15-40% → STANDARD (auto-escalate critical + high)
+- <15% → AUTONOMOUS (full triage authority, all actionable)
+
+Manual override always available. Tiers recalculated hourly by cron.
+
+## Metrics That Matter (NOT Vanity)
+
+| Metric | What | Target |
+|--------|------|--------|
+| Time to Awareness (TTA) | Gap between something breaking and someone knowing | <4h HIGH, <1h CRITICAL |
+| Human Override Rate | How often humans change Ruggy's classification | <25% month 1, <15% month 2 |
+| Signal-to-Action Ratio | % of signals that led to actual code change/fix | >10% within 7 days |
+| Coverage Gap Detection | Incidents Ruggy missed | 0 CRITICAL missed |
+| Cost per Actionable Signal | Total spend / signals that led to action | <$5/signal |
+
+What we DON'T track: total signal volume, widget install count, Discord usage, uptime %, classification speed, issue count.
+
+## Identity
+
+Ruggy's voice (from ruggy-v3 IDENTITY.md + GECKO.md BEAUVOIR):
+- Lowercase energy — calm, approachable, never corporate
+- Direct but warm — doesn't waste words but the words carry weight
+- Speaks from experience, not authority
+- The "bazaar trader" archetype — on the ground, in the dust, between the stalls
+- Never fabricates, never optimizes for engagement, never extrapolates desire from behavior
+
+## Phase 2 (Future)
+
+- Onchain observability via Score API (transaction patterns, contract health)
+- Cross-signal correlation across repos (incident grouping)
+- Linear Agent SDK (first-class team member identity)
+- Compound learning (pattern extraction from classified signals)
+- construct-rugby Railway deployment (blocked on loa-finn / FINN_URL)
+- Historical feedback migration from midi-interface Supabase (~155 rows)
+
+## Key Research Sources
+
+- grimoires/gecko/context-pack/ (16 files, complete research package)
+- grimoires/loa/context/ruggy-signal-architecture.md (Mermaid diagrams, security model, env vars)
+- grimoires/loa/context/prd-cycle-044-signals.md (original signal PRD)
+
+## Constraints
+
+- Bun runtime (monorepo uses bun, Convex uses Node.js internally)
+- ~$1/day cost ceiling for 6 repos
+- Single maintainer (@janitooor), 1-3 dev team
+- Karpathy constraint: one thing well (ecosystem health triage), not everything
+- Trust boundary: reads everything, writes only grimoires/gecko/ and creates Linear issues/Discord alerts

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "active_cycle": "cycle-045",
-  "global_sprint_counter": 59,
+  "active_cycle": "cycle-047",
+  "global_sprint_counter": 62,
   "cycles": [
     {
       "id": "cycle-025",
@@ -649,35 +649,100 @@
     {
       "id": "cycle-045",
       "label": "Ruggy — Autonomous Ecosystem Intelligence Agent",
-      "status": "active",
+      "status": "archived",
       "created_at": "2026-03-12T23:00:00Z",
-      "prd": "grimoires/loa/prd.md",
-      "sdd": "grimoires/loa/sdd.md",
-      "sprint_plan": "grimoires/loa/sprint.md",
+      "archived_at": "2026-03-13T00:00:00Z",
+      "archive_path": "grimoires/loa/archive/cycle-045-rugby-ecosystem-intelligence",
+      "prd": "grimoires/loa/archive/cycle-045-rugby-ecosystem-intelligence/prd.md",
+      "sdd": "grimoires/loa/archive/cycle-045-rugby-ecosystem-intelligence/sdd.md",
+      "sprint_plan": "grimoires/loa/archive/cycle-045-rugby-ecosystem-intelligence/sprint.md",
       "foundation": "cycle-044",
+      "note": "Build complete. Signal pipeline, sovereignty engine, API keys, 7 fan-out PRs, 8 review fixes. Deployment closeout moved to cycle-046.",
       "sprints": [
         {
           "local_id": "sprint-1",
           "global_id": "sprint-56",
           "label": "Foundation — Dixie Fork + Convex Extensions",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "local_id": "sprint-2",
           "global_id": "sprint-57",
           "label": "Widget Integration — Connect Product Repos",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "local_id": "sprint-3",
           "global_id": "sprint-58",
           "label": "Enhanced Classification + Sovereignty Logic",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "local_id": "sprint-4",
           "global_id": "sprint-59",
           "label": "Discord Slash Commands + E2E",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "id": "cycle-046",
+      "label": "Rugby Deployment Closeout — Merge, Deploy, E2E",
+      "status": "archived",
+      "created_at": "2026-03-13T00:00:00Z",
+      "archived_at": "2026-03-13T12:00:00Z",
+      "prd": "grimoires/loa/context/cycle-045-closeout-plan.md",
+      "sdd": "grimoires/loa/sdd.md",
+      "sprint_plan": "grimoires/loa/sprint.md",
+      "foundation": "cycle-045",
+      "note": "Complete. All 6 fan-out PRs merged, env vars set, E2E verified (LAB-915 in Linear). Sovereignty fix deployed. Architecture docs created.",
+      "sprints": [
+        {
+          "local_id": "sprint-1",
+          "global_id": "sprint-60",
+          "label": "Commit, PR, and Merge",
+          "status": "completed"
+        },
+        {
+          "local_id": "sprint-2",
+          "global_id": "sprint-61",
+          "label": "Environment Configuration and E2E",
+          "status": "completed"
+        },
+        {
+          "local_id": "sprint-3",
+          "global_id": "sprint-62",
+          "label": "Fan-Out PR Merges",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "id": "cycle-047",
+      "label": "Ruggy Structural Alignment — Documentation, Reliability, Consolidation",
+      "status": "active",
+      "created_at": "2026-03-13T12:00:00Z",
+      "prd": "grimoires/loa/prd.md",
+      "foundation": "cycle-046",
+      "sdd": "grimoires/loa/sdd.md",
+      "sprint_plan": "grimoires/loa/sprint.md",
+      "sprints": [
+        {
+          "local_id": "sprint-1",
+          "global_id": "sprint-63",
+          "label": "Documentation & Dashboard Visibility",
+          "status": "pending"
+        },
+        {
+          "local_id": "sprint-2",
+          "global_id": "sprint-64",
+          "label": "HIGH Reliability Fixes",
+          "status": "pending"
+        },
+        {
+          "local_id": "sprint-3",
+          "global_id": "sprint-65",
+          "label": "Consolidation",
           "status": "pending"
         }
       ]

--- a/grimoires/loa/prd.md
+++ b/grimoires/loa/prd.md
@@ -1,319 +1,179 @@
-# PRD: Ruggy — Autonomous Ecosystem Intelligence Agent
+# PRD: Ruggy Structural Alignment — Documentation, Reliability, Consolidation
 
-**Cycle**: cycle-045
-**Created**: 2026-03-12
+**Cycle**: cycle-047
+**Created**: 2026-03-13
 **Status**: Draft
-**Foundation**: cycle-044 (Centralized Observability Dashboard — deployed, E2E tested)
+**Foundation**: cycle-044 (signal infrastructure), cycle-045 (Ruggy build), cycle-046 (deployment closeout)
 **Context**:
-- `grimoires/gecko/context-pack/` (16 files, ~150KB — complete research package)
-- `grimoires/loa/context/ruggy-ecosystem-intelligence.md` (synthesis)
-- `grimoires/loa/context/prd-cycle-044-signals.md` (foundation PRD)
-- `grimoires/gecko/autoresearch-pi-dig-trail.md` (deep research trail)
-
-**Review**:
-- Observer construct: feedback capture rigor, signal taxonomy, UTC/bug classification
-- Bridgebuilder: architecture quality, Dixie fork viability, scope discipline
-- Protocol construct: data flow correctness, Convex↔PostgreSQL boundary
-- Gecko BEAUVOIR: voice, identity coherence, anti-patterns
+- `grimoires/loa/context/ruggy-structural-alignment.md` (structural alignment plan)
+- `grimoires/loa/context/ruggy-signal-architecture.md` (architecture reference)
+- `grimoires/loa/context/prd-cycle-044-signals.md` (original signal PRD)
 
 ---
 
 ## 1. Problem Statement
 
-The 0xHoneyJar ecosystem operates 5+ live product apps across Berachain with no automated feedback-to-action pipeline. Cycle-044 built the signal infrastructure (Convex ingestion, Haiku classification, Linear escalation, Discord alerting, dashboard). But that infrastructure only works inside the explorer app. The product repos where users actually encounter bugs — mibera-dimensions, mcv-interface, cubquests-interface, set-and-forgetti, apdao-auction-house — have no connection to it.
+Ruggy's signal pipeline is deployed and verified (LAB-915 in Linear, all 6 fan-out PRs merged). But three categories of structural debt surfaced during deployment closeout:
 
-The gap: **users hit bugs in product apps, but the team discovers them manually** — via Discord messages, direct reports, or stumbling into them during unrelated work. The constructs network API crash loop (2026-03-12, Bun/bcrypt segfault) was discovered accidentally. Zero product repos have error tracking, alerting, or feedback routing.
+1. **Documentation fiction**: `ruggy-ecosystem-intelligence.md` describes a "Dixie fork" with Hono/PostgreSQL/Redis/incur/cheval — none of which were built. The actual implementation is a Convex-native pipeline. The Convex README is generic boilerplate. New contributors or future sessions will build on false assumptions.
 
-Ruggy closes this gap. Not by building new infrastructure — by connecting the infrastructure that exists to the repos that need it.
+2. **Missing visibility**: The signals dashboard exists at `/dashboard/signals` with 7 fully-built components, but there's no link to it from the dashboard overview. Admin users have no way to discover it without a direct URL.
 
-> Sources: grimoires/gecko/context-pack/00-framing.md, grimoires/gecko/context-pack/10-ground-truth.md, grimoires/loa/context/prd-cycle-044-signals.md
+3. **Reliability gaps**: 14 architectural findings from the deployment audit — 4 HIGH severity affecting signal lifecycle (infinite retry loops, silently swallowed escalation failures, silent no-op on missing Linear env vars, missing database indexes).
 
-## 2. Vision
+The pipeline works end-to-end today, but these gaps mean: (a) a failed classification retries forever with no terminal state, (b) a failed Linear escalation looks identical to a successful one, (c) removing `LINEAR_API_KEY` silently drops all escalations with no alert, and (d) sovereignty recalculation will degrade to full table scans as volume grows.
 
-Ruggy is the business bear. it makes sure business is going smoothly.
-
-Ruggy is a Dixie deployment — a fork of loa-dixie (the governed multi-agent BFF) configured with Ruggy's identity, knowledge, and skills. It monitors 5 product repos, classifies user feedback as bugs or user-to-creator signals (UTCs), creates Linear issues following the Observer workflow, and reports ecosystem health via Discord.
-
-The vision is not "build an autonomous agent." The vision is: **when something breaks in any product repo, the team knows within hours, not days.**
-
-> Sources: grimoires/gecko/context-pack/11-decisions.md, grimoires/gecko/context-pack/15-reframe-dixie-as-template.md
-
-## 3. Goals & Success Metrics
-
-### Primary Goal
-Reduce Time to Awareness (TTA) for product repo issues from "unknown" (currently unmeasured, likely days) to <4 hours for HIGH severity and <1 hour for CRITICAL.
-
-### Success Metrics (Real, Not Vanity)
-
-| Metric | Definition | Month 1 Target | Month 3 Target |
-|--------|-----------|----------------|----------------|
-| **Time to Awareness (TTA)** | Time from user feedback submission to first human view of the Linear issue | Establish baseline | <4h HIGH, <1h CRITICAL |
-| **Human Override Rate** | % of Ruggy's classifications that a human changes | <50% (learning) | <25% |
-| **Signal-to-Action Ratio** | % of ingested signals that lead to a code change, fix, or design decision within 7 days | >5% | >10% |
-| **Coverage Gap Detection** | CRITICAL incidents discovered outside Ruggy's pipeline (found via other channels) | Log all gaps | 0 missed CRITICALs |
-| **Cost per Actionable Signal** | Total Ruggy spend (API + infra) / count of signals that led to action | <$10 | <$5 |
-
-### What We Explicitly Don't Track
-
-Total signal volume, widget install count, Discord command usage, uptime percentage, classification speed, number of Linear issues created. These are vanity — they measure deployment, not value.
-
-> Sources: grimoires/gecko/context-pack/16-real-metrics.md
-
-## 4. Users & Stakeholders
-
-### Primary Users
-
-**Product repo users** — people using mibera-dimensions, mcv-interface, cubquests-interface, set-and-forgetti, or apdao-auction-house who encounter bugs or have feedback. They interact with existing feedback UI in each app. They don't know Ruggy exists.
-
-**The development team** (@janitooor + 1-2 devs) — they receive classified, labeled, routed Linear issues instead of raw Discord messages. They review Ruggy's triage via the dashboard and Linear. They override Ruggy's classification when it's wrong.
-
-### Secondary Users
-
-**Construct authors** — future. When Ruggy observes patterns across construct usage, authors get signal about what's working and what's not.
-
-### Stakeholders
-
-- **@janitooor** — primary maintainer, sole reviewer, final authority on all overrides
-- **0xHoneyJar team** — receives ecosystem health reports
-
-## 5. Functional Requirements
-
-### FR-1: Dixie Fork & Identity Configuration
-
-Fork loa-dixie. Replace:
-- `persona/oracle.md` → `persona/ruggy.md` (hand-crafted BEAUVOIR: bazaar trader, lowercase energy)
-- `knowledge/oracle-binding.yaml` → `knowledge/ruggy-binding.yaml`
-- `knowledge/sources.json` → Ruggy's domain knowledge (5 product repos, signal taxonomy, construct registry, Linear config, Observer workflow)
-- `knowledge/contracts/oracle-requirements.json` → `knowledge/contracts/ruggy-requirements.json`
-
-Fix hardcoded Oracle references:
-- `identity.ts` fallback `nftId: 'oracle'` → parameterize from binding
-- `CorpusMeta.KNOWN_REPOS` → drive from binding or config
-
-Run existing test suite. Fix what breaks from identity swap.
-
-**Acceptance criteria**: Dixie fork boots, passes health check, returns Ruggy identity from `/api/health`. Knowledge queries return Ruggy-domain results.
-
-### FR-2: Signal Triage Pipeline (Observer Workflow)
-
-Implement the feedback-to-issue pipeline:
-
-```
-User feedback (existing UI in product repo)
-  → POST api.constructs.network/v1/signals (per-app API key)
-  → Convex signal store (dedup, store-first)
-  → Haiku classification (async, via cheval multi-model routing)
-    ├── bug → severity (critical/high/medium/low) + category
-    └── UTC → severity + category
-  → Linear issue creation
-    ├── bug template (707cddad)
-    └── UTC template (5377584f)
-    └── labels: [source_repo, severity, category, ruggy-triage]
-  → Discord alert (CRITICAL/HIGH only, via webhook)
-```
-
-**Acceptance criteria**: End-to-end test — submit feedback from a product repo widget → signal appears in Convex → Haiku classifies → Linear issue created with correct template and labels → Discord alert fires for HIGH/CRITICAL.
-
-### FR-3: Malleable Widget Integration (5 Product Repos)
-
-Insert signal ingestion logic into existing feedback UI in each product repo. Do NOT replace or restyle the existing UI — inject the POST to signals API alongside whatever the existing form does.
-
-| Repo | Priority | Notes |
-|------|----------|-------|
-| mibera-dimensions | 1 | Paired with honeyroad |
-| mibera-honeyroad | 1 | Paired with dimensions |
-| mcv-interface | 2 | Most mature, highest expected signal density |
-| cubquests-interface | 3 | Active product |
-| set-and-forgetti | 4 | Gold standard dApp |
-| apdao-auction-house | 5 | Origin repo |
-
-Each repo gets a per-app API key (`sk_live_...`) synced to Convex.
-
-**Acceptance criteria**: Each product repo submits feedback to the signals API. Signal arrives in Convex tagged with correct `app_slug`. Existing feedback UX is unchanged.
-
-**Discovery required**: Audit each repo's current feedback UI before implementation. Document what exists and what needs modification.
-
-### FR-4: Discord Hybrid (Alerts + Commands)
-
-**Webhook alerts** (push, fire-and-forget):
-- CRITICAL/HIGH signal alerts in #alerts channel
-- Daily summary in #ops channel (if signals were classified)
-
-**Slash command bot** (interactive):
-- `/ruggy status` — health score, signal volume (24h/7d), active incidents
-- `/ruggy signals [repo]` — recent signals with classification for a specific repo
-- `/ruggy escalations` — open Linear issues created from signals
-- `/ruggy repos` — all monitored repos with signal counts
-
-**Acceptance criteria**: Webhook alerts fire for CRITICAL/HIGH signals. Slash commands return correct data from Convex. Bot handles errors gracefully.
-
-### FR-5: Sovereignty Tier System
-
-Override rate drives autonomy tier automatically:
-
-| Override Rate | Tier | Behavior |
-|---------------|------|----------|
-| >40% | CONSTRAINED | Ruggy classifies but ALL issues require human review before creation |
-| 15-40% | STANDARD | Ruggy creates LOW/MEDIUM issues autonomously. HIGH/CRITICAL require review |
-| <15% | AUTONOMOUS | Full triage authority. Circuit breaker still active |
-
-Manual override: team can set any tier regardless of rate. Default: CONSTRAINED.
-
-Circuit breaker (from SOUL.md): 5 consecutive failures → halt. Same error 3 times → halt.
-
-Rate limits (from SOUL.md): Max 5 Linear issues/day per repo. 1 hour between issues to same repo.
-
-**Acceptance criteria**: Override rate tracked per-repo. Tier transitions happen automatically when 7-day rolling rate crosses thresholds. Manual override works. Circuit breaker halts on failure patterns.
-
-### FR-6: Knowledge Corpus
-
-Ruggy's knowledge base following Dixie's `sources.json` pattern:
-
-| Source | Priority | Required | Content |
-|--------|----------|----------|---------|
-| product-repos.md | 1 | Yes | The 5 monitored repos — what they do, who maintains them, known issues |
-| signal-taxonomy.md | 1 | Yes | Classification categories, severity definitions, routing rules |
-| linear-config.md | 2 | Yes | Team ID, templates, label taxonomy, project structure |
-| construct-registry.md | 3 | No | 14 constructs, their health signals, composition patterns |
-| observer-workflow.md | 2 | Yes | Feedback capture → classification → labelling → issue creation flow |
-| ecosystem-map.md | 3 | No | Org repos, infrastructure, team structure |
-
-**Acceptance criteria**: Knowledge queries retrieve relevant sources. Contract tests validate corpus meets requirements. Freshness tracking reports stale sources.
-
-## 6. Technical Requirements
-
-### TR-1: Dixie Fork Stack
-
-| Component | Technology | Source |
-|-----------|-----------|--------|
-| Runtime | Hono on Bun (Dixie's Hono, migrated to Bun) | loa-dixie fork |
-| Database | PostgreSQL (Dixie's 15 migrations) | loa-dixie fork |
-| Cache | Redis (projection cache, reputation cache) | loa-dixie fork |
-| Real-time | Convex (signal store, dashboard, patrol state) | cycle-044 |
-| Models | Claude Haiku/Sonnet/Opus via cheval | loa-dixie fork |
-| CLI | incur (agent-first, TOON, MCP bridge) | New |
-| Issue tracking | Linear GraphQL API | Existing (team 466d92ac) |
-| Alerting | Discord webhooks + slash command bot | New |
-
-### TR-2: Convex ↔ PostgreSQL Boundary
-
-| Convex (real-time, reactive) | PostgreSQL (governed, transactional) |
-|------------------------------|--------------------------------------|
-| Signal store (ingestion, dedup) | GovernedResource state (audit trail) |
-| Signal classifications | Compound learning patterns |
-| Patrol state (current cycle) | Sovereignty tier history |
-| Dashboard subscriptions | Override tracking (rolling 7-day) |
-| API key validation cache | API key master records |
-
-### TR-3: Cost Architecture
-
-| Model | Cost/op | Usage |
-|-------|---------|-------|
-| Haiku 3.5 | $0.001 | Every signal classification |
-| Sonnet 4 | $0.05 | Cross-signal investigation (10% of signals) |
-| Opus 4 | $0.50 | Complex incident analysis (1% of signals) |
-
-Target: ~$1/day for 5 repos. Hard ceiling: $3/day. Budget enforcement via cheval's existing mechanism.
-
-### TR-4: Security
-
-- API keys per product repo (`sk_live_...`) — SHA256 hashed in cache, cleartext never logged
-- Linear API key: personal key (not OAuth agent) — stored in env, never in code
-- Anthropic API key: stored in env, cost ceiling enforced
-- Trust boundary: reads everything, writes only to grimoires/gecko/, Linear issues, Discord webhooks
-- No direct database writes from external requests — all mutations through Convex or Dixie's middleware pipeline
-
-## 7. Scope
-
-### In Scope (Week 1)
-
-- FR-1: Dixie fork with Ruggy identity
-- FR-2: Signal triage pipeline (Observer workflow)
-- FR-3: Malleable widget integration (5 repos)
-- FR-4: Discord hybrid (alerts + commands)
-- FR-5: Sovereignty tier system (starting CONSTRAINED)
-- FR-6: Knowledge corpus
-
-### Out of Scope (Phase 2+)
-
-| Feature | Why Deferred |
-|---------|-------------|
-| Onchain observability (Score API) | Separate integration, separate signal type |
-| Linear Agent SDK registration | Can use personal account. SDK adds complexity without users yet |
-| Cross-signal correlation / incident grouping | Need signal volume data before designing correlation logic |
-| Compound learning (active) | Pipeline will accumulate data passively. Active pattern extraction is Phase 2 |
-| Beauvoir edge deployment (Cloudflare Workers) | Need always-on requirement before adding edge infrastructure |
-| Autonomous patrol loop | Triage loop first. Proactive patrol second. |
-| incur CLI | For agent self-invocation. Add after the triage pipeline proves value |
-
-### Explicitly NOT Building
-
-| Not This | Why |
-|----------|-----|
-| A Discord bot that chats | Ruggy creates issues and sends alerts. It doesn't have conversations |
-| A monitoring SaaS | Not competing with Datadog. Ruggy monitors user feedback, not infrastructure |
-| A general-purpose agent | Karpathy constraint: one thing well (ecosystem health triage) |
-| A replacement for Bridgebuilder | Bridgebuilder reviews code quality. Ruggy watches ecosystem health. Different loops |
-| Everything at once | Week 1 ships the triage loop. Compound learning is month 3+ |
-
-## 8. Risks & Dependencies
-
-### Risks
-
-| Risk | Impact | Mitigation |
-|------|--------|-----------|
-| Dixie fork test breakage | Days of debugging instead of building | Timebox to 1 day. If >50% tests break, skip test fixes and focus on new tests for Ruggy-specific code |
-| Product repos have no feedback UI | "Malleable insertion" has nothing to insert into | Audit repos FIRST (Day 0). Fall back to standalone widget if needed |
-| Low signal volume | Can't validate metrics with 0 signals | Seed with test signals. First real validation when repos go live |
-| Haiku classification accuracy | High override rate kills trust | Start CONSTRAINED. Every override is training data. Accuracy improves with corrections |
-| Single maintainer bottleneck | @janitooor reviews everything | Sovereignty system reduces review burden as accuracy improves |
-
-### Dependencies
-
-| Dependency | Status | Risk |
-|-----------|--------|------|
-| Convex signal pipeline (cycle-044) | Deployed, E2E tested | Low — working |
-| Linear team + templates | Configured (466d92ac) | Low — existing |
-| Discord webhook | Configured | Low — existing |
-| loa-dixie repo access | Private, org member | Low — same org |
-| Product repo access (5 repos) | Private, org member | Low — same org |
-| Anthropic API key | Configured | Low — existing |
-| Per-app API keys | Infrastructure exists, keys need creation per repo | Medium — 5 keys to create and configure |
-
-## 9. Ruggy Identity (BEAUVOIR)
-
-Hand-crafted, not dAMP-96 generated. Adapted from ruggy-v3 IDENTITY.md + GECKO.md BEAUVOIR.
-
-**Core traits**:
-- **lowercase energy** — calm, approachable, never shouting
-- **high analytical** — data-first, evidence-based triage
-- **high depth** — follows signals to root causes, not symptoms
-- **moderate formality** — business bear, not corporate bot
-- **high citation density** — always shows its work
-- **warm but measured** — cares about the ecosystem, doesn't panic
-
-**Voice**: Direct but warm. Speaks from experience, not authority. "i've seen this before" not "the data suggests." Encourages without cheerleading. Honest about what it doesn't know.
-
-**Anti-patterns**: Never surveil (observe, don't watch). Never extrapolate desire from behavior. Never optimize for engagement. Never mistake the registry for the bazaar.
-
-**Banned words**: exciting, incredible, massive, revolutionary, game-changing, conviction, stay tuned, trust the process.
-
-> Sources: grimoires/bridgebuilder/GECKO.md, /Users/zksoju/Documents/GitHub/ruggy-v3/deploy/loa-identity/IDENTITY.md, grimoires/gecko/context-pack/07-dixie-baseline.md
-
-## 10. Timeline
-
-| Day | Deliverable |
-|-----|------------|
-| 0 | Audit 5 product repos — what feedback UI exists? Document findings. |
-| 1 | Fork loa-dixie. Replace persona + knowledge + binding. Run tests, fix breakage. |
-| 2 | Signal triage route (Convex bridge). Haiku classifier through cheval. |
-| 3 | Linear issue creation from classified signals. Observer workflow wired end-to-end. |
-| 3 | Malleable widget logic PRs for product repos (based on Day 0 audit). |
-| 4 | Discord hybrid — webhook alerts + slash command bot. |
-| 4 | Sovereignty tier tracking (CONSTRAINED default). Circuit breaker. Rate limits. |
-| 5 | Integration testing — full pipeline: widget → signal → classify → issue → alert. |
-| 5 | Deploy. Start measuring TTA and override rate. |
+> Sources: `ruggy-structural-alignment.md`, deployment audit findings (this session)
 
 ---
 
-*This PRD crystallizes decisions from 16 files of research across 3 sessions. Superseded architectures (standalone construct, patterns-only adoption) are archived in `grimoires/gecko/context-pack/`. The current architecture is: fork Dixie, build on top, deploy.*
+## 2. Goals & Success Metrics
+
+### Primary Goal
+
+Align documentation with reality, surface the signals dashboard to admin users, and close the 4 highest-severity reliability gaps in the signal pipeline.
+
+### Success Criteria
+
+| Metric | Target | Verification |
+|--------|--------|--------------|
+| Documentation accuracy | Zero Dixie references in `ruggy-ecosystem-intelligence.md` | Manual read |
+| Dashboard discoverability | "Signals" QuickLink visible on `/dashboard` for admin users | Visual check |
+| Convex README relevance | Describes actual signal pipeline, not generic tutorial | Manual read |
+| Classification terminal state | Signals fail after 3 attempts → `classification_failed` status | Send malformed signal, check Convex DB after 3 cron cycles |
+| Escalation failure visibility | Failed Linear calls → `escalationStatus: "failed"` | Simulate Linear API failure |
+| Missing env var detection | Missing `LINEAR_API_KEY` throws error (not silent return) | Remove env var, send HIGH signal |
+| Override query performance | `by_appSlug_createdAt` index used in sovereignty recalculation | Check Convex query plan |
+
+### Non-Goals (Deferred)
+
+- construct-ruggy Railway deployment (blocked on `FINN_URL` / loa-finn)
+- Historical feedback migration from Supabase (~155 rows)
+- Discord slash command bot
+- Shared auth helper extraction (Phase 3 — lower priority)
+- Circuit breaker persistence (Phase 3)
+
+---
+
+## 3. User & Stakeholder Context
+
+### Primary Persona: Ecosystem Operator (@janitooor)
+
+- Maintains all 6 product repos + constructs network infrastructure
+- Needs: signals dashboard discoverable from main dashboard, accurate documentation for context in future sessions, confidence that pipeline failures surface visibly
+- Current pain: dashboard exists but requires direct URL, documentation describes architecture that was never built, no way to know if Linear escalation silently failed
+
+> Sources: user interview (this session), cycle-046 deployment observations
+
+---
+
+## 4. Functional Requirements
+
+### Phase 1: Documentation & Visibility (No code behavior changes)
+
+| ID | Requirement | Acceptance Criteria |
+|----|-------------|---------------------|
+| P1-1 | Add Signals QuickLink to dashboard overview | `<QuickLink href="/dashboard/signals" label="Signals" />` visible in admin grid at `/dashboard` |
+| P1-2 | Rewrite `ruggy-ecosystem-intelligence.md` | Zero Dixie references. Describes Convex-native pipeline with 6 repos, correct API path (`constructs.network/api/signals`), correct stack (Convex + Haiku 4.5 direct). Preserves: metrics, sovereignty model, identity, phase 2 roadmap. |
+| P1-3 | Replace Convex README boilerplate | Describes actual signal pipeline functions, cron jobs, schema tables, env vars. Not generic Convex tutorial. |
+
+### Phase 2: HIGH Reliability Fixes (4 items)
+
+| ID | Requirement | Acceptance Criteria |
+|----|-------------|---------------------|
+| P2-1 | Classification retry cap | `classificationAttempts` counter increments per try. After 3 failures → `status: "classification_failed"`. `retry-classification` cron filters `classificationAttempts < 3`. Schema: add `classificationAttempts` optional number field. |
+| P2-2 | Escalation failure visibility | Failed Linear call in `sovereigntyGatedEscalate` → `escalationStatus: "failed"` (not `"escalated"`). `check-linear-failures` cron (15m) picks up for retry. |
+| P2-3 | Linear env var missing detection | Missing `LINEAR_API_KEY` in `createLinearIssue` throws descriptive error (not silent return). Surfaces in Convex function logs. |
+| P2-4 | Override query index | Add `by_appSlug_createdAt` index on override table in `schema.ts`. Sovereignty recalculation queries use `.withIndex()`. |
+
+### Phase 3: MEDIUM/LOW Consolidation (6 items)
+
+| ID | Requirement | Acceptance Criteria |
+|----|-------------|---------------------|
+| P3-1 | Extract shared auth helper | Key cache + SHA256 validation extracted to `apps/explorer/lib/signals/auth.ts` |
+| P3-2 | Shared Zod validator | Single canonical schema between route (Zod) and Convex (validators). No duplication. |
+| P3-3 | Circuit breaker persistence | `circuitBreakerState` field on sovereignty table. Survives Convex cold starts. |
+| P3-4 | Heartbeat cron offset | `heartbeat` and `heartbeat-check` staggered by 30m. No simultaneous execution. |
+| P3-5 | statusCounts safety bound | Dashboard `statusCounts` query adds `.take(10000)` safety cap. |
+| P3-6 | Sovereignty initialization upsert | First signal from new app creates sovereignty tier with upsert logic. No race condition on simultaneous signals. |
+
+> Sources: `ruggy-structural-alignment.md` (14 findings)
+
+---
+
+## 5. Technical & Non-Functional Requirements
+
+### Architecture Constraints
+
+| Constraint | Rationale |
+|-----------|-----------|
+| Schema changes require `npx convex deploy` to both dev and prod | Convex schema is server-side; changes must be pushed |
+| `classificationAttempts` must be optional (backward compatible) | Existing signals in DB have no field; optional with default 0 |
+| Override index must match existing query pattern | Index field order must match `.withIndex()` call |
+| No breaking changes to `/api/signals` contract | 6 product repos already sending signals; route interface is frozen |
+
+### Files Modified
+
+| File | Changes | Risk |
+|------|---------|------|
+| `apps/explorer/app/(dashboard)/dashboard/page.tsx` | Add QuickLink | Low — additive UI |
+| `grimoires/loa/context/ruggy-ecosystem-intelligence.md` | Full rewrite | None — documentation only |
+| `apps/explorer/convex/README.md` | Full rewrite | None — documentation only |
+| `apps/explorer/convex/signals.ts` | Classify retry cap, escalation error handling, statusCounts bound, sovereignty race | Medium — core pipeline logic |
+| `apps/explorer/convex/linear.ts` | Throw on missing env var | Medium — changes failure mode |
+| `apps/explorer/convex/schema.ts` | New field + new index | Medium — schema migration |
+| `apps/explorer/convex/crons.ts` | Heartbeat offset | Low — timing only |
+
+### Failure Modes
+
+| Failure | Impact | Mitigation |
+|---------|--------|------------|
+| Schema push fails (classificationAttempts) | New field not available | Field is optional; existing signals unaffected. Retry push. |
+| Linear env var throw breaks existing flow | Escalation pipeline errors instead of silent skip | `check-linear-failures` cron (15m) retries. Better than silent data loss. |
+| Index migration on large table | Slow Convex schema push | Override table is small (<100 rows); negligible. |
+
+---
+
+## 6. Scope & Prioritization
+
+### In Scope (this cycle)
+
+| Phase | Scope | Effort |
+|-------|-------|--------|
+| Phase 1 | Documentation + dashboard visibility | Small (3 files, no behavior changes) |
+| Phase 2 | 4 HIGH reliability fixes | Medium (core pipeline logic + schema) |
+| Phase 3 | 6 MEDIUM/LOW consolidation items | Medium (refactoring + schema) |
+
+### Explicitly Out of Scope
+
+| Item | Reason |
+|------|--------|
+| construct-ruggy Railway deployment | Blocked on FINN_URL (loa-finn doesn't exist) |
+| Historical feedback migration | Separate micro-cycle (~155 Supabase rows) |
+| New fan-out integrations | All 6 repos already wired |
+| Discord slash command bot | Phase 2 roadmap (not blocking triage) |
+| Sentry integration | Separate infrastructure decision |
+
+### MVP Definition
+
+**Phase 1 + Phase 2 is the MVP.** Documentation accuracy and the 4 HIGH reliability fixes are the minimum viable delivery. Phase 3 consolidation is valuable but not blocking.
+
+---
+
+## 7. Risks & Dependencies
+
+### Technical Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Convex schema push fails | Low | Schema changes not applied | Retry; fields are optional/additive |
+| `createLinearIssue` throw cascades | Medium | Escalation pipeline surfaces errors | Existing `check-linear-failures` cron retries at 15m intervals |
+| Classification retry counter race | Low | Counter incremented twice for same attempt | Convex mutations are serialized per document |
+
+### External Dependencies
+
+| Dependency | Type | Risk Level |
+|-----------|------|------------|
+| Convex dashboard (schema push) | Deployment | Low — well-understood flow |
+| Convex prod deployment (`quaint-anaconda-866`) | Deployment | Low — deployed multiple times in cycle-046 |
+| Vercel redeploy (explorer) | Deployment | Low — automatic on merge to main |

--- a/grimoires/loa/sdd.md
+++ b/grimoires/loa/sdd.md
@@ -1,534 +1,216 @@
-# SDD: Ruggy — Autonomous Ecosystem Intelligence Agent
+# SDD: Ruggy Structural Alignment
 
-**Cycle**: cycle-045
+**Cycle**: cycle-047
 **PRD**: grimoires/loa/prd.md
 **Created**: 2026-03-13
 **Status**: Draft
 
-**Grounded In**:
-- Cycle-044 signal infrastructure (Convex schema, API routes, classification, Linear, Discord — all deployed)
-- loa-dixie fork surface audit (5 Oracle identity points, 15-layer middleware, 13 routes, 2,431 tests)
-- Day 0 product repo audit (4 have widgets, 2 need them)
-- Flatline PRD skeptic concerns (7 findings — all addressed)
+---
+
+## 1. Architecture Overview
+
+No new systems or services. All changes are within the existing Convex signal pipeline (`apps/explorer/convex/`) and the explorer Next.js app. The architecture remains:
+
+```
+Product repos → POST /api/signals (Vercel) → Convex ingest → Haiku classify → sovereignty gate → Linear/Discord
+```
+
+This cycle addresses structural debt: documentation accuracy, dashboard visibility, and reliability gaps in error handling and failure recovery paths.
 
 ---
 
-## 1. Executive Summary
+## 2. Phase 1: Documentation & Visibility
 
-Ruggy connects existing infrastructure to the repos that need it. Two layers:
+### 2.1 Dashboard QuickLink
 
-**Convex Signal Layer** (exists, deployed, tested) — ingestion, dedup, Haiku classification, Linear escalation, Discord alerting, dashboard. This IS the pipeline. Rugby doesn't rebuild it.
+**File**: `apps/explorer/app/(dashboard)/dashboard/page.tsx`
 
-**Dixie Governance Layer** (new, forked) — identity, knowledge corpus, sovereignty engine, Discord slash commands, override tracking, audit trail. Intelligence and governance ON TOP of the signal pipeline.
+Add `Signals` QuickLink inside the existing admin grid (lines 54-59, `isAdmin && (...)` block). Follows the existing `QuickLink` component pattern already used for API Keys, Graph, and Metrics.
 
-Product repos POST feedback to the existing Convex signal API (`constructs.network/api/signals`). The Dixie fork orchestrates governance decisions and provides Discord interactivity.
+```tsx
+// Inside the admin grid, after existing StatCards
+<QuickLink href="/dashboard/signals" label="Signals" />
+```
 
-### What Already Works (Don't Touch)
+No new components. No new routes. The `/dashboard/signals` page already exists with 7 components.
 
-| Component | Location | Status |
-|-----------|----------|--------|
-| Signal ingestion + dedup | `apps/explorer/convex/signals.ts:ingest` | Deployed |
-| Haiku classification (3-retry) | `apps/explorer/convex/signals.ts:classify` | Deployed |
-| Linear issue creation (template-routed) | `apps/explorer/convex/linear.ts:createLinearIssue` | Deployed |
-| Discord alerts (CRITICAL/HIGH, 5-min debounce) | `apps/explorer/convex/signals.ts:alertDiscord` | Deployed |
-| Signal API key validation (bcryptjs) | `apps/explorer/convex/signals.ts:verifySignalKey` | Deployed |
-| Rate limiting (100/key/hour) | `apps/explorer/convex/signalRateLimits` table | Deployed |
-| Reconciliation cron (hourly) | `apps/explorer/convex/crons.ts` | Deployed |
-| Retry classification cron (5-min) | `apps/explorer/convex/crons.ts` | Deployed |
-| Heartbeat monitoring (hourly) | `apps/explorer/convex/signals.ts:sendHeartbeat` | Deployed |
-| API key provisioning | `apps/api/src/routes/keys.ts:POST /v1/keys` | Deployed |
-| Feedback widget (explorer) | `apps/explorer/components/feedback-widget.tsx` | Deployed |
+### 2.2 Rewrite `ruggy-ecosystem-intelligence.md`
 
-### What Ruggy Adds
+**File**: `grimoires/loa/context/ruggy-ecosystem-intelligence.md`
 
-| Component | Purpose |
-|-----------|---------|
-| Dixie fork with Ruggy identity | Governance brain |
-| Sovereignty engine | Override-rate-driven tier system |
-| Discord slash commands | Interactive ecosystem queries |
-| Knowledge corpus | Rugby-domain context for classification |
-| Widget logic in 6 product repos | Signal forwarding to Convex API |
-| Override tracking (Convex table) | 7/30-day rolling window |
-| Enhanced classification prompt | App-context-aware, severity-calibrated |
-| Origin validation | Per-key domain allowlist (SKP-001) |
-| Pipeline error alerting | Discord alert on 3x Linear failure (SKP-003) |
+Full rewrite. Current doc claims Dixie fork with Hono/PostgreSQL/Redis/incur/cheval — none built. Replace with:
+- Actual stack: Convex-native pipeline, Claude Haiku 4.5 direct, 6 repos
+- Correct API path: `constructs.network/api/signals` (not `api.constructs.network/v1/signals`)
+- Preserve: metrics table, sovereignty model, identity section, phase 2 roadmap
+- Reference: `ruggy-signal-architecture.md` for Mermaid diagrams (already accurate)
+
+### 2.3 Replace Convex README
+
+**File**: `apps/explorer/convex/README.md`
+
+Replace 91-line generic Convex tutorial with project-specific reference covering:
+- Signal pipeline functions (ingest, classify, escalate, alertDiscord)
+- Cron jobs (8 total: presence cleanup, retry-classification, reconcile-linear, purge-expired, heartbeat, heartbeat-check, recalculate-sovereignty, check-linear-failures)
+- Schema tables (signals, signalKeys, signalRateLimits, sovereigntyState, dashboardPresence)
+- Required env vars (ANTHROPIC_API_KEY, CONVEX_WRITE_KEY, LINEAR_API_KEY, LINEAR_TEAM_PRODUCT, LINEAR_TEAM_INFRASTRUCTURE, DISCORD_SIGNALS_WEBHOOK_URL)
 
 ---
 
-## 2. System Architecture
+## 3. Phase 2: HIGH Reliability Fixes
 
-### 2.1 High-Level Architecture
+### 3.1 Classification Terminal State (P2-1)
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                      PRODUCT REPOS (sensors)                         │
-│                                                                       │
-│  midi-interface   honeyroad   mcv   cubquests   S&F   apDAO          │
-│    [fan-out]      [new]     [fan-out] [new]   [fan-out] [fan-out]    │
-│       │              │         │        │         │         │         │
-└───────┼──────────────┼─────────┼────────┼─────────┼─────────┼────────┘
-        └──────────────┴─────────┴────┬───┴─────────┴─────────┘
-                                      │
-                             POST /api/signals
-                             (Authorization: sk_live_...)
-                                      │
-                                      ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                  CONVEX SIGNAL LAYER (nervous system)                 │
-│                                                                       │
-│  Ingestion → Classify (Haiku) → Escalate (Linear) → Alert (Discord) │
-│                                                                       │
-│  + signalOverrides (new)  + sovereigntyState (new)  + pipelineErrors │
-└────────────────────────────────────┬────────────────────────────────┘
-                                     │ Convex HTTP queries
-                                     ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                 DIXIE GOVERNANCE LAYER (brain)                       │
-│                                                                       │
-│  Sovereignty Engine  │  Discord Slash Commands  │  Knowledge Corpus  │
-│  Circuit Breaker     │  Ruggy Identity          │  Compound Learning │
-└─────────────────────────────────────────────────────────────────────┘
-```
+**File**: `apps/explorer/convex/signals.ts`
 
-### 2.2 Signal Lifecycle
+**Current behavior** (lines 322-434): `classify` action already increments `classificationAttempts` and guards at `>= 3`. But signals reaching 3 attempts stay at `status: "new"` forever — the `retryFailedClassifications` cron (lines 953-977) silently excludes them. No terminal status, no alerting, no manual re-queue path.
 
-```
-1. USER submits feedback via product repo widget
-2. Widget POSTs to constructs.network/api/signals (sk_live_ key)
-3. CONVEX ingest(): validate key → rate limit → dedup → store
-4. CONVEX classify(): Haiku classification (async, <30s p95, 3 retries)
-5. SOVEREIGNTY CHECK: tier determines auto-escalation vs human review
-6. CONVEX escalate() → Linear issue (bug template 707cddad / UTC 5377584f)
-7. CONVEX alertDiscord() for CRITICAL/HIGH (5-min debounce)
-8. LINEAR webhook → CONVEX sync (Done→resolved, Canceled→dismissed)
-9. OVERRIDE: human changes classification → logged to signalOverrides
-```
-
-### 2.3 Convex ↔ Dixie Boundary
-
-| Convex (real-time, event-driven) | Dixie PostgreSQL (governed, transactional) |
-|----------------------------------|-------------------------------------------|
-| Signal store (ingestion, dedup, classification) | GovernedResource state (audit trail) |
-| Signal overrides (rolling window) | Sovereignty tier history (all transitions) |
-| Dashboard subscriptions (live) | Compound learning patterns (passive) |
-| API key validation cache | API key master records |
-| Rate limit windows | Knowledge corpus metadata |
-
-**Bridge**: Dixie reads Convex via HTTP queries for Discord commands and dashboard data. Sovereignty state lives ONLY in Convex (where classification decisions are made) — no bridge needed for the hot path. Dixie fork handles Discord interactions and knowledge queries, not real-time governance decisions.
-
----
-
-## 3. Component Design
-
-### 3.1 Dixie Fork — Identity Swap
-
-**Repo**: `construct-ruggy` (fork of `loa-dixie`)
-
-**5 Oracle Identity Change Points** (from audit):
-
-| File | Change |
-|------|--------|
-| `persona/oracle.md` | Replace with `persona/ruggy.md` |
-| `knowledge/oracle-binding.yaml` | Replace with `knowledge/ruggy-binding.yaml` |
-| `app/src/routes/identity.ts` | `'oracle'` → parameterize from binding (3 occurrences) |
-| `app/src/routes/chat.ts` | `agentId: 'oracle'` → read from binding |
-| `app/src/services/corpus-meta.ts` | `KNOWN_REPOS` at line 265 → Ruggy's 6 repos |
-
-**New binding** (`knowledge/ruggy-binding.yaml`):
-```yaml
-agent_id: ruggy
-name: Ruggy
-model:
-  pool: default
-  temperature: 0.3
-  max_tokens: 4096
-knowledge:
-  mode: full
-  default_budget_tokens: 30000
-identity:
-  type: hand_crafted
-persona_path: persona/ruggy.md
-sources_path: knowledge/sources.json
-```
-
-**New KNOWN_REPOS**:
-```typescript
-const KNOWN_REPOS: Array<{ repo: string; sourceIds: string[] }> = [
-  { repo: 'midi-interface',       sourceIds: ['product-repos'] },
-  { repo: 'mibera-honeyroad',     sourceIds: ['product-repos'] },
-  { repo: 'mcv-interface',        sourceIds: ['product-repos'] },
-  { repo: 'cubquests-interface',  sourceIds: ['product-repos'] },
-  { repo: 'set-and-forgetti',     sourceIds: ['product-repos'] },
-  { repo: 'apdao-auction-house',  sourceIds: ['product-repos'] },
-];
-```
-
-**Test strategy**: Run existing 2,431 tests after identity swap. Expected breakage: tests asserting "Oracle" in responses, identity route tests, knowledge contract tests. Timebox: 1 day. If >50% break, write new Ruggy-specific tests only.
-
-### 3.2 Convex Schema Extensions
-
-**New table: `signalOverrides`** — tracks human classification changes for sovereignty calculation.
+**Change**: After incrementing `classificationAttempts` to 3 in the catch block, also set `status: "classification_failed"`.
 
 ```typescript
-signalOverrides: defineTable({
-  signalId: v.id("signals"),
-  appSlug: v.string(),
-  originalClassification: v.object({
-    level1Symptom: v.string(),
-    level2Want: v.string(),
-    level3Hypothesis: v.string(),
-    confidence: v.number(),
-    labels: v.array(v.string()),
-  }),
-  overriddenClassification: v.object({
-    level1Symptom: v.string(),
-    level2Want: v.string(),
-    level3Hypothesis: v.string(),
-    confidence: v.number(),
-    labels: v.array(v.string()),
-  }),
-  overriddenBy: v.string(),
-  reason: v.optional(v.string()),
-  timestamp: v.number(),
-}).index("by_app_timestamp", ["appSlug", "timestamp"])
-  .index("by_signal", ["signalId"]),
+// In classify action catch block, after incrementing classificationAttempts:
+const newAttempts = (signal.classificationAttempts ?? 0) + 1;
+await ctx.runMutation(internal.signals.patchClassificationAttempt, {
+  signalId: args.signalId,
+  attempts: newAttempts,
+  // NEW: set terminal status when max retries reached
+  ...(newAttempts >= 3 ? { status: 'classification_failed' } : {}),
+});
 ```
 
-**New table: `sovereigntyState`** — current tier per scope.
+**Also**: Same treatment for the missing-API-key early return path (currently increments attempts silently).
 
+**Schema note**: `classificationAttempts` already exists as a required number field. `status` is a plain string — no enum constraint. Adding `"classification_failed"` as a value requires no schema change.
+
+**Affected functions**: `patchClassificationAttempt` mutation needs a `status` parameter (currently only patches `classificationAttempts`).
+
+### 3.2 Escalation Failure Visibility (P2-2)
+
+**File**: `apps/explorer/convex/signals.ts` (lines 1139-1180)
+
+**Current behavior**: `sovereigntyGatedEscalate` schedules `internal.linear.createLinearIssue` via `ctx.scheduler.runAfter(0, ...)`. This is fire-and-forget — if `createLinearIssue` fails, the caller never knows.
+
+**Problem refinement**: The issue isn't in `sovereigntyGatedEscalate` itself (it just schedules) — it's in `createLinearIssue` (linear.ts lines 37-88). On failure, it increments `linearCreationAttempts` but does NOT update the signal's status. The signal may have been set to `escalated` before the Linear call actually succeeded.
+
+**Change in `linear.ts`**: On catch, set `escalationStatus` or equivalent field to indicate failure. Since the schema doesn't have an `escalationStatus` field, use the existing `status` field:
+- On successful Linear issue creation: status stays as-is (set by caller)
+- On failed Linear creation: leave status unchanged (don't mark as escalated). The `checkLinearFailures` cron (every 15m) already detects signals with `linearCreationAttempts > 0` and no `linearIssueId`.
+
+**Actual fix**: In `sovereigntyGatedEscalate`, do NOT update signal status to `escalated` before scheduling `createLinearIssue`. Instead, let `createLinearIssue` update status to `escalated` only on success. Current flow unclear — need to verify whether status is set before or after the schedule call.
+
+### 3.3 Linear Env Var Detection (P2-3)
+
+**File**: `apps/explorer/convex/linear.ts` (line ~45)
+
+**Current behavior**: `if (!apiKey) return;` — silent no-op. All signals that should escalate silently vanish. Same for missing `LINEAR_TEAM_*` env vars.
+
+**Change**:
 ```typescript
-sovereigntyState: defineTable({
-  scope: v.string(),             // "global" or app_slug
-  tier: v.union(v.literal("constrained"), v.literal("standard"), v.literal("autonomous")),
-  overrideRate: v.number(),      // 0.0 - 1.0
-  signalCount: v.number(),       // signals in window
-  overrideCount: v.number(),     // overrides in window
-  windowDays: v.number(),        // 7 or 30 (adaptive)
-  manualOverride: v.optional(v.object({
-    tier: v.string(),
-    setBy: v.string(),
-    reason: v.string(),
-    expiresAt: v.optional(v.number()),
-  })),
-  lastTransition: v.optional(v.object({
-    from: v.string(),
-    to: v.string(),
-    timestamp: v.number(),
-    trigger: v.string(),
-  })),
-  updatedAt: v.number(),
-}).index("by_scope", ["scope"]),
-```
-
-### 3.3 Sovereignty Engine
-
-**Tier transitions** (enhanced per SKP-005a — minimum sample size):
-
-```
-CONSTRAINED (default)
-  ↓  override_rate < 40% AND signal_count >= 20
-STANDARD
-  ↓  override_rate < 15% AND signal_count >= 50
-AUTONOMOUS
-```
-
-**Adaptive window**: ≥10 signals/week → 7-day window. <10 signals/week → 30-day window. Prevents noise-driven tier transitions on low volume.
-
-**Circuit breaker** (SOUL.md): 5 consecutive failures → halt. Same error 3× → halt. Manual reset via Discord command.
-
-**Rate limits** (SOUL.md): Max 5 Linear issues/day per repo. 1 hour between issues to same repo.
-
-**Implementation**: Convex cron `recalculateSovereignty` runs hourly. Reads `signalOverrides` for rolling window, updates `sovereigntyState`. The `classify` → `escalate` path checks tier before scheduling Linear creation.
-
-**Maintainer burden relief** (SKP-004): Start apdao-auction-house at STANDARD tier. Origin repo, lowest risk, validates autonomous classification path faster.
-
-### 3.4 Widget Integration Strategy
-
-**Day 0 Audit Results**:
-
-| Repo | Local Path | Widget Status | Backend | Integration |
-|------|-----------|--------------|---------|-------------|
-| midi-interface (mibera-dimensions) | `/Users/zksoju/Documents/GitHub/midi-interface/` | Pulse widget + feedback dialog | Supabase `score_feedback` | Fan-out after Supabase write |
-| mibera-honeyroad | `/Users/zksoju/Documents/GitHub/mibera-honeyroad/` | None | — | New widget in `(main)/layout.tsx` |
-| mcv-interface | `/Users/zksoju/Documents/GitHub/mcv-interface/` | Vault rating modal (bad/fine/good) | Convex `vaultFeedback` | Convex HTTP action after insert |
-| cubquests-interface | `/Users/zksoju/Documents/GitHub/cubquests-interface/` | None | — | New widget in `components/layout/navbar.tsx` |
-| set-and-forgetti | `/Users/zksoju/Documents/GitHub/set-and-forgetti/` | Popover + dialog in navbar | Linear (AI-classified) | Fan-out after `createFeedbackIssue()` |
-| apdao-auction-house | `/Users/zksoju/Documents/GitHub/apdao-auction-house/` | Popover + screenshot upload | Linear (AI spam+priority) | Fan-out after `createIssue()` |
-
-**Fan-out pattern** (4 repos with existing widgets):
-
-```typescript
-// Fire-and-forget after existing feedback submission succeeds
-try {
-  await fetch('https://constructs.network/api/signals', {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${process.env.SIGNALS_API_KEY}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      source: 'feedback_widget',
-      severity: derivedSeverity,
-      title: feedbackTitle,
-      data: { type: 'feedback', category, description },
-    }),
-  });
-} catch (err) {
-  // Log failure — don't block existing pipeline, but make it observable
-  console.error('[ruggy-fanout] Signal forwarding failed:', err instanceof Error ? err.message : err);
+const apiKey = process.env.LINEAR_API_KEY;
+if (!apiKey) {
+  console.error('[linear] LINEAR_API_KEY is not set — cannot create issues. Signal will be retried by check-linear-failures cron.');
+  throw new Error('LINEAR_API_KEY not configured');
 }
 ```
 
-**Integration points per repo**:
+This surfaces in Convex function logs and causes the `checkLinearFailures` cron to detect the signal (it checks `linearCreationAttempts > 0` with no `linearIssueId`). After 3 failures, Discord alert fires.
 
-| Repo | File | Insert After |
-|------|------|-------------|
-| midi-interface | `app/actions/feedback.ts` | Supabase `score_feedback` insert |
-| mcv-interface | `convex/feedback.ts` | Convex scheduled HTTP action after `submit` mutation |
-| set-and-forgetti | `apps/web/app/api/feedback/route.ts` | `createFeedbackIssue()` success |
-| apdao-auction-house | `actions/create-feedback.ts` | `createIssue()` success |
+**Same treatment for `LINEAR_TEAM_PRODUCT` / `LINEAR_TEAM_INFRASTRUCTURE`** — throw with descriptive error instead of silent return.
 
-**New widget pattern** (2 repos — honeyroad, cubquests):
+### 3.4 Override Query Index (P2-4)
 
-Copy `apps/explorer/components/feedback-widget.tsx` and adapt:
-- Remove explorer-specific imports
-- Configure per-repo API key via env var
-- Point at `https://constructs.network/api/signals`
-- Match repo's design system
+**File**: `apps/explorer/convex/signals.ts` (recalculateSovereignty function) + `apps/explorer/convex/schema.ts`
 
-**mcv special case**: Convex mutations can't call external HTTP APIs directly. Solution: schedule a Convex HTTP action (`ctx.scheduler.runAfter`) after the `submit` mutation that POSTs to the signals API.
+**Current behavior**: Sovereignty recalculation needs override rate data. The sovereignty state table has index `by_scope ([scope])` which is used for lookups. The override rate calculation reads from signals directly using `by_app` index (which already exists as `[appSlug, timestamp]`).
 
-### 3.5 Discord Slash Commands
+**Assessment**: The `by_app` index on signals table already covers `[appSlug, timestamp]` — this is exactly what override rate calculation needs. If `recalculateSovereignty` is not using this index (doing a filter instead of `.withIndex()`), update the query to use it. If it already uses the index, this finding is resolved.
 
-**Architecture**: Discord Interactions endpoint on Dixie fork. HTTP-based (not gateway bot). Ed25519 signature verification.
-
-**Route**: `POST /api/discord/interactions` (Dixie fork)
-
-| Command | Data Source | Response |
-|---------|-----------|----------|
-| `/ruggy status` | Convex `statusCounts()` + `sovereigntyState` | Health score, volumes (24h/7d), tier per repo |
-| `/ruggy signals [repo]` | Convex `byApp(appSlug)` | Recent signals with classification |
-| `/ruggy escalations` | Convex `status: 'escalated'` query | Open Linear issues with links |
-| `/ruggy repos` | Convex `statusCounts()` | All repos with signal counts + tier |
-
-**Response format**: Discord embeds with severity color coding (critical=red, high=amber, medium=blue, low=gray). Deferred responses for multi-query commands.
-
-### 3.6 Enhanced Classification
-
-Existing Haiku classifier works. Ruggy enhances the prompt with app-specific context:
-
-```
-You are Ruggy, an ecosystem health triage agent for 0xHoneyJar products.
-
-Context about {appSlug}:
-{knowledge_snippet}
-
-Classify this user feedback:
-- App: {appSlug}
-- Title: {title}
-- Description: {description}
-- Frustration: {frustration}/5
-
-Respond with JSON:
-{
-  "type": "bug" | "utc",
-  "level1Symptom": "...",
-  "level2Want": "...",
-  "level3Hypothesis": "...",
-  "severity": "critical" | "high" | "medium" | "low",
-  "category": "crash" | "regression" | "broken_feature" | "data_issue" |
-              "feature_request" | "ux_friction" | "performance" | "confusion" | "praise",
-  "confidence": 0.0-1.0,
-  "labels": ["..."]
-}
-```
-
-The `knowledge_snippet` is a short context block per app stored alongside the classification prompt, giving Haiku context about what the app does and known issues.
-
-### 3.7 Knowledge Corpus
-
-Following Dixie's `sources.json` pattern:
-
-| Source | Priority | Required | Tokens |
-|--------|----------|----------|--------|
-| `product-repos.md` | 1 | Yes | 8000 |
-| `signal-taxonomy.md` | 1 | Yes | 4000 |
-| `observer-workflow.md` | 2 | Yes | 4000 |
-| `linear-config.md` | 2 | Yes | 3000 |
-| `construct-registry.md` | 3 | No | 5000 |
-| `ecosystem-map.md` | 3 | No | 4000 |
+**Action**: Verify the actual query in `recalculateSovereignty` and ensure it uses `.withIndex("by_app")` with appropriate range bounds rather than collecting and filtering in-memory.
 
 ---
 
-## 4. Security Architecture
+## 4. Phase 3: MEDIUM/LOW Consolidation
 
-### 4.1 Client-Side API Key Protection (SKP-001)
+### 4.1 Extract Auth Helper (P3-1)
 
-| Layer | Protection | Status |
-|-------|-----------|--------|
-| Rate limiting | 100 signals/key/hour (sliding window) | Deployed |
-| Origin validation | `Origin`/`Referer` check against per-key domain allowlist | **New** |
-| Body validation | Zod schema rejects malformed payloads | Deployed |
-| Stack trace sanitization | Strips secrets from traces | Deployed |
-| Dedup | 5-minute time bucket dedup | Deployed |
-| Key revocation | Immediate via `DELETE /v1/keys/:id` | Deployed |
-| Cost ceiling | 100 signals/hr × $0.001 = $2.40/day worst case per key | Acceptable |
+**Files**: `apps/explorer/app/api/signals/route.ts` → new `apps/explorer/lib/signals/auth.ts`
 
-**New: Origin validation** (add to `apps/explorer/app/api/signals/route.ts`):
+Extract the in-memory key cache (SHA256, 60s TTL, 5K max) and validation logic into a shared module. The route handler currently inlines ~40 lines of cache management.
 
+### 4.2 Shared Validator (P3-2)
+
+**Files**: `apps/explorer/lib/signals/validation.ts`, `apps/explorer/convex/signals.ts`
+
+Signal schema is defined twice: Zod in the route handler (validation.ts) and Convex validators in signals.ts. For cycle-047, document the discrepancy rather than extract — the Convex validator is authoritative at storage time, and Zod catches malformed input at the edge. Dual validation is defense-in-depth, not a bug.
+
+**Downgrade to documentation task**: Add a comment in both files cross-referencing each other.
+
+### 4.3 Circuit Breaker Persistence (P3-3)
+
+**File**: `apps/explorer/convex/schema.ts`
+
+Currently piggybacked onto `sovereigntyState.manualOverride` (when `setBy === 'circuit_breaker'`) and failure counts encoded as parseable strings in `lastTransition.trigger`. This works but is fragile.
+
+**Change**: Add dedicated fields to `sovereigntyState`:
 ```typescript
-const ALLOWED_ORIGINS: Record<string, string[]> = {
-  'midi-interface':       ['https://mibera.xyz', 'http://localhost:3000'],
-  'mibera-honeyroad':     ['https://honeyroad.xyz', 'http://localhost:3000'],
-  'set-and-forgetti':     ['https://setandforgetti.com', 'http://localhost:3000'],
-  'apdao-auction-house':  ['https://apiology.xyz', 'http://localhost:3000'],
-  'mcv-interface':        ['https://moneycomb.xyz', 'http://localhost:3000'],
-  'cubquests-interface':  ['https://cubquests.xyz', 'http://localhost:3000'],
-};
+circuitBreakerTripped: v.optional(v.boolean()),
+circuitBreakerTrippedAt: v.optional(v.string()),
+consecutiveFailures: v.optional(v.number()),
 ```
 
-**Phase 2**: Short-lived signed tokens (server-issued, 15-min TTL).
+Update `isCircuitBroken` and `tripCircuitBreaker` functions to use typed fields instead of string parsing.
 
-### 4.2 Key Lifecycle (SKP-002)
+### 4.4 Heartbeat Cron Offset (P3-4)
 
-| Policy | Value |
-|--------|-------|
-| Rotation | 90 days advisory |
-| Revocation | Immediate via API |
-| Compromise response | Revoke → provision new → update env → deploy |
-| Audit | `lastUsedAt` on `apiKeys` table |
+**File**: `apps/explorer/convex/crons.ts`
 
-### 4.3 Trust Boundary
+Both `signals/heartbeat` and `signals/heartbeat-check` run at 1-hour intervals. Convex crons don't support offset configuration, but we can change `heartbeat-check` to run every 90 minutes instead of 60, creating natural drift that prevents same-tick collision. Alternatively, change `heartbeat-check` to 2 hours (less frequent but guaranteed separation).
 
-| Can Write To | Gate |
-|-------------|------|
-| Convex signal store | Rate-limited, key-validated |
-| Convex signalOverrides | writeKey-gated |
-| Linear issues | Personal key, template-constrained |
-| Discord messages | Webhook URL |
-| grimoires/gecko/ | Filesystem (Dixie fork only) |
+### 4.5 statusCounts Safety Bound (P3-5)
 
----
+**File**: `apps/explorer/convex/signals.ts` (lines 197-239)
 
-## 5. Failure Handling (SKP-003)
+Currently does `.collect()` on `by_status` index for `new`, `triaged`, `escalated` — no limit. Add `.take(10000)` as safety bound. Also fix the dead `resolved`/`dismissed` counts (initialized but never populated from DB queries).
 
-### 5.1 Existing Protections
+### 4.6 Sovereignty Initialization Upsert (P3-6)
 
-| Step | Failure Mode | Existing Handling |
-|------|-------------|-------------------|
-| Ingestion | Convex down | 500 to client (client retries) |
-| Classification | Haiku error | 3 retries + 5-min cron |
-| Linear creation | Linear error | 3 retries + hourly reconciliation |
-| Discord alert | Webhook fail | Silent (fire-and-forget) |
-| Status sync | Webhook miss | Hourly reconciliation polls Linear |
+**File**: `apps/explorer/convex/signals.ts`
 
-### 5.2 New: Pipeline Error Alerting
-
-After 3 failed Linear creation attempts, alert Discord #ops:
-
-```typescript
-if (signal.linearCreationAttempts >= 3) {
-  await ctx.scheduler.runAfter(0, internal.signals.alertPipelineError, {
-    signalId, error: 'Linear creation failed after 3 attempts', step: 'linear_escalation',
-  });
-}
-```
-
-### 5.3 Idempotency
-
-| Operation | Key | Strategy |
-|-----------|-----|----------|
-| Signal ingestion | `incidentGroupId` (5-min bucket) | Dedup on match |
-| Classification | `classificationAttempts` counter | Max 3, no infinite retry |
-| Linear creation | `linearIssueId` field | Only creates if null |
-| Discord alert | `discordAlertedAt` field | Only alerts once |
-| Override recording | Signal ID + timestamp | Append-only |
+First signal from a new app triggers sovereignty tier creation. Convex mutations are serialized per document, but two signals from a new app could each check "does tier exist?" before either creates one, resulting in duplicates. Use Convex's `db.query().withIndex("by_scope").unique()` + conditional insert pattern (idempotent upsert).
 
 ---
 
-## 6. Operational SLOs (SKP-007)
+## 5. Testing Strategy
 
-| SLO | Target | Measurement |
-|-----|--------|-------------|
-| Ingestion availability | 99.5% | Heartbeat cron (existing) |
-| Classification p95 latency | <30s | `classifiedAt - createdAt` |
-| Linear creation success rate | >95%/day | `linearCreationAttempts < 3` ratio |
-| Alert delivery latency | <5 min from classification | `discordAlertedAt - classifiedAt` |
+| Change | Test Method |
+|--------|-------------|
+| Dashboard QuickLink | Visual — navigate to `/dashboard` as admin |
+| Documentation rewrites | Manual read — no Dixie references, correct API paths |
+| Classification terminal state | Send signal with invalid data that fails classification 3 times → verify `status: "classification_failed"` in Convex DB |
+| Escalation failure visibility | Temporarily remove `LINEAR_API_KEY` → send HIGH signal → verify `linearCreationAttempts` increments, `checkLinearFailures` fires Discord alert |
+| Linear env var detection | Remove env var → send signal → verify error in Convex function logs |
+| Override query index | Check `recalculateSovereignty` uses `.withIndex()` in code review |
+| Circuit breaker fields | Trigger circuit breaker → verify typed fields populated (not string-encoded) |
+| Heartbeat offset | Check crons.ts shows different intervals |
+| statusCounts bound | Code review — `.take(10000)` present |
+| Sovereignty upsert | Send 2 signals from new appSlug simultaneously → verify single sovereignty row |
 
-Not vanity — these are the operational guarantees required for TTA <4h HIGH, <1h CRITICAL.
+## 6. Deployment
 
----
-
-## 7. Deployment Architecture
-
-### 7.1 Dixie Fork
-
-Railway deployment. Environment:
-
-| Variable | Source |
-|----------|--------|
-| `DATABASE_URL` | New PostgreSQL (Supabase or Railway) |
-| `REDIS_URL` | New Redis (Upstash or Railway) |
-| `CONVEX_URL` | Existing: `quaint-anaconda-866` (prod) |
-| `CONVEX_WRITE_KEY` | Existing (shared with explorer) |
-| `DISCORD_APPLICATION_ID` | New Discord app |
-| `DISCORD_PUBLIC_KEY` | New Discord app |
-
-### 7.2 Convex Changes
-
-Deploy to existing instance. Additions:
-- Tables: `signalOverrides`, `sovereigntyState`
-- Functions: `recordOverride`, `recalculateSovereignty`, `alertPipelineError`
-- Modified: `classify` (enhanced prompt)
-- Cron: `recalculateSovereignty` (hourly)
-
-### 7.3 Phased Rollout (SKP-005b)
-
-| Phase | Day | Repos | Approach |
-|-------|-----|-------|----------|
-| 1 | 2-3 | set-and-forgetti, apdao-auction-house | Fan-out (existing widgets + Linear) |
-| 2 | 3-4 | midi-interface, mcv-interface | Fan-out (existing widgets, different backends) |
-| 3 | 4-5 | cubquests-interface, mibera-honeyroad | New widgets built |
+1. **Phase 1** (docs + dashboard): Commit to main → auto-deploy on Vercel. No Convex changes.
+2. **Phase 2** (reliability fixes): Commit to main → auto-deploy on Vercel. Push Convex functions: `CONVEX_DEPLOYMENT=prod:quaint-anaconda-866 npx convex deploy`. No schema migration needed (no new fields in Phase 2).
+3. **Phase 3** (consolidation): Same as Phase 2, but schema change needed for circuit breaker fields. Run `npx convex deploy` — Convex handles additive optional fields automatically.
 
 ---
 
-## 8. Cost Architecture
+## 7. Files Modified
 
-| Component | Cost/month |
-|-----------|-----------|
-| Haiku classification | ~$3 (100 signals/day × $0.001) |
-| Railway (Dixie fork) | ~$5 |
-| Convex | $0 (free tier) |
-| Linear | $0 (existing) |
-| Discord | $0 |
-| **Total** | **~$8/month** |
-
-Hard ceiling: $3/day. Enforced via classification count in Convex.
-
----
-
-## 9. Ruggy Identity (BEAUVOIR)
-
-`persona/ruggy.md` — hand-crafted, not dAMP-96 generated.
-
-Core: lowercase energy, bazaar trader archetype, speaks from experience not authority. Classifies and recommends — humans decide. Never surveils, never extrapolates desire from behavior, never optimizes for engagement.
-
-Banned words: exciting, incredible, massive, revolutionary, game-changing, conviction, stay tuned, trust the process.
-
----
-
-## 10. Timeline (Revised)
-
-| Day | Deliverable |
-|-----|------------|
-| 0 | Provision 6 API keys via `POST /v1/keys`. Discord app setup |
-| 1 | Fork loa-dixie → construct-ruggy. Identity swap (5 files). Run tests |
-| 2 | Convex extensions (signalOverrides, sovereigntyState, enhanced classify). Origin validation |
-| 2-3 | Fan-out PRs: set-and-forgetti, apdao-auction-house, midi-interface |
-| 3 | Sovereignty engine + circuit breaker. mcv-interface Convex HTTP action PR |
-| 4 | Discord slash commands (`/ruggy status` first). New widget PRs: cubquests, honeyroad |
-| 5 | E2E integration test. Deploy Dixie fork (Railway). Convex deploy |
-
----
-
-*Grounded in: cycle-044 Convex signal infrastructure (deployed, 10/10 E2E), loa-dixie fork surface (5 identity points, 2,431 tests), Day 0 product repo audit (4 have widgets, 2 need them). Flatline skeptic concerns (Opus + GPT-5.3 + Gemini 2.5 Pro) addressed in Sections 4-6.*
+| File | Phase | Changes |
+|------|-------|---------|
+| `apps/explorer/app/(dashboard)/dashboard/page.tsx` | 1 | Add QuickLink |
+| `grimoires/loa/context/ruggy-ecosystem-intelligence.md` | 1 | Full rewrite |
+| `apps/explorer/convex/README.md` | 1 | Full rewrite |
+| `apps/explorer/convex/signals.ts` | 2, 3 | Terminal status, statusCounts bound, sovereignty upsert |
+| `apps/explorer/convex/linear.ts` | 2 | Throw on missing env vars |
+| `apps/explorer/convex/schema.ts` | 3 | Circuit breaker typed fields |
+| `apps/explorer/convex/crons.ts` | 3 | Heartbeat interval change |
+| `apps/explorer/lib/signals/auth.ts` | 3 | New: extracted auth helper |

--- a/grimoires/loa/sprint.md
+++ b/grimoires/loa/sprint.md
@@ -1,241 +1,72 @@
-# Sprint Plan: Ruggy — Autonomous Ecosystem Intelligence Agent
+# Sprint Plan: Ruggy Structural Alignment
 
-**Cycle**: cycle-045
+**Cycle**: cycle-047
 **PRD**: `grimoires/loa/prd.md`
 **SDD**: `grimoires/loa/sdd.md`
-**Team**: 1 developer (@janitooor)
-**Sprint duration**: 2-3 days each
+**Created**: 2026-03-13
 
 ---
 
-## Sprint 1: Foundation — Dixie Fork + Convex Extensions
+## Sprint 1: Documentation & Dashboard Visibility
 
-**Goal**: Ruggy exists as a running service with sovereignty state tracking.
+**Goal**: Align all documentation with reality and make signals dashboard discoverable.
 
-### Tasks
+| Task | File | Description | Est |
+|------|------|-------------|-----|
+| T1.1 | `apps/explorer/app/(dashboard)/dashboard/page.tsx` | Add `<QuickLink href="/dashboard/signals" label="Signals" />` to admin grid | 5m |
+| T1.2 | `grimoires/loa/context/ruggy-ecosystem-intelligence.md` | Full rewrite — remove Dixie fiction, describe actual Convex pipeline | 20m |
+| T1.3 | `apps/explorer/convex/README.md` | Replace boilerplate with signal pipeline reference | 15m |
 
-#### 1.1 Fork loa-dixie → construct-ruggy
-- Fork `loa-dixie` repo under 0xHoneyJar org
-- Replace `persona/oracle.md` → `persona/rugby.md` (BEAUVOIR identity from PRD §9)
-- Replace `knowledge/oracle-binding.yaml` → `knowledge/rugby-binding.yaml`
-- Replace `knowledge/sources.json` with Ruggy's 6-source corpus
-- Create knowledge source files: `product-repos.md`, `signal-taxonomy.md`, `observer-workflow.md`, `linear-config.md`
-- **Acceptance**: Fork boots, `bun run dev` starts without crash
+**Acceptance**: `/dashboard` shows Signals link for admin. `ruggy-ecosystem-intelligence.md` has zero Dixie references. `convex/README.md` describes actual functions.
 
-#### 1.2 Oracle identity dehard-coding
-- `app/src/routes/identity.ts`: parameterize `'oracle'` (3 occurrences) from binding
-- `app/src/routes/chat.ts`: `agentId: 'oracle'` → read from binding
-- `app/src/services/corpus-meta.ts`: replace `KNOWN_REPOS` at line 265 with 6 Ruggy repos
-- **Acceptance**: `/api/health` returns Ruggy identity. Knowledge queries return Ruggy-domain results
-
-#### 1.3 Run test suite, fix identity breakage
-- Run `vitest run` — expect failures in Oracle-specific assertions
-- Fix tests that assert "Oracle" strings → "Ruggy"
-- If >50% break: timebox 4 hours, then write Ruggy-specific tests only
-- **Acceptance**: Test suite passes or Ruggy-specific tests cover new code paths
-
-#### 1.4 Convex schema extensions
-- Add `signalOverrides` table (SDD §3.2) to `apps/explorer/convex/schema.ts`
-- Add `sovereigntyState` table (SDD §3.2)
-- Add `recordOverride` mutation
-- Add `recalculateSovereignty` function + hourly cron
-- Initialize `sovereigntyState` with all 6 repos at `constrained` tier (apdao at `standard` per SDD §3.3)
-- **Acceptance**: `npx convex deploy` succeeds. Sovereignty state readable via Convex dashboard
-
-#### 1.5 Origin validation for signal ingestion
-- Add `ALLOWED_ORIGINS` map to `apps/explorer/app/api/signals/route.ts` (SDD §4.1)
-- Check `Origin`/`Referer` header after key validation
-- Allow `localhost:3000` for all repos in dev
-- **Acceptance**: Requests from unknown origins return 403. Known origins pass through
-
-#### 1.6 Provision API keys for 6 product repos
-- Call `POST /v1/keys` with `scopes: ['write:signals']` and `appSlug` for each repo
-- Store keys securely for distribution to product repos
-- **Acceptance**: 6 keys created, each verified via `verifySignalKey`
+**Gate**: No code behavior changes. Commit and deploy.
 
 ---
 
-## Sprint 2: Widget Integration — Connect Product Repos
+## Sprint 2: HIGH Reliability Fixes
 
-**Goal**: User feedback from 4+ product repos flows into the Convex signal pipeline.
+**Goal**: Close the 4 highest-severity gaps — classification terminal state, escalation failure visibility, Linear env var detection, override query verification.
 
-### Tasks
+| Task | File | Description | Est |
+|------|------|-------------|-----|
+| T2.1 | `apps/explorer/convex/signals.ts` | Classification terminal state: set `status: "classification_failed"` when `classificationAttempts >= 3`. Update `patchClassificationAttempt` mutation to accept optional `status` param. Apply in both catch block and missing-API-key path. | 30m |
+| T2.2 | `apps/explorer/convex/linear.ts` | Throw on missing `LINEAR_API_KEY` and `LINEAR_TEAM_*` instead of silent return. `console.error` with descriptive message before throw. | 15m |
+| T2.3 | `apps/explorer/convex/signals.ts` | Verify `recalculateSovereignty` uses `.withIndex("by_app")` for override rate calculation. Fix if using filter/collect instead. | 15m |
+| T2.4 | `apps/explorer/convex/signals.ts` | Verify escalation status flow — ensure signal is not marked `escalated` before Linear call confirms success. Fix if status is set prematurely. | 20m |
 
-#### 2.1 set-and-forgetti fan-out integration
-- File: `apps/web/app/api/feedback/route.ts`
-- After `createFeedbackIssue()` succeeds, POST to `constructs.network/api/signals`
-- Map S&F feedback fields → signal schema (category, severity derivation, description)
-- Add `SIGNALS_API_KEY` env var to S&F deployment
-- Log fan-out failures (not silent)
-- **Acceptance**: Submit feedback in S&F → signal appears in Convex tagged `set-and-forgetti`
+**Acceptance**: Signal at 3 failed classifications → `classification_failed` status. Missing `LINEAR_API_KEY` → error in Convex logs (not silent). Override query uses index.
 
-#### 2.2 apdao-auction-house fan-out integration
-- File: `actions/create-feedback.ts`
-- After `createIssue()` succeeds, POST to signals API
-- Map apDAO feedback fields → signal schema
-- Add `SIGNALS_API_KEY` env var
-- **Acceptance**: Submit feedback in apDAO → signal in Convex tagged `apdao-auction-house`
-
-#### 2.3 midi-interface (mibera-dimensions) fan-out integration
-- File: `app/actions/feedback.ts`
-- After Supabase `score_feedback` insert, POST to signals API
-- Map pulse widget fields (bad/fine/good + note) → signal schema
-- Severity derivation: "bad" → high, "fine" → low, "good" → low (praise)
-- Add `SIGNALS_API_KEY` env var
-- **Acceptance**: Submit feedback in midi-interface → signal in Convex tagged `midi-interface`
-
-#### 2.4 mcv-interface Convex HTTP action
-- File: `convex/feedback.ts`
-- After `submit` mutation succeeds, schedule Convex HTTP action to POST to signals API
-- Map vault feedback fields (bad/fine/good + note) → signal schema
-- **Acceptance**: Submit vault feedback in mcv → signal in Convex tagged `mcv-interface`
-
-#### 2.5 cubquests-interface new widget
-- Create feedback button component in `components/layout/`
-- Mount in `navbar.tsx` (right side, before connect wallet)
-- On submit: POST directly to `constructs.network/api/signals`
-- Match cubquests design system (BoldenVan font, existing color tokens)
-- Add `SIGNALS_API_KEY` env var
-- **Acceptance**: Feedback widget visible in cubquests navbar. Submission creates signal tagged `cubquests-interface`
-
-#### 2.6 mibera-honeyroad new widget
-- Create floating feedback button component
-- Mount in `(main)/layout.tsx` (no persistent navbar exists)
-- On submit: POST directly to `constructs.network/api/signals`
-- Match honeyroad design system
-- Add `SIGNALS_API_KEY` env var
-- **Acceptance**: Feedback widget visible in honeyroad. Submission creates signal tagged `mibera-honeyroad`
+**Gate**: Deploy Convex functions to prod. E2E test with curl.
 
 ---
 
-## Sprint 3: Enhanced Classification + Sovereignty Logic
+## Sprint 3: Consolidation
 
-**Goal**: Haiku classification is context-aware. Sovereignty tier system is operational.
+**Goal**: Close MEDIUM/LOW findings — circuit breaker persistence, cron timing, safety bounds, race conditions.
 
-### Tasks
+| Task | File | Description | Est |
+|------|------|-------------|-----|
+| T3.1 | `apps/explorer/convex/signals.ts` | `statusCounts` — add `.take(10000)` safety bound on each status query. Fix dead `resolved`/`dismissed` counts. | 15m |
+| T3.2 | `apps/explorer/convex/signals.ts` | Sovereignty initialization — add upsert pattern for first-signal-from-new-app tier creation. | 15m |
+| T3.3 | `apps/explorer/convex/crons.ts` | Change `heartbeat-check` interval from 1 hour to 2 hours to avoid collision with `heartbeat`. | 5m |
+| T3.4 | `apps/explorer/convex/schema.ts` + `signals.ts` | Add typed circuit breaker fields (`circuitBreakerTripped`, `consecutiveFailures`) to `sovereigntyState`. Update `isCircuitBroken`/`tripCircuitBreaker` to use typed fields. | 30m |
+| T3.5 | `apps/explorer/lib/signals/auth.ts` + `route.ts` | Extract auth helper — move key cache + SHA256 validation from route handler to shared module. | 20m |
+| T3.6 | `apps/explorer/lib/signals/validation.ts` + `convex/signals.ts` | Add cross-reference comments between Zod and Convex validators. | 5m |
 
-#### 3.1 Enhanced classification prompt
-- Update `apps/explorer/convex/signals.ts:classify` function
-- Add per-app context snippets (what the app does, known issues)
-- Add `type` field to classification output (bug vs UTC)
-- Add `severity` and `category` fields to classification schema
-- Store app context snippets as Convex environment variable or inline map
-- **Acceptance**: Classification output includes `type`, `severity`, `category`. Context-appropriate for each app
+**Acceptance**: statusCounts has safety bound. New app sovereignty tier creation is idempotent. Circuit breaker uses typed fields. Auth helper extracted and route handler simplified.
 
-#### 3.2 Sovereignty-gated escalation
-- Modify escalation path: after classification, check `sovereigntyState` for app's tier
-- CONSTRAINED: mark signal as `needs_review`, don't auto-create Linear issue
-- STANDARD: auto-escalate LOW/MEDIUM, mark HIGH/CRITICAL as `needs_review`
-- AUTONOMOUS: auto-escalate all, circuit breaker active
-- **Acceptance**: Signal with `sovereigntyTierAtCreation` field set. CONSTRAINED signals require dashboard action to escalate
-
-#### 3.3 Circuit breaker implementation
-- Track consecutive failures per repo in Convex
-- 5 consecutive classification failures → set repo to `halted` state
-- Same error message 3× → halt
-- Add `/ruggy reset [repo]` Discord command to clear halt
-- **Acceptance**: Simulated failures trigger halt. Reset clears it
-
-#### 3.4 Override tracking integration
-- Modify `updateStatusFromDashboard` to detect classification changes
-- When human changes classification labels/severity → write to `signalOverrides`
-- Trigger `recalculateSovereignty` after override
-- **Acceptance**: Changing a signal's classification in dashboard creates override record. Sovereignty recalculation reflects it
-
-#### 3.5 Pipeline error alerting
-- After 3 failed `linearCreationAttempts`, alert Discord #ops channel
-- New Convex function: `alertPipelineError`
-- Include signal ID, app slug, error details in embed
-- **Acceptance**: Simulated Linear failure triggers Discord alert after 3rd attempt
-
----
-
-## Sprint 4: Discord Slash Commands + E2E
-
-**Goal**: Team can query ecosystem health via Discord. Full pipeline tested end-to-end.
-
-### Tasks
-
-#### 4.1 Discord application setup
-- Create Discord application in developer portal
-- Configure slash commands: `/ruggy status`, `/ruggy signals`, `/ruggy escalations`, `/ruggy repos`
-- Set interactions endpoint URL to Dixie fork
-- **Acceptance**: Discord app exists with registered commands
-
-#### 4.2 Discord interactions endpoint
-- `construct-ruggy/app/src/routes/discord.ts`
-- Ed25519 signature verification
-- PING/PONG handler
-- Route to subcommand handlers
-- **Acceptance**: Discord verification succeeds. PING returns PONG
-
-#### 4.3 `/ruggy status` command
-- Query Convex `statusCounts()` + `sovereigntyState`
-- Return embed: health summary, signal volumes (24h/7d), tier per repo, active incidents
-- **Acceptance**: `/ruggy status` in Discord returns accurate ecosystem snapshot
-
-#### 4.4 `/ruggy signals [repo]` command
-- Query Convex `byApp(appSlug)` with limit
-- Return embed: recent signals with classification, severity color coding
-- **Acceptance**: `/ruggy signals set-and-forgetti` returns S&F signals
-
-#### 4.5 `/ruggy escalations` command
-- Query Convex for `status: 'escalated'` signals
-- Return embed: open Linear issues with links, severity, age
-- **Acceptance**: Shows current open escalations
-
-#### 4.6 `/ruggy repos` command
-- Query Convex `statusCounts()`
-- Return embed: all 6 repos with signal counts, tier, last signal timestamp
-- **Acceptance**: Shows all monitored repos with stats
-
-#### 4.7 Deploy Dixie fork to Railway
-- Configure Railway service with environment variables (SDD §7.1)
-- Set Discord interactions endpoint to Railway URL
-- Health check endpoint responds
-- **Acceptance**: Dixie fork running on Railway. Discord commands work via Railway endpoint
-
-#### 4.8 Deploy Convex changes
-- `npx convex deploy` from `apps/explorer/`
-- Verify new tables, functions, crons are active
-- **Acceptance**: Convex dashboard shows new tables. Sovereignty cron running
-
-#### 4.9 E2E integration test
-- Submit feedback from set-and-forgetti dev environment
-- Verify: signal in Convex → classified → sovereignty check → Linear issue → Discord alert
-- Test override: change classification in dashboard → override recorded → sovereignty recalculated
-- Test circuit breaker: simulate failures → halt triggered
-- **Acceptance**: Full pipeline works end-to-end. Override tracking functional. Circuit breaker operational
+**Gate**: Deploy Convex schema + functions to prod. Verify heartbeat crons show different intervals.
 
 ---
 
 ## Sprint Summary
 
-| Sprint | Focus | Repos Touched | Key Risk |
-|--------|-------|---------------|----------|
-| 1 | Foundation | construct-ruggy (new), loa-constructs | Dixie fork test breakage |
-| 2 | Widget Integration | 6 product repos | Cross-repo coordination, mcv Convex pattern |
-| 3 | Classification + Sovereignty | loa-constructs (Convex) | Sovereignty edge cases, low volume |
-| 4 | Discord + E2E | construct-ruggy, Discord | Discord API complexity, integration timing |
+| Sprint | Tasks | Focus | Risk |
+|--------|-------|-------|------|
+| 1 | 3 | Documentation + visibility | Low |
+| 2 | 4 | HIGH reliability fixes | Medium |
+| 3 | 6 | MEDIUM/LOW consolidation | Medium |
 
-## Dependencies
+**Total estimated**: ~3.5 hours of implementation across 13 tasks.
 
-```
-Sprint 1 ──→ Sprint 2 (keys needed for widgets)
-Sprint 1 ──→ Sprint 3 (Convex tables needed for sovereignty)
-Sprint 3 ──→ Sprint 4.9 (sovereignty needed for E2E test)
-Sprint 1 ──→ Sprint 4.7 (Dixie fork needed for Railway deploy)
-```
-
-Sprints 2 and 3 can run in parallel after Sprint 1 completes.
-
-## Success Criteria (Week 1 Close)
-
-- [ ] Ruggy Dixie fork deployed on Railway, health check passing
-- [ ] 4+ product repos forwarding feedback to Convex signal pipeline
-- [ ] Haiku classification includes type (bug/UTC), severity, category
-- [ ] Sovereignty state tracked for all 6 repos (5 CONSTRAINED, 1 STANDARD)
-- [ ] Override tracking operational (human changes → sovereignty recalculation)
-- [ ] Circuit breaker halts on failure patterns
-- [ ] `/ruggy status` returns ecosystem health in Discord
-- [ ] E2E test passes: widget → signal → classify → Linear → Discord alert
+**MVP gate**: Sprint 1 + Sprint 2. Sprint 3 is valuable but can be deferred.

--- a/scripts/seed-forge-packs.ts
+++ b/scripts/seed-forge-packs.ts
@@ -13,7 +13,7 @@
 
 import postgres from 'postgres';
 import { randomUUID, randomBytes, createHash } from 'crypto';
-import bcrypt from 'bcrypt';
+import bcrypt from 'bcryptjs';
 import { readdir, readFile, stat } from 'fs/promises';
 import { join, dirname, relative } from 'path';
 import { fileURLToPath } from 'url';
@@ -77,7 +77,12 @@ const SHORT_DESCRIPTION_OVERRIDES: Record<string, string> = {
   'the-arcade': 'Game design philosophy',
   'the-easel': 'Aesthetic direction studio',
   webreel: 'Cinematic web capture',
+  'vocabulary-bank': 'Vocabulary governance for products',
   'webgl-particles': 'WebGL particle system',
+  showcase: 'Landing page visual intelligence',
+  'vfx-playbook': 'VFX patterns and techniques',
+  'the-mint': 'Material transformation pipeline',
+  'the-speakers': 'Psychoacoustic engineering',
 };
 
 // Pack icons (not stored in manifest to keep manifests simple)
@@ -98,8 +103,13 @@ const PACK_ICONS: Record<string, string> = {
   gecko: '🦎',
   'social-oracle': '🔮',
   'mibera-codex': '📖',
+  'vocabulary-bank': '📖',
   webreel: '🎬',
   growthpages: '🌱',
+  showcase: '🖥️',
+  'vfx-playbook': '🎞️',
+  'the-mint': '⚒️',
+  'the-speakers': '🔊',
 };
 
 // Git source configurations for packs with registered repos
@@ -171,6 +181,30 @@ const GIT_CONFIGS: Record<string, { gitUrl: string; gitRef: string }> = {
   },
   growthpages: {
     gitUrl: 'https://github.com/0xHoneyJar/construct-growthpages.git',
+    gitRef: 'main',
+  },
+  gecko: {
+    gitUrl: 'https://github.com/0xHoneyJar/construct-gecko.git',
+    gitRef: 'main',
+  },
+  showcase: {
+    gitUrl: 'https://github.com/0xHoneyJar/construct-showcase.git',
+    gitRef: 'main',
+  },
+  'vfx-playbook': {
+    gitUrl: 'https://github.com/0xHoneyJar/construct-vfx-playbook.git',
+    gitRef: 'main',
+  },
+  'the-mint': {
+    gitUrl: 'https://github.com/0xHoneyJar/construct-the-mint.git',
+    gitRef: 'main',
+  },
+  'the-speakers': {
+    gitUrl: 'https://github.com/0xHoneyJar/construct-the-speakers.git',
+    gitRef: 'main',
+  },
+  'vocabulary-bank': {
+    gitUrl: 'https://github.com/0xHoneyJar/construct-vocabulary-bank.git',
     gitRef: 'main',
   },
 };


### PR DESCRIPTION
## Summary

Structural alignment for the Ruggy signal pipeline deployed in cycle-045/046. Addresses 14 architectural findings from the deployment audit.

- **Sprint 1**: Dashboard signals link, rewrite Ruggy docs (remove Dixie fiction), replace Convex README boilerplate
- **Sprint 2**: Classification terminal state at 3 retries, throw on missing Linear env vars, override query index optimization
- **Sprint 3**: Extract auth helper, typed circuit breaker fields, heartbeat cron offset, statusCounts safety bounds

## Sprint Breakdown

| Sprint | Focus | Files | Status |
|--------|-------|-------|--------|
| Sprint 1 | Documentation & Dashboard Visibility | 3 | Complete |
| Sprint 2 | HIGH Reliability Fixes | 2 | Complete |
| Sprint 3 | Consolidation | 6 | Complete |

## Key Changes

### Reliability
- Signals that fail classification 3x now get `status: "classification_failed"` (was stuck at `new` forever)
- Missing `LINEAR_API_KEY` now throws instead of silently dropping all escalations
- Override rate query uses index range bound instead of in-memory filter

### Architecture
- Auth helper extracted to `lib/signals/auth.ts` (key cache + origin validation)
- Circuit breaker uses typed schema fields instead of string-encoded state in `lastTransition.trigger`
- `heartbeat-check` cron changed from 1h to 2h to avoid collision with `heartbeat`
- `statusCounts` queries capped at 10,000 per status

### Documentation
- `ruggy-ecosystem-intelligence.md` rewritten — removed "Dixie fork" fiction, describes actual Convex pipeline
- `convex/README.md` replaced with signal pipeline reference
- Dashboard overview now links to `/dashboard/signals` for admin users

## Test plan

- [ ] Navigate to `/dashboard` as admin — verify "Signals" QuickLink visible
- [ ] Read `ruggy-ecosystem-intelligence.md` — verify zero Dixie references
- [ ] Deploy Convex functions to prod (`npx convex deploy`)
- [ ] Send test signal via curl — verify classification works
- [ ] Verify `checkLinearFailures` cron detects missing env vars
- [ ] Check heartbeat crons show different intervals in Convex dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)