### PR TITLE
fix: close construct sync lifecycle — skills discoverable after upgrade and session start

### DIFF
--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -156,9 +156,36 @@ validate_symlink_target() {
                 constructs_abs=$(readlink -f "$constructs_dir" 2>/dev/null || realpath "$constructs_dir" 2>/dev/null || (cd "$constructs_dir" 2>/dev/null && pwd -P) || echo "")
             fi
 
-            # Verify resolved path is within constructs
-            if [[ -n "$constructs_abs" ]] && [[ "$resolved_target" != "$constructs_abs"* ]]; then
-                print_warning "Symlink resolves outside constructs: $resolved_target"
+            # Verify resolved path is within constructs (local or global store)
+            # Trust boundary: only accept global store under $HOME to prevent
+            # env var injection from widening the validation boundary
+            local global_store="${LOA_GLOBAL_STORE:-${HOME}/.loa/constructs}"
+            local global_abs=""
+            if [[ -d "$global_store" ]] && [[ "$global_store" == "${HOME}/"* ]]; then
+                if command -v get_canonical_path &>/dev/null; then
+                    global_abs=$(get_canonical_path "$global_store")
+                else
+                    global_abs=$(readlink -f "$global_store" 2>/dev/null || realpath "$global_store" 2>/dev/null || (cd "$global_store" 2>/dev/null && pwd -P) || echo "")
+                fi
+            fi
+
+            # Normalize trailing slashes for boundary-safe prefix checks
+            constructs_abs="${constructs_abs%/}"
+            global_abs="${global_abs%/}"
+
+            local in_local="false"
+            local in_global="false"
+
+            if [[ -n "$constructs_abs" ]] && { [[ "$resolved_target" == "$constructs_abs" ]] || [[ "$resolved_target" == "$constructs_abs/"* ]]; }; then
+                in_local="true"
+            fi
+
+            if [[ -n "$global_abs" ]] && { [[ "$resolved_target" == "$global_abs" ]] || [[ "$resolved_target" == "$global_abs/"* ]]; }; then
+                in_global="true"
+            fi
+
+            if [[ "$in_local" != "true" ]] && [[ "$in_global" != "true" ]]; then
+                print_warning "Symlink resolves outside constructs/global store: $resolved_target"
                 return 1
             fi
         fi
@@ -1627,6 +1654,13 @@ do_upgrade_pack() {
     # Phase 6: Update metadata
     update_pack_meta "$pack_slug" "$pack_dir"
 
+    # Phase 7: Re-link skills and commands (new skills from upgrade become discoverable)
+    local skills_linked commands_linked
+    skills_linked=$(symlink_pack_skills "$pack_slug" 2>/dev/null)
+    skills_linked=${skills_linked:-0}
+    commands_linked=$(symlink_pack_commands "$pack_slug" 2>/dev/null)
+    commands_linked=${commands_linked:-0}
+
     # Cleanup
     rm -rf "$tmp_new" "$backup_dir"
 
@@ -1635,6 +1669,9 @@ do_upgrade_pack() {
     echo "  Kept local:   $merged files"
     if [[ $conflicts -gt 0 ]]; then
         print_warning "  Conflicts:    $conflicts files (check .upstream files)"
+    fi
+    if [[ "$skills_linked" -gt 0 ]] || [[ "$commands_linked" -gt 0 ]]; then
+        echo "  Skills linked: $skills_linked, Commands linked: $commands_linked"
     fi
     echo ""
     print_success "Pack '$pack_slug' upgraded to $latest_version"
@@ -1685,6 +1722,102 @@ do_link_commands() {
     fi
 
     return $EXIT_SUCCESS
+}
+
+# Re-link pack skills (useful after updates, local dev, or post-upgrade)
+# Args:
+#   $1 - Pack slug (or "all" for all packs)
+do_link_skills() {
+    local pack_slug="$1"
+    local packs_dir
+    packs_dir=$(get_packs_dir)
+
+    if [[ "$pack_slug" == "all" ]]; then
+        # Link all packs
+        local total_linked=0
+        local total_stale=0
+        for pack_path in "$packs_dir"/*/; do
+            [[ -d "$pack_path" ]] || continue
+            local slug
+            slug=$(basename "$pack_path")
+
+            echo "Linking skills for pack: $slug"
+            local linked
+            linked=$(symlink_pack_skills "$slug")
+            echo "  Created $linked skill symlinks"
+            total_linked=$((total_linked + linked))
+        done
+
+        # Clean stale skill symlinks
+        local stale
+        stale=$(clean_stale_skill_symlinks)
+        total_stale=$stale
+
+        echo ""
+        print_success "Total: $total_linked skill symlinks created"
+        if [[ $total_stale -gt 0 ]]; then
+            echo "  Removed $total_stale stale skill symlinks"
+        fi
+    else
+        # Link specific pack
+        local pack_dir="$packs_dir/$pack_slug"
+        if [[ ! -d "$pack_dir" ]]; then
+            print_error "ERROR: Pack '$pack_slug' is not installed"
+            return $EXIT_NOT_FOUND
+        fi
+
+        echo "Linking skills for pack: $pack_slug"
+        local linked
+        linked=$(symlink_pack_skills "$pack_slug")
+        print_success "Created $linked skill symlinks"
+    fi
+
+    return $EXIT_SUCCESS
+}
+
+# Re-link both skills and commands for a pack (combined convenience)
+# Args:
+#   $1 - Pack slug (or "all" for all packs)
+do_link_all() {
+    local pack_slug="$1"
+
+    echo "=== Linking skills ==="
+    do_link_skills "$pack_slug"
+    echo ""
+    echo "=== Linking commands ==="
+    do_link_commands "$pack_slug"
+}
+
+# Remove stale skill symlinks that point to nonexistent pack skill directories
+# Returns: Number of stale symlinks removed
+clean_stale_skill_symlinks() {
+    local repo_root
+    repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    local skills_dir="$repo_root/.claude/skills"
+    local removed=0
+
+    [[ -d "$skills_dir" ]] || { echo "0"; return 0; }
+
+    # Use find -type l to catch dangling symlinks (glob */ skips them)
+    while IFS= read -r -d '' link_path; do
+        [[ -L "$link_path" ]] || continue
+
+        local target
+        target=$(readlink "$link_path" 2>/dev/null || echo "")
+
+        # Only manage canonical relative links we create:
+        # ../constructs/packs/<slug>/skills/<skill>
+        [[ "$target" =~ ^[.][.]/constructs/packs/[^/]+/skills/[^/]+$ ]] || continue
+
+        # Check if the target actually exists (resolve relative to symlink dir)
+        local resolved="$skills_dir/$target"
+        if [[ ! -d "$resolved" ]]; then
+            rm -f "$link_path"
+            ((removed++))
+        fi
+    done < <(find "$skills_dir" -mindepth 1 -maxdepth 1 -type l -print0 2>/dev/null)
+
+    echo "$removed"
 }
 
 # =============================================================================
@@ -2265,6 +2398,8 @@ Commands:
     uninstall skill <slug>   Uninstall a skill
     upgrade <slug> [version] Upgrade a pack to latest or specified version
     link-commands <slug>     Re-link pack commands (use "all" for all packs)
+    link-skills <slug>       Re-link pack skills (use "all" for all packs)
+    link <slug>              Re-link both skills and commands (use "all" for all)
     register <slug> [opts]   Register a new construct (delegates to constructs-register.sh)
     sync <slug>              Sync a git-sourced construct from registry
     status [slug]            Show sync status for installed constructs
@@ -2288,6 +2423,8 @@ Examples:
     constructs-install.sh skill thj/terraform-assistant
     constructs-install.sh uninstall pack gtm-collective
     constructs-install.sh link-commands all
+    constructs-install.sh link-skills all
+    constructs-install.sh link all
 
 Authentication:
     Set LOA_CONSTRUCTS_API_KEY environment variable, or create:
@@ -2341,6 +2478,14 @@ main() {
         link-commands)
             [[ -n "${2:-}" ]] || { print_error "ERROR: Missing pack slug (or 'all')"; exit $EXIT_ERROR; }
             do_link_commands "$2"
+            ;;
+        link-skills)
+            [[ -n "${2:-}" ]] || { print_error "ERROR: Missing pack slug (or 'all')"; exit $EXIT_ERROR; }
+            do_link_skills "$2"
+            ;;
+        link)
+            [[ -n "${2:-}" ]] || { print_error "ERROR: Missing pack slug (or 'all')"; exit $EXIT_ERROR; }
+            do_link_all "$2"
             ;;
         register)
             # Delegate to standalone register script.

