### PR TITLE
feat: sitemap date metadata + Umami traffic in digest

### DIFF
--- a/apps/explorer/app/(marketing)/constructs/[slug]/page.tsx
+++ b/apps/explorer/app/(marketing)/constructs/[slug]/page.tsx
@@ -1,13 +1,18 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { fetchConstruct } from '@/lib/data/fetch-constructs';
+import { fetchConstruct, fetchAllConstructs } from '@/lib/data/fetch-constructs';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { InstallBlock } from '@/components/ui/install-block';
 import { Disclosure } from '@/components/ui/disclosure';
 
 export const revalidate = 3600;
+
+export async function generateStaticParams() {
+  const constructs = await fetchAllConstructs();
+  return constructs.map((c) => ({ slug: c.slug }));
+}
 
 export async function generateMetadata({
   params,
@@ -61,9 +66,8 @@ export default async function ConstructDetailPage({
     },
     url: `https://constructs.network/constructs/${slug}`,
     ...(construct.version && { version: construct.version }),
-    ...(construct.verifiedAt
-      ? { datePublished: construct.verifiedAt }
-      : { datePublished: '2025-01-01' }),
+    ...(construct.createdAt && { datePublished: construct.createdAt }),
+    ...(construct.updatedAt && { dateModified: construct.updatedAt }),
   };
 
   const verificationBadge = (() => {

--- a/apps/explorer/app/sitemap.ts
+++ b/apps/explorer/app/sitemap.ts
@@ -27,7 +27,7 @@ export default async function sitemap(): Promise<SitemapEntry[]> {
 
   const constructPages: SitemapEntry[] = constructs.map((c) => ({
     url: `${BASE_URL}/constructs/${c.slug}`,
-    lastModified: new Date(),
+    lastModified: c.updatedAt ? new Date(c.updatedAt) : new Date(),
     changeFrequency: 'weekly' as const,
     priority: 0.8,
   }));

--- a/apps/explorer/convex/analytics.ts
+++ b/apps/explorer/convex/analytics.ts
@@ -1,4 +1,4 @@
-import { internalQuery } from './_generated/server';
+import { internalAction, internalQuery } from './_generated/server';
 
 const DAY_MS = 86_400_000;
 
@@ -109,6 +109,94 @@ export const getDailyBaseline = internalQuery({
       avgDailyInstalls: Math.round(avgInstalls * 10) / 10,
       avgDailySignals: Math.round(avgSignals * 10) / 10,
       avgHealthScore,
+    };
+  },
+});
+
+// --- Umami Cloud Traffic ---
+
+const UMAMI_API_BASE = 'https://api.umami.is/v1';
+
+export interface UmamiTrafficStats {
+  visitors: number;
+  pageviews: number;
+  topReferrers: { name: string; value: number }[];
+  topPages: { name: string; value: number }[];
+}
+
+async function umamiGet(
+  path: string,
+  apiKey: string,
+  params: Record<string, string>,
+): Promise<unknown | null> {
+  const url = new URL(`${UMAMI_API_BASE}${path}`);
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  try {
+    const response = await fetch(url.toString(), {
+      headers: { 'x-umami-api-key': apiKey },
+    });
+    if (!response.ok) {
+      console.error(`[umami] ${path} HTTP ${response.status}`);
+      return null;
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('[umami] fetch error:', (error as Error).message);
+    return null;
+  }
+}
+
+/**
+ * Fetch last-24h traffic stats from Umami Cloud.
+ * Returns null when UMAMI_API_KEY or UMAMI_WEBSITE_ID are not configured.
+ */
+export const fetchUmamiTraffic = internalAction({
+  handler: async (): Promise<UmamiTrafficStats | null> => {
+    const apiKey = process.env.UMAMI_API_KEY;
+    const websiteId = process.env.UMAMI_WEBSITE_ID;
+
+    if (!apiKey || !websiteId) {
+      console.warn('[umami] UMAMI_API_KEY or UMAMI_WEBSITE_ID not set — skipping traffic');
+      return null;
+    }
+
+    const now = Date.now();
+    const startAt = String(now - DAY_MS);
+    const endAt = String(now);
+
+    // Fetch stats and top referrers in parallel
+    const [statsRaw, referrersRaw, pagesRaw] = await Promise.all([
+      umamiGet(`/websites/${websiteId}/stats`, apiKey, { startAt, endAt }),
+      umamiGet(`/websites/${websiteId}/metrics`, apiKey, {
+        startAt,
+        endAt,
+        type: 'referrer',
+        limit: '5',
+      }),
+      umamiGet(`/websites/${websiteId}/metrics`, apiKey, {
+        startAt,
+        endAt,
+        type: 'url',
+        limit: '5',
+      }),
+    ]);
+
+    if (!statsRaw) return null;
+
+    const stats = statsRaw as {
+      visitors: { value: number };
+      pageviews: { value: number };
+    };
+    const referrers = (referrersRaw as { x: string; y: number }[] | null) ?? [];
+    const pages = (pagesRaw as { x: string; y: number }[] | null) ?? [];
+
+    return {
+      visitors: stats.visitors?.value ?? 0,
+      pageviews: stats.pageviews?.value ?? 0,
+      topReferrers: referrers.map((r) => ({ name: r.x || 'direct', value: r.y })),
+      topPages: pages.map((p) => ({ name: p.x, value: p.y })),
     };
   },
 });

--- a/apps/explorer/convex/telegram.ts
+++ b/apps/explorer/convex/telegram.ts
@@ -56,6 +56,12 @@ function formatDigest(
     avgDailySignals: number;
     avgHealthScore: number | null;
   },
+  traffic: {
+    visitors: number;
+    pageviews: number;
+    topReferrers: { name: string; value: number }[];
+    topPages: { name: string; value: number }[];
+  } | null,
 ): string {
   const dateStr = formatDate(new Date());
   const { installs, signals, health } = metrics;
@@ -63,15 +69,31 @@ function formatDigest(
   // Detect anomalies — anything notably above baseline
   const installAnomaly = installs.total > 0 && installs.total >= baseline.avgDailyInstalls * 1.5;
   const signalAnomaly = signals.total > 0 && signals.total >= baseline.avgDailySignals * 1.5;
-  const hasActivity = installs.total > 0 || signals.total > 0;
+  const hasActivity = installs.total > 0 || signals.total > 0 || (traffic && traffic.visitors > 0);
 
-  // Steady state — no installs, no signals, health unchanged
+  // Steady state — no installs, no signals, no traffic, health unchanged
   if (!hasActivity) {
     const healthSuffix = health ? `, health ${health.score}/100` : '';
     return `<b>constructs.network \u2014 ${dateStr}</b> \u2014 steady state, 0 installs${healthSuffix}`;
   }
 
   const lines: string[] = [`<b>constructs.network \u2014 ${dateStr}</b>`, ''];
+
+  // Traffic (Umami)
+  if (traffic && traffic.visitors > 0) {
+    // Build referrer breakdown — show top sources as percentages
+    let referrerSuffix = '';
+    if (traffic.topReferrers.length > 0) {
+      const totalReferrerHits = traffic.topReferrers.reduce((s, r) => s + r.value, 0);
+      if (totalReferrerHits > 0) {
+        const parts = traffic.topReferrers
+          .slice(0, 3)
+          .map((r) => `${r.name} ${Math.round((r.value / totalReferrerHits) * 100)}%`);
+        referrerSuffix = ` | ${parts.join(', ')}`;
+      }
+    }
+    lines.push(`\u26A1 ${traffic.visitors} visitors${referrerSuffix}`);
+  }
 
   // Installs
   if (installs.total > 0) {
@@ -131,13 +153,14 @@ export const sendDigest = internalAction({
       return;
     }
 
-    // Pull metrics and baseline in parallel
-    const [metrics, baseline] = await Promise.all([
+    // Pull metrics, baseline, and traffic in parallel
+    const [metrics, baseline, traffic] = await Promise.all([
       ctx.runQuery(internal.analytics.getDigestMetrics),
       ctx.runQuery(internal.analytics.getDailyBaseline),
+      ctx.runAction(internal.analytics.fetchUmamiTraffic),
     ]);
 
-    const message = formatDigest(metrics, baseline);
+    const message = formatDigest(metrics, baseline, traffic);
 
     const result = await sendMessage(botToken, chatId, message);
     if (result.ok) {

--- a/apps/explorer/lib/data/fetch-constructs.ts
+++ b/apps/explorer/lib/data/fetch-constructs.ts
@@ -43,6 +43,8 @@ interface APIConstruct {
   construct_type?: string;
   verification_tier?: string;
   verified_at?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
   forked_from?: { slug: string; name: string } | null;
   fork_count?: number;
   skill_prose?: string | null;
@@ -119,6 +121,8 @@ function transformToNode(construct: APIConstruct): ConstructNode {
     rating: construct.rating ?? null,
     hasIdentity: construct.has_identity ?? false,
     verificationTier: construct.verification_tier ?? 'UNVERIFIED',
+    createdAt: construct.created_at ?? null,
+    updatedAt: construct.updated_at ?? null,
     domains: domains && domains.length > 0 ? domains : undefined,
     composesWith: composesWith.length > 0 ? composesWith : undefined,
     skillSlugs: skillSlugs.length > 0 ? skillSlugs : undefined,

--- a/apps/explorer/lib/types/graph.ts
+++ b/apps/explorer/lib/types/graph.ts
@@ -41,6 +41,8 @@ export interface ConstructNode {
   hasIdentity?: boolean;
   verificationTier?: string;
   visibility?: string;
+  createdAt?: string | null;
+  updatedAt?: string | null;
   /** Expertise domains from identity — used for domain tag pills */
   domains?: string[];
   /** Slugs this construct composes with — used for composition degree */


### PR DESCRIPTION
## Summary

- **Sitemap**: Use real `updated_at` from API for `lastModified` instead of always `new Date()`. Add `generateStaticParams` so all construct detail pages are pre-rendered at build time.
- **JSON-LD**: Replace arbitrary `2025-01-01` fallback with actual `created_at` for `datePublished` and `updated_at` for `dateModified`. Omit dates when API doesn't provide them (per bridgebuilder FIND-006).
- **Umami traffic**: New `fetchUmamiTraffic` internalAction queries Umami Cloud `/stats` and `/metrics` endpoints for visitors, pageviews, top referrers, and top pages (last 24h).
- **Telegram digest**: Merges traffic data into digest format with referrer percentage breakdown. Gracefully skips when `UMAMI_API_KEY` or `UMAMI_WEBSITE_ID` env vars are not set.

## Setup required

Set these env vars in the Convex dashboard (quaint-anaconda-866):
- `UMAMI_API_KEY` — from Umami Cloud settings
- `UMAMI_WEBSITE_ID` — `3635aede-2c66-4b7c-8809-491e2573a423`

## Test plan

- [ ] Verify sitemap.xml shows real `lastmod` dates from API instead of current timestamp
- [ ] Verify construct detail pages have `datePublished`/`dateModified` in JSON-LD from API data
- [ ] Verify no `2025-01-01` fallback date appears in JSON-LD
- [ ] Deploy Convex functions and trigger digest manually to verify traffic section renders
- [ ] Confirm digest still works correctly when Umami env vars are not set (graceful skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)