### PR TITLE
docs(cycle-004): kickoff — doctrine v4 + SEED + F26 closure

### DIFF
--- a/grimoires/loa-constructs-seed-2026-04-21/bonfire-construct-pipe-doctrine.md
+++ b/grimoires/loa-constructs-seed-2026-04-21/bonfire-construct-pipe-doctrine.md
@@ -633,3 +633,134 @@ Given v3 amendments, cycle-003's cycle-004 inheritance queue gains doctrinal fra
 ---
 
 *v3 · 2026-04-21-late · After cycle-003 walk + second operator review. Doctrine deepens: Operator OS is the proto-composition system we're naming underneath. Frames vs workflows distinguished. Vibe-coding surface promoted. Hivemind as shareable. Four layers explicitly co-exist without forced unification.*
+
+---
+
+## 16 · Amendments (v3 → v4, 2026-04-21-late third operator review)
+
+After doctrine v3 merged + cycle-003 closed. Operator signaled two structural shifts + named a friction point that reframes cycle-004 primary target.
+
+### 16.1 · Operator OS inverts — prescriptive → prototype (open playground)
+
+Operator observation:
+
+> *"We built this Claude MD at the base before we even designed this new update here… I think we should reverse our understanding of using this as a composition. I guess it's a prototype of the composition system; it can inform what types of compositions there could be, but again, if we design stuff in the sense that they are Unix tools, then all of these modes and possibilities should be possible. My personal workflow should never prescribe specificity, but it could provide ideas and overall form of how an operator may structure his/hers. Open playground."*
+
+**Structural claim**: with pipe doctrine as the ground, Operator OS (the `~/.claude/CLAUDE.md` modes + lenses + Construct Resolution table) is no longer the canonical spec. It becomes the **reference implementation** — one operator's structured workflow, offered as a starter template for others. Any operator may:
+
+- Use it as-is
+- Fork it and customize modes/lenses
+- Replace it entirely with their own composition
+- Mix: adopt some modes, introduce their own
+
+The pipe doctrine guarantees that **all of these are valid** as long as the compositional substrate (typed I/O, Signal/Verdict/Artifact/Intent/Operator-Model streams) is honored. Modes are a UX affordance over that substrate, not the substrate itself.
+
+**Implication for public release** (operator-stated post-cycle goal): the README should frame Operator OS as "here's one operator's workflow — here's how to author yours." The construct network's value is the *substrate*; Operator OS is one of many surfaces.
+
+**Doctrine invariant**: no construct, pipe, or composition may require Operator OS modes/lenses as preconditions for operation. Modes are **orchestration hints**, not dispatch requirements.
+
+### 16.2 · Hivemind trichotomy — named layers
+
+Operator clarification:
+
+> *"The hive mind OS is an internal hive mind tool. The hive mind that I'm talking about more so is the /hive mind, so I think we can consider the hive mind construct as an internal knowledge base, and then we can also consider the organizational memory, the hive mind, as well. There's a personal hive mind, and then there's the organizational hive mind."*
+
+Clean trichotomy:
+
+| Layer | What it is | Lives at |
+|---|---|---|
+| **Construct** | `hivemind-os` pack — installable org-knowledge structure + skills | `~/.loa/constructs/packs/hivemind-os/` |
+| **Skill** | `/hivemind` (router) + `querying-hivemind` (org lookup) — invocation surface | `.claude/skills/` |
+| **Knowledge (personal)** | Operator's own memory — self, strategy, wiki concepts, world notes | `~/hivemind/` |
+| **Knowledge (organizational)** | Org-shared — library, laboratory, distribution, identity | `~/.loa/constructs/packs/hivemind-os/library+laboratory+network+…` |
+| **Archivist** | Separate construct for vault mechanics — ingest, supersede, decay | `~/.loa/constructs/packs/archivist/` (not installed by default) |
+
+**Structural claim**: these five are distinct and composable. Operator-Model (§14.2) reads from **all four knowledge-bearing layers** through the Skill layer. Construct layer (hivemind-os) is the *shareable structure* that any org can adopt. Archivist composes with either personal or org hivemind to provide vault mechanics without re-implementing them.
+
+**Implication for §15.4 "hivemind-as-shareable-system"**: the shareable thing is the *structure*, the *conventions* (frontmatter, wikilinks, decay classes, supersession), and the *skill router* — not any specific operator's content. Publishing `hivemind-os` publicly means publishing the PATTERN, with redacted starter content showing how to use it.
+
+**Implication for cycle-N**: document the trichotomy in public-facing material. Not as "this is complicated" — as "here are four clean slots: plug your org's knowledge into layer 2, your personal into layer 3, compose with archivist for mechanics, invoke through the skill."
+
+### 16.3 · Composition determinism — the stated friction
+
+Operator observation (load-bearing for cycle-004):
+
+> *"One of the key friction points is that it is unclear to me which constructs are being called and how consistent they are. It doesn't feel extremely consistent, especially with the amount of context loaded in and the variance and non-deterministic nature of agents. I think you have a lot more variance if the sessions that you kick off are very unstructured; it could be a conflict of frames."*
+
+**Three distinct failures** this names:
+
+1. **Transparency failure** — operator can't see which constructs are informing the current agent response
+2. **Consistency failure** — same operator utterance on different sessions routes to different constructs
+3. **Frame conflict** — when multiple constructs load into one session, their frames (modes, lenses, personas) can contradict without explicit resolution
+
+**Structural claim**: composition determinism is a first-class construct-network invariant, not a tooling nicety.
+
+Minimum requirements a construct-using agent session must support:
+
+| Invariant | Manifestation |
+|---|---|
+| **Active set visible** | Agent can report "constructs in my active context right now" at any point — a `constructs-active` command or equivalent |
+| **Invocation deterministic** | When operator invokes `/feel`, the same pack + skill + lens set fires every time. Variance is explicit (e.g., parameter), not hidden |
+| **Frame resolution named** | When two constructs' frames conflict (e.g., FEEL mode + TEND mode simultaneously), the resolution is explicit — one wins, or they compose with a stated rule |
+| **Trajectory completeness** | Every construct-touching action emits a trajectory row (Signal stream), not just Skill tool invocations |
+
+**Cycle-003's contribution**: the `.run/construct-trajectory.jsonl` + hook wiring solves the trajectory side of #1. But the UX-level "what's active right now" question is not answered — trajectory is append-only historical, not active-state.
+
+**Cycle-004 primary target**: close this trifecta. Composition determinism becomes the load-bearing cycle outcome, not an incidental fix.
+
+### 16.4 · Invariant: agent-transparency is non-optional
+
+Promoting a consequence of §16.3 to doctrine-level invariant:
+
+> **Every construct-network-aware agent session MUST support the operator asking "what's informing this response" and receiving a specific, complete, trustworthy answer within read-mode latency (glance <1s, orient <5s).**
+
+This is not "logging." It's a runtime capability. An agent that can't surface its active construct set *cannot participate honestly in operator orchestration* — the operator's pipe-stage input can't route effectively if they don't know what's downstream.
+
+**Implementation implications for cycle-004**:
+- Shell tool: `constructs-active.sh` — outputs active set with mode + lens + pack + active skills per pack. Three read-modes per §14.3.
+- Integration: hook into operator workflow naturally — e.g., at session start, on /loa-style status, on explicit `/active` query.
+- Coverage: personal hivemind context, org hivemind context, operator OS mode, active lenses, invoked skills (trajectory-backed), agent's own self-reported frame.
+
+**Invariant fails** if:
+- Active-state is inferred post-hoc from trajectory rather than available live
+- Modes/lenses/constructs can be "loaded" without the agent being able to enumerate them
+- Different invocations of the same intent produce non-deterministic active sets without operator visibility into the divergence
+
+### 16.5 · Operator-Context ↔ Hivemind autoload revisited
+
+Previously in §15.5 I named Operator-Context as cycle-006+ candidate. After §16.3 framing, this is now earlier-stage:
+
+- Operator-Context (slice of Operator-Model load-bearing NOW) is the MECHANISM that makes composition determinism work across expertise levels
+- Without it, an agent either over-explains (operator impatience pattern per `~/hivemind/self/patterns.md`) or under-explains (misses context operator needs)
+- With it, the same construct invocation adapts output-depth to operator state per read-mode
+
+**Revised placement**: Operator-Context construct candidate moves from cycle-006 → cycle-005. Same cycle as workflow-kind composition design, since both rely on operator-state read-paths.
+
+### 16.6 · Cycle-004 legs restructured
+
+Original cycle-003 inheritance queue (§15.7) carried infra-heavy priorities (F24, DB swap). After §16.3 friction surfaced, cycle-004 primary target shifts to **transparency + determinism + open-playground doctrine**. Infra defers to cycle-005.
+
+| Leg | Purpose | Priority |
+|---|---|---|
+| **L1 · constructs-active.sh** | Active-set reporter for agent sessions (§16.4 invariant) | CERTAIN |
+| **L2 · Mode invocation contract** | Document + enforce: /feel, @ALEXANDER, "FEEL mode" all route deterministically to same pack+skill+lens | CERTAIN |
+| **L3 · Operator OS as starter template** | Draft `~/.claude/CLAUDE.md` as template; separate operator's canonical version as example; publish as hivemind page | CERTAIN |
+| **L4 · Hivemind trichotomy doc** | Formal named page: personal / org / construct / skill / archivist | CERTAIN |
+| **L5 · feel-audit workflow-kind composition** | First real workflow per §15.2; composes artisan + observer | LIKELY |
+| **L6 · Trajectory extension** | Cover not just Skill tool use but full agent-action attribution (Bash/Read/Edit touching construct files) | POSSIBLE |
+| **L7 · F24 three-way-merge** | Carryover from cycle-003; still useful but not primary | CONDITIONAL |
+| **L8 · DB swap** | Defers to cycle-005+ | DEFERRED |
+
+### 16.7 · Version bump
+
+**v4**. v3 chain-preserved. Amendments:
+- Operator OS inverted (prescriptive → prototype, open playground)
+- Hivemind trichotomy named (5 layers, 4 composable)
+- Composition determinism invariant (§16.4)
+- Agent transparency promoted (non-optional)
+- Operator-Context upgraded to cycle-005 placement
+- Cycle-004 legs restructured around transparency
+
+---
+
+*v4 · 2026-04-21-late · Third operator review. Operator OS inverts from canon to starter-template. Hivemind trichotomy cleaned. Composition determinism promoted to cycle-004 primary. Agent transparency becomes doctrine-level invariant. Open playground — "my workflow is one example, not THE workflow."*