--- a/scripts/sync-packs.sh
+++ b/scripts/sync-packs.sh
@@ -199,9 +199,9 @@ skill_stale=0
 
 mkdir -p "$LOCAL_SKILLS"
 
-# LC_ALL=C ensures deterministic pack iteration order across locales
-# (collision resolution is first-wins, so order must be stable)
-for pack_dir in $(LC_ALL=C ls -d "$LOCAL_PACKS"/*/ 2>/dev/null); do
+# Deterministic pack iteration order for stable collision resolution (first-wins)
+# Uses null-delimited sorted glob to handle spaces in paths safely
+while IFS= read -r -d '' pack_dir; do
     [[ -d "$pack_dir" ]] || continue
     slug=$(basename "$pack_dir")
     skills_dir="${pack_dir}skills"
@@ -228,6 +228,13 @@ for pack_dir in $(LC_ALL=C ls -d "$LOCAL_PACKS"/*/ 2>/dev/null); do
             fi
             # Keep only canonical construct skill links (first wins, stable)
             if [[ "$current_target" =~ ^[.][.]/constructs/packs/[^/]+/skills/[^/]+$ ]] && [[ -d "${LOCAL_SKILLS}/${current_target}" ]]; then
+                # Log collision for visibility (only on non-JSON output)
+                if [[ "$JSON_OUTPUT" != "true" ]]; then
+                    existing_pack=$(echo "$current_target" | sed 's|.*/constructs/packs/\([^/]*\)/.*|\1|')
+                    if [[ "$existing_pack" != "$slug" ]]; then
+                        echo "  skill collision: ${skill_name} (keeping ${existing_pack}, skipping ${slug})" >&2
+                    fi
+                fi
                 skill_skipped=$((skill_skipped + 1))
                 continue
             fi