--- a/grimoires/loa-constructs-seed-2026-04-21/cycle-003-findings.md
+++ b/grimoires/loa-constructs-seed-2026-04-21/cycle-003-findings.md
@@ -198,3 +198,26 @@ The thesis of friction-driven composable cycles is now validated across three di
 ---
 
 *Cycle-003 walk complete. 2026-04-21. First-person-agent walk proved the doctrine at runtime. 8 steps, 4 passes, 2 partials, 2 spec-only, 4 new findings. 450 lines shell shipped, 0 non-shell. Next: operator pacing.*
+
+---
+
+## Post-close addendum (2026-04-21-late)
+
+### F26 · Adversarial-review env gap
+
+Running `/flatline-review` against the doctrine failed in degraded mode:
+- `ANTHROPIC_API_KEY` not set in operator's local shell env (Claude Code uses a separate auth path)
+- 4/6 Phase-1 review calls failed (Opus + Gemini reviews)
+- Only 2/6 succeeded (GPT-5.3-codex reviews)
+- Orchestrator exited code 3 despite `api_key_mode: graceful` declared in `.loa.config.yaml` — graceful degradation not honored for zero-items-scored case
+
+`/bridgebuilder-review` didn't run either:
+- `post_pr_validation.bridgebuilder_review.enabled=true` is harness-scoped, not CI-hooked
+- PR #195 (doctrine v3) received Vercel + Socket comments but no Bridgebuilder auto-review
+
+**Remediation paths** (cycle-005+ candidates):
+1. Operator sets `ANTHROPIC_API_KEY` + `GOOGLE_API_KEY` in shell env → flatline-review becomes runnable
+2. Small GitHub Actions workflow that invokes `bridgebuilder-review` on PRs matching cycle-* branches
+3. Fix `api_key_mode: graceful` — orchestrator should emit partial consensus when fewer than 6/6 calls succeed, not exit-3
+
+**Scope note**: cycle-003 shipped without triple-model adversarial review. Doctrine v4 also ships without it. This is documented risk — the review gates operators have in this state are: (a) operator conversational review, (b) KANSEI gate, (c) cycle-001 review-lens (GECKO/KEEPER/OTLET/KISS). Adequate for cycle-pacing; insufficient for public-release sign-off. Public README cycle should include running flatline against the full corpus once env gap closed.