@@ -239,7 +246,7 @@ for pack_dir in $(LC_ALL=C ls -d "$LOCAL_PACKS"/*/ 2>/dev/null); do
         ln -s "$relative_path" "$local_skill"
         skill_linked=$((skill_linked + 1))
     done
-done
+done < <(printf '%s\0' "$LOCAL_PACKS"/*/ | LC_ALL=C sort -z)
 
 # Clean stale skill symlinks: remove any canonical construct links whose target
 # directory no longer exists. Uses find -type l to catch dangling symlinks.

--- a/scripts/sync-packs.sh
+++ b/scripts/sync-packs.sh
@@ -186,6 +186,78 @@ if [[ -d "$LOCAL_COMMANDS" ]]; then
 fi
 
 # =============================================================================
+# Sync pack skills to .claude/skills/
+# =============================================================================
+# Creates symlinks from .claude/skills/<name> → pack skill directories.
+# Non-symlink entries (framework built-in skills) are never overwritten.
+# Stale symlinks pointing to removed pack skills are cleaned up.
+
+LOCAL_SKILLS="${REPO_ROOT}/.claude/skills"
+skill_linked=0
+skill_skipped=0
+skill_stale=0
+
+mkdir -p "$LOCAL_SKILLS"
+
+# LC_ALL=C ensures deterministic pack iteration order across locales
+# (collision resolution is first-wins, so order must be stable)
+for pack_dir in $(LC_ALL=C ls -d "$LOCAL_PACKS"/*/ 2>/dev/null); do
+    [[ -d "$pack_dir" ]] || continue
+    slug=$(basename "$pack_dir")
+    skills_dir="${pack_dir}skills"
+    [[ -d "$skills_dir" ]] || continue
+
+    for skill_path in "$skills_dir"/*/; do
+        [[ -d "$skill_path" ]] || continue
+        skill_name=$(basename "$skill_path")
+        local_skill="${LOCAL_SKILLS}/${skill_name}"
+        relative_path="../constructs/packs/${slug}/skills/${skill_name}"
+
+        if [[ -e "$local_skill" ]] && [[ ! -L "$local_skill" ]]; then
+            # Real directory/file — framework built-in, don't overwrite
+            skill_skipped=$((skill_skipped + 1))
+            continue
+        fi
+
+        if [[ -L "$local_skill" ]]; then
+            # Already a symlink — check if target is correct or valid from another pack
+            current_target=$(readlink "$local_skill" 2>/dev/null || echo "")
+            if [[ "$current_target" == "$relative_path" ]]; then
+                skill_skipped=$((skill_skipped + 1))
+                continue
+            fi
+            # Keep only canonical construct skill links (first wins, stable)
+            if [[ "$current_target" =~ ^[.][.]/constructs/packs/[^/]+/skills/[^/]+$ ]] && [[ -d "${LOCAL_SKILLS}/${current_target}" ]]; then
+                skill_skipped=$((skill_skipped + 1))
+                continue
+            fi
+            # Non-canonical, stale, or broken — replace
+            rm -f "$local_skill"
+        fi
+
+        # Create symlink
+        ln -s "$relative_path" "$local_skill"
+        skill_linked=$((skill_linked + 1))
+    done
+done
+
+# Clean stale skill symlinks: remove any canonical construct links whose target
+# directory no longer exists. Uses find -type l to catch dangling symlinks.
+while IFS= read -r -d '' link_path; do
+    [[ -L "$link_path" ]] || continue
+
+    target=$(readlink "$link_path" 2>/dev/null || echo "")
+    # Only manage canonical relative links created by this script
+    [[ "$target" =~ ^[.][.]/constructs/packs/[^/]+/skills/[^/]+$ ]] || continue
+
+    # Resolve relative target from the symlink's directory
+    if [[ ! -d "${LOCAL_SKILLS}/${target}" ]]; then
+        rm -f "$link_path"
+        skill_stale=$((skill_stale + 1))
+    fi
+done < <(find "$LOCAL_SKILLS" -mindepth 1 -maxdepth 1 -type l -print0 2>/dev/null)
+
+# =============================================================================
 # Write sync state
 # =============================================================================
 
@@ -208,6 +280,9 @@ cat > "$SYNC_STATE" << EOF
   "packs_total": ${total},
   "commands_registered": ${cmd_registered},
   "commands_skipped": ${cmd_skipped},
+  "skills_linked": ${skill_linked},
+  "skills_skipped": ${skill_skipped},
+  "skills_stale_removed": ${skill_stale},
   "global_total": ${global_pack_count},
   "global_store": "${GLOBAL_PACKS}",
   "method": "symlink"
@@ -220,9 +295,11 @@ EOF
 
 if [[ "$JSON_OUTPUT" == "true" ]]; then
     cat "$SYNC_STATE"
-elif [[ $added -gt 0 ]] || [[ $updated -gt 0 ]] || [[ $removed -gt 0 ]] || [[ $cmd_registered -gt 0 ]]; then
+elif [[ $added -gt 0 ]] || [[ $updated -gt 0 ]] || [[ $removed -gt 0 ]] || [[ $cmd_registered -gt 0 ]] || [[ $skill_linked -gt 0 ]] || [[ $skill_stale -gt 0 ]]; then
     # Only report when changes happen (silent on no-op)
     msg="packs synced: +${added} ~${updated} -${removed} (${total} total)"
     [[ $cmd_registered -gt 0 ]] && msg+=", commands: +${cmd_registered}"
+    [[ $skill_linked -gt 0 ]] && msg+=", skills: +${skill_linked}"
+    [[ $skill_stale -gt 0 ]] && msg+=", stale: -${skill_stale}"
     echo "$msg" >&2
 fi


### PR DESCRIPTION
## Summary

Closes the construct install→upgrade→sync lifecycle gap that caused skills to silently disappear after pack evolution. Three root causes fixed:

- **`do_upgrade_pack()` never re-linked skills** — 3-way merge completed but new skills from upgrades stayed invisible to Claude Code's skill discovery
- **`sync-packs.sh` (SessionStart hook) skipped `.claude/skills/`** — synced pack-level and command symlinks but never touched skill symlinks
- **No manual re-link path existed** — `link-commands` had no `link-skills` counterpart

## Changes

| File | What |
|------|------|
| `.claude/scripts/constructs-install.sh` | Phase 7 in upgrade, `do_link_skills()`, `do_link_all()`, `clean_stale_skill_symlinks()`, `link-skills` + `link` CLI subcommands, boundary-safe `validate_symlink_target()` |
| `scripts/sync-packs.sh` | Skill symlink sync section, stale cleanup via `find -type l`, canonical regex validation, `LC_ALL=C` deterministic ordering |

## Security hardening (from GPT-5.2 cross-model review)

- Boundary-safe prefix matching with slash delimiter (prevents sibling-path bypass like `/x/constructs-evil` matching `/x/constructs*`)
- Canonical regex for trusted symlink targets: `^../constructs/packs/[^/]+/skills/[^/]+$`
- `find -type l` for stale cleanup (glob `*/` misses dangling symlinks)
- `HOME`-scoped trust boundary on `LOA_GLOBAL_STORE` env var
- Defensive numeric coercion on `symlink_pack_skills` output

## Verification

| Check | Result |
|-------|--------|
| First sync run | 107 skills linked, 6 stale removed |
| Second run (idempotency) | 0 linked, 160 skipped, 0 stale |
| Timing (24 packs, 160 skills) | 1.27s |
| `link-skills observer` | 24/24 linked |
| `link all` | 160 skills, 66 commands |
| `constructs-health.sh` | No regression (143/192 pre-existing) |
| `bash -n` syntax check | Both files pass |
| Collision handling | 2 collisions (`research`, `configure-project`) — first-wins-stable |

## Test plan

- [ ] Verify `sync-packs.sh --json` shows `skills_linked: 0` on clean repo (idempotent)
- [ ] Install a new pack, verify skills appear in `.claude/skills/`
- [ ] Remove a skill from a pack, verify stale symlink is cleaned on next sync
- [ ] Run `constructs-install.sh link all` — all skills and commands linked
- [ ] Verify SessionStart hook completes in < 2 seconds

Closes #120
Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)