--- a/grimoires/loa-constructs-seed-2026-04-21/cycle-004-SEED-open-playground.md
+++ b/grimoires/loa-constructs-seed-2026-04-21/cycle-004-SEED-open-playground.md
@@ -1,0 +1,187 @@
+# SEED — Cycle-004 · Open Playground (transparency + determinism)
+
+> *"My personal workflow should never prescribe specificity, but it could provide ideas and overall form of how an operator may structure his/hers. Open playground."* — operator 2026-04-21-late
+>
+> **Status**: Active · Authored 2026-04-21 post doctrine v4
+> **Supersedes**: cycle-003 inheritance queue (F24/DB swap → cycle-005)
+> **Dispatch mode**: `/spiraling` harness (formal cycle); L1+L2 shell-first, L3+L4 doctrine-work, L5 workflow authoring
+> **SEED-driven**: yes — this SEED is harness-compatible
+
+---
+
+## 0 · Why this cycle exists
+
+Three forces converging:
+
+1. **Doctrine v4 §16.3 friction** (operator 2026-04-21):
+   > *"It's unclear to me which constructs are being called and how consistent they are. It doesn't feel extremely consistent, especially with the amount of context loaded in and the variance and non-deterministic nature of agents."*
+
+2. **Doctrine v4 §16.1** — Operator OS inverts: from canonical spec to prototype/starter-template. Other operators should be able to author their own workflows.
+
+3. **Doctrine v4 §16.2** — Hivemind trichotomy now named (construct / skill / knowledge-personal / knowledge-org / archivist). Needs formal documentation in a single page an external operator can read.
+
+Cycle-004 closes the trifecta: make constructs visible (transparency), make invocations deterministic (consistency), invite variation (open playground).
+
+**After this cycle**, public README becomes possible — doctrine v4 + cycle-003 walk + cycle-004 transparency tooling = a coherent story for external operators.
+
+---
+
+## 1 · Scope lock
+
+Cycle-004 touches:
+
+- `.claude/scripts/` — new shell tools (constructs-active.sh, mode-invocation audit, trajectory extension)
+- `grimoires/` — doctrine v5 amendments (if cycle surfaces new structural claims), cycle-004-findings.md
+- `~/hivemind/wiki/concepts/` — hivemind-trichotomy page (new), operator-os-as-template page (new)
+- Draft of `~/.claude/CLAUDE.md` reshape (as artifact; operator does the actual edit)
+- `.claude/constructs/compositions/feel-audit.yaml` — author first workflow-kind composition
+
+**Does NOT touch**:
+- `apps/api/` (no DB swap — defers to cycle-005)
+- `constructs-install.sh` three-way-merge (F24 — defers to cycle-005)
+- `apps/explorer/` (defers per operator "don't rebuild the network")
+- Dynamic Labs auth (defers per F11 pull-thread)
+- Upstream construct repos (ALEXANDER SKILL.md edits — defers to separate follow-up PRs per construct)
+
+---
+
+## 2 · Legs (from doctrine v4 §16.6)
+
+| Leg | Purpose | Est. lines | Status |
+|---|---|---|---|
+| **L1 · constructs-active.sh** | Reports active construct set + mode + lenses in 3 read-modes | ~180 shell | CERTAIN |
+| **L2 · Mode invocation contract** | Document + enforce deterministic routing for /feel, @ALEXANDER, "FEEL mode" → same pack+skill+lens | ~100 shell + 1 doc | CERTAIN |
+| **L3 · Operator OS as starter template** | Reshape `~/.claude/CLAUDE.md` reference + publish template as construct-starter-os.md page | 1 doctrine doc + template | CERTAIN |
+| **L4 · Hivemind trichotomy doc** | Single page clearly naming construct / skill / knowledge-personal / knowledge-org / archivist | 1 concept page | CERTAIN |
+| **L5 · feel-audit workflow-kind composition** | Author first runnable workflow per doctrine §15.2 | 1 YAML + executor hint | LIKELY |
+| **L6 · Trajectory extension to non-Skill actions** | Hook Bash/Read/Edit when they touch construct files; attribute back to pack | ~120 shell | POSSIBLE |
+| **L7 · F24 three-way-merge carryover** | Only if L1-L5 land and budget/time permits | ~80 shell | CONDITIONAL |
+
+Priority ordering matches doctrine §16.4 invariant: **transparency first** (L1), **determinism second** (L2), **playground-opening doctrine** (L3/L4), **then workflows** (L5), then extensions (L6/L7).
+
+---
+
+## 3 · Acceptance criteria
+
+### L1 · constructs-active
+
+- **AC-L1.1** · `constructs-active.sh` outputs a glance-mode line answering "what's my active set" in <1s
+- **AC-L1.2** · `--orient` mode shows modes-in-effect, active lenses, constructs in scope, active skills per construct
+- **AC-L1.3** · `--intervene` mode outputs JSON pipeable to downstream tools
+- **AC-L1.4** · Active set reflects both **declared** (mode invocations, @-mentions) and **observed** (trajectory-backed skill invocations)
+
+### L2 · Mode invocation contract
+
+- **AC-L2.1** · A written spec: one operator utterance shape → deterministic pack+skill+lens resolution
+- **AC-L2.2** · For "FEEL mode" / "/feel" / "@ALEXANDER": all three MUST route to artisan pack, ALEXANDER persona, craft lens — documented + enforced
+- **AC-L2.3** · If frames conflict (e.g., FEEL + TEND simultaneously), resolution rule is stated and the agent reports the conflict + chosen resolution to operator
+
+### L3 · Operator OS as starter template
+
+- **AC-L3.1** · Draft `construct-starter-os.md` exists in hivemind as a template
+- **AC-L3.2** · Draft shows: modes section (commented "edit to your workflow"), lenses section (same), construct-resolution table (same), invocation examples
+- **AC-L3.3** · Reference implementation (operator's current CLAUDE.md) is linked as "one example"
+
+### L4 · Hivemind trichotomy doc
+
+- **AC-L4.1** · New `~/hivemind/wiki/concepts/hivemind-trichotomy.md` page
+- **AC-L4.2** · Names all 5 layers (construct / skill / knowledge-personal / knowledge-org / archivist)
+- **AC-L4.3** · Each layer gets: 1-sentence what, path, 1 example use, 1 composition with another layer
+- **AC-L4.4** · Linked from hivemind index
+
+### L5 · feel-audit workflow
+
+- **AC-L5.1** · `compositions/feel-audit.yaml` v1 shape per doctrine §4 (workflow kind) + §15.2 (frame+chain separation)
+- **AC-L5.2** · Declares `reads`/`writes` types per stage (Artifact → Signal → Verdict)
+- **AC-L5.3** · Runnable via conceptual stub — a bash `construct-compose.sh feel-audit <target>` that manually sequences the constructs (real runner defers to cycle-005)
+
+---
+
+## 4 · Dispatch
+
+**Budget**: $60 target, $120 cap. Profile `light` (no Flatline gates on individual legs; final review gate optional).
+
+**Dispatch mechanism**: `/spiraling` harness available and appropriate for this cycle shape (formal SEED, multi-leg, KANSEI gate at close).
+
+```bash
+.claude/scripts/spiral-harness.sh \
+  --task "Build cycle-004 open playground per SEED 2026-04-21. Legs L1-L5 CERTAIN/LIKELY, L6/L7 conditional on budget. L1 constructs-active.sh shell tool with 3 read-modes (glance/orient/intervene) reporting active construct+mode+lens set. L2 mode-invocation contract spec + enforcement. L3 Operator OS starter template in hivemind. L4 hivemind-trichotomy concept page. L5 feel-audit workflow-kind composition YAML. Shell-first per doctrine §13.1. Doctrine v4 compliance: §16.4 transparency invariant, §16.3 determinism friction closure, §16.1 open-playground framing." \
+  --cycle-dir .run/cycles/loa-constructs-cycle-004 \
+  --cycle-id loa-constructs-cycle-004 \
+  --branch feat/cycle-004-open-playground \
+  --profile light \
+  --budget 120 \
+  --seed-context grimoires/loa-constructs-seed-2026-04-21/cycle-004-SEED-open-playground.md
+```
+
+**Pre-flight**: operator-authored legs (L3, L4) may be done conversationally alongside harness for L1/L2/L5. The harness can dispatch L1+L2 autonomously; L3+L4 are doctrine work that benefits from operator-pair.
+
+**Alternative**: all-conversational mode (cycle-003 precedent) if operator prefers reading each leg as it lands rather than batch-reviewing a harness output. Either works.
+
+---
+
+## 5 · KANSEI gate (operator-answered, per doctrine §14.3 read-mode calibration)
+
+At close:
+
+| # | Question | Pass |
+|---|---|---|
+| Q1 | Can I ask the agent "what constructs are active?" and get a trustworthy answer in ≤5s? | Y |
+| Q2 | Does "/feel" or "FEEL mode" produce the same pack+skill+lens each time? | Y |
+| Q3 | Does the starter template make sense as a replacement for the current `~/.claude/CLAUDE.md`, OR as a source to fork from? | Y or "this is close enough to try" |
+| Q4 | Can I explain hivemind trichotomy to someone external in ≤3 sentences? | Y |
+| Q5 | Free-text: which friction remains, and does the construct network feel closer to an "open playground" than before? | positive sentiment or concrete open friction |
+
+Pass: 4/5 YES on Q1-Q4 + constructive Q5. Halt if <3/5.
+
+---
+
+## 6 · Review lens (carryover from cycle-001 + additions)
+
+Still applicable: `cycle-001-review-lens.md` (GECKO + KEEPER + OTLET + KISS).
+
+**Cycle-004 additions**:
+
+- **TRANSPARENCY lens** (doctrine §16.4): reviewer asks "does this make the agent's active set visible to the operator in read-mode latency?"
+- **DETERMINISM lens** (doctrine §16.3): reviewer asks "does this make the same invocation produce the same result, or at least make variance explicit?"
+- **PLAYGROUND lens** (doctrine §16.1): reviewer asks "does this allow for operator variation, or does it lock one pattern in?"
+
+COMPILE lens from cycle-003 F13: `bun run typecheck` still required for any code changes in apps/*.
+
+---
+
+## 7 · What this cycle proves (if it lands)
+
+1. **Composition determinism is implementable** — transparency + invocation contract in shell tools.
+2. **Operator OS can invert** from canon to template without breaking anything.
+3. **Hivemind trichotomy is documentable in one page** — external operators can onboard to the structure.
+4. **Workflow-kind compositions are authorable** — feel-audit becomes the first real one, not just folklore YAML.
+5. **Public README is unblocked** — doctrine v4 + walk + open-playground is a coherent story.
+
+If it struggles, specific learnings route back into doctrine v5 amendments.
+
+---
+
+## 8 · What cycle-005 inherits
+
+Pre-drafted:
+
+1. **F24 three-way-merge impl** (carried from cycle-003, deprioritized out of cycle-004)
+2. **L1 DB swap Supabase → Turso** (still primary infra carry)
+3. **`.source.json` backfill for 29 legacy installs** (F22 carry)
+4. **Upstream SKILL.md emission PRs** (one PR per construct-artisan, construct-observer, construct-k-hole)
+5. **Composition runtime `construct-compose.sh`** (cycle-004 L5 ships a YAML; runtime follows)
+6. **Operator-Context construct** (doctrine §15.5 / §16.5 — context-aware hivemind autoload)
+7. **Archivist pack installation + wiring** (enables vault-mechanics for hivemind)
+
+---
+
+## 9 · Note on /flatline-review + /bridgebuilder-review
+
+Deferred per cycle-003 F26 (env gap: `ANTHROPIC_API_KEY` not set for adversarial multi-model). When operator sets that env var, flatline-review can run against doctrine v4 retroactively. Bridgebuilder CI auto-hook is cycle-006+ (§16.6 L6 candidate).
+
+Cycle-004 ships without triple-model adversarial review. The KANSEI gate + operator conversational review + the transparency lens substitute for now.
+
+---
+
+*Drafted 2026-04-21-late. First SEED authored post-doctrine-v4. Primary target: the stated friction (which constructs are active / are they consistent). Secondary target: open the playground. Shell-first, doctrine-compatible, harness-dispatch-ready.*


### PR DESCRIPTION
## Cycle-004 kickoff — Open Playground

Three coupled docs land together: doctrine v4 amendments, cycle-004 SEED, cycle-003 F26 addendum.

### Primary target (per doctrine v4 §16.3)

Operator's stated friction:

> *"It's unclear to me which constructs are being called and how consistent they are. It doesn't feel extremely consistent, especially with the amount of context loaded in and the variance and non-deterministic nature of agents."*

Cycle-004 closes this via transparency + determinism + open-playground doctrine.

### Doctrine v4 additions

- **§16.1** Operator OS inverts: prescriptive spec → prototype/starter-template. *"My personal workflow should never prescribe specificity."*
- **§16.2** Hivemind trichotomy: construct (hivemind-os) / skill (/hivemind + querying-hivemind) / knowledge-personal (~/hivemind) / knowledge-org (hivemind-os/library+laboratory) / archivist
- **§16.3** Composition determinism: three failures (transparency / consistency / frame-conflict)
- **§16.4** Agent-transparency promoted to non-optional doctrine-level invariant
- **§16.5** Operator-Context upgraded from cycle-006 → cycle-005
- **§16.6** Cycle-004 legs restructured: transparency first, not infra
- **§16.7** Version bump, chain-preserved

### Cycle-004 legs

| Leg | Priority |
|---|---|
| L1 constructs-active.sh (3 read-modes) | CERTAIN |
| L2 mode invocation contract | CERTAIN |
| L3 Operator OS starter template | CERTAIN |
| L4 hivemind trichotomy concept page | CERTAIN |
| L5 feel-audit workflow YAML | LIKELY |
| L6 trajectory extension | POSSIBLE |
| L7 F24 three-way-merge carryover | CONDITIONAL |

### Cycle-003 F26 addendum

Adversarial review env gap (ANTHROPIC_API_KEY not set locally; Bridgebuilder CI hook absent). Remediation deferred to cycle-005+.

### Dispatch shape

Harness-compatible SEED ready for `/spiraling` OR conversational-paired mode. Operator picks.

Shell-first per doctrine §13.1. No TypeScript expected this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)