### PR TITLE
feat(cycle-005): runtime + integration — composition runner, stream schemas, manifest validator, butterfreezone adapter, doctrine v5

### DIFF
--- a/.claude/commands/constructs.md
+++ b/.claude/commands/constructs.md
@@ -53,11 +53,13 @@ Browse and install packs from the Loa Constructs Registry with a multi-select UI
 ```
 /constructs                    # Smart default: manage installed OR browse to install
 /constructs browse             # Browse available packs
-/constructs install <pack>     # Install specific pack
-/constructs list               # List installed packs
+/constructs install <pack>     # Install a single pack
+/constructs list               # List installed packs (--orient shows streams + personas)
 /constructs search <query>     # Search packs by name/description
-/constructs update             # Check for updates
+/constructs update             # Check for updates across all packs
+/constructs upgrade <pack>     # Upgrade a single pack (git pull / re-fetch)
 /constructs uninstall <pack>   # Remove a pack
+/constructs auth               # View auth status / setup API key
 ```
 
 ## Prerequisites

--- a/.claude/schemas/artifact.schema.json
+++ b/.claude/schemas/artifact.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://constructs.network/schemas/artifact.schema.json",
+  "title": "Artifact",
+  "description": "Produced material stream row. Doctrine §3.3. File-at-path with content-hash + metadata. Content-addressable — multiple constructs may read the same artifact; writers commit to versioned paths.",
+  "type": "object",
+  "schema_version": "1.0.0",
+  "additionalProperties": true,
+  "required": ["stream_type", "schema_version", "timestamp", "path"],
+  "properties": {
+    "stream_type": {
+      "const": "Artifact"
+    },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "path": {
+      "type": "string",
+      "description": "Filesystem or URI path to the material."
+    },
+    "content_hash": {
+      "type": "string",
+      "description": "Optional content hash (sha256 hex preferred) for content-addressable lookup."
+    },
+    "media_type": {
+      "type": "string",
+      "description": "MIME type or informal type tag (e.g. text/markdown, application/yaml, image/png)."
+    },
+    "producer": {
+      "type": "string",
+      "description": "Construct slug or pack-scoped skill handle that produced this artifact."
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "derived_from": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional list of upstream artifact paths or content-hashes this artifact was derived from."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Free-form producer metadata — descriptions, tags, version labels.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/.claude/schemas/intent.schema.json
+++ b/.claude/schemas/intent.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://constructs.network/schemas/intent.schema.json",
+  "title": "Intent",
+  "description": "Operator routing signal. Doctrine §3.4 + §14.4 (structured-slot amendment). The entry point — every pipe chain begins with an Intent. Producers: operator (the only source). Consumers: orchestration layer.",
+  "type": "object",
+  "schema_version": "1.0.0",
+  "additionalProperties": true,
+  "required": ["stream_type", "schema_version", "timestamp", "intent"],
+  "properties": {
+    "stream_type": {
+      "const": "Intent"
+    },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "intent": {
+      "type": "string",
+      "description": "Operator utterance — free-form prose framing the ask."
+    },
+    "intent_class": {
+      "type": "string",
+      "description": "Optional classification enum (e.g. audit, implement, review, plan, dispatch). Orchestrator may use it for composition selection."
+    },
+    "context": {
+      "type": "object",
+      "description": "Inline typed slots — artifact refs, entity handles, mode hints. Doctrine §14.4 multi-modal slot pattern.",
+      "additionalProperties": true
+    },
+    "constraints": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Hard guardrails from the operator (e.g. 'no admin-merge', 'shell-first only')."
+    },
+    "feedback_on": {
+      "type": "string",
+      "description": "Optional reference — prior artifact, verdict, or run_id — this intent reacts to. Feedback-as-pipe-input per doctrine §6."
+    },
+    "operator": {
+      "type": "string",
+      "description": "Optional operator identifier for multi-operator contexts."
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "read_mode": {
+      "type": "string",
+      "enum": ["glance", "orient", "intervene"]
+    }
+  }
+}

--- a/.claude/schemas/operator-model.schema.json
+++ b/.claude/schemas/operator-model.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://constructs.network/schemas/operator-model.schema.json",
+  "title": "Operator-Model",
+  "description": "Operator knowledge/expertise map. Doctrine §14.2 (5th stream primitive). Sourced from ~/hivemind/ + session context + explicit operator utterances. Every pipe stage reads this alongside its domain input so output register calibrates to operator expertise.",
+  "type": "object",
+  "schema_version": "1.0.0",
+  "additionalProperties": true,
+  "required": ["stream_type", "schema_version", "timestamp"],
+  "properties": {
+    "stream_type": {
+      "const": "Operator-Model"
+    },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "operator": {
+      "type": "string",
+      "description": "Operator identifier. Default implicit when single-operator context."
+    },
+    "expertise": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Declared or inferred domains of expertise (e.g. design-engineering, solidity, convex)."
+    },
+    "mode": {
+      "type": "string",
+      "description": "Current Operator-OS mode if any (e.g. FEEL, ARCH, DIG, SHIP, FRAME, TEND). Orientation hint, not dispatch requirement."
+    },
+    "lenses": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Active lenses layered over mode (e.g. craft, keeper, canon, weaver)."
+    },
+    "references": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Things the operator has named this session — projects, people, code refs. Consumers may avoid re-explaining these."
+    },
+    "register": {
+      "type": "string",
+      "enum": ["novice", "intermediate", "expert", "mixed"],
+      "description": "Optional calibration tier for output depth. Consumers may expand on novice, shortcut on expert."
+    },
+    "hivemind_sources": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Paths to hivemind entries loaded into context (personal + organizational). Provenance for any operator-facing claim."
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "read_mode": {
+      "type": "string",
+      "enum": ["glance", "orient", "intervene"]
+    }
+  }
+}

--- a/.claude/schemas/signal.schema.json
+++ b/.claude/schemas/signal.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://constructs.network/schemas/signal.schema.json",
+  "title": "Signal",
+  "description": "Raw observation stream row. Doctrine §3.1. Append-only JSONL. Producers: observer, beehive, dig-search, feedback-widget. Consumers: archivists, analyzers, scoring constructs.",
+  "type": "object",
+  "schema_version": "1.0.0",
+  "additionalProperties": true,
+  "required": ["stream_type", "schema_version", "timestamp", "source", "observation"],
+  "properties": {
+    "stream_type": {
+      "const": "Signal"
+    },
+    "schema_version": {
+      "type": "string",
+      "description": "Semver of the row shape. Rows with forward-compatible minor bumps MUST continue to validate; breaking shape changes require a major bump.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp (e.g. 2026-04-22T12:34:56Z)."
+    },
+    "source": {
+      "type": "string",
+      "description": "Producer identity — usually construct slug or pack-scoped skill handle (e.g. observer/observing-users)."
+    },
+    "observation": {
+      "type": "string",
+      "description": "Free-form observation text. Glance/orient consumers read this directly."
+    },
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional tag set for filtering."
+    },
+    "session_id": {
+      "type": "string",
+      "description": "Optional paired trajectory session_id if this Signal originated inside a construct invocation."
+    },
+    "run_id": {
+      "type": "string",
+      "description": "Optional composition run_id if this Signal was emitted inside a composition chain."
+    },
+    "read_mode": {
+      "type": "string",
+      "enum": ["glance", "orient", "intervene"],
+      "description": "Tiered output level per doctrine §14.3. Consumers at glance-latency read only rows tagged glance; intervene-level rows carry full detail."
+    }
+  }
+}

--- a/.claude/schemas/verdict.schema.json
+++ b/.claude/schemas/verdict.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://constructs.network/schemas/verdict.schema.json",
+  "title": "Verdict",
+  "description": "Evaluated judgment stream row. Doctrine §3.2. Per-invocation (one invocation → one verdict row). Composes with feedback-v3.schema.json — a Verdict row at this level is equivalent to a feedback-v3 entry with an explicit stream_type.",
+  "type": "object",
+  "schema_version": "1.0.0",
+  "additionalProperties": true,
+  "required": ["stream_type", "schema_version", "timestamp", "source", "verdict"],
+  "properties": {
+    "stream_type": {
+      "const": "Verdict"
+    },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "type": "string",
+      "description": "Emitting persona or construct slug (e.g. ALEXANDER, observer)."
+    },
+    "verdict": {
+      "type": "string",
+      "description": "Core evaluated judgment — actionable, operator-legible."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["info", "low", "medium", "high", "critical"],
+      "description": "Operator-facing severity tag. Consumers may filter by severity tier."
+    },
+    "evidence": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Supporting signals or file:line references. Should cite observable reality, not speculation."
+    },
+    "subject": {
+      "type": "string",
+      "description": "Optional target of the verdict — file path, component name, entity id."
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "read_mode": {
+      "type": "string",
+      "enum": ["glance", "orient", "intervene"]
+    },
+    "glance": {
+      "type": "string",
+      "description": "Single-line variant of this verdict (≤ 120 chars). Satisfies glance-latency consumers."
+    },
+    "orient": {
+      "type": "string",
+      "description": "3-5 line variant of this verdict. Satisfies orient-latency consumers."
+    }
+  }
+}

--- a/.claude/scripts/butterfreezone-construct-gen.sh
+++ b/.claude/scripts/butterfreezone-construct-gen.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# =============================================================================
+# butterfreezone-construct-gen.sh — per-pack CONSTRUCT-README.md generator (cycle-005 L6)
+# =============================================================================
+# Reads a construct pack directory (construct.yaml + skills/ + commands/ +
+# identity/ + CLAUDE.md) and emits CONSTRUCT-README.md summarising:
+#
+#   - description + short_description
+#   - persona handles (with identity file paths)
+#   - skill inventory (slug → SKILL.md title + description)
+#   - command inventory (name → description)
+#   - composability (composes_with + symmetric compositions)
+#   - streams reads/writes (doctrine §3 pipe compatibility)
+#   - grimoires read/write paths (SEED §12 — "grimoire path IS the interface")
+#   - install instructions
+#   - author + provenance
+#
+# Idempotent: output byte-identical across re-runs modulo a single timestamp
+# line in the footer (stripped by default; pass --timestamp to include).
+#
+# Usage:
+#   butterfreezone-construct-gen.sh <pack-path> [-o OUTPUT_FILE] [--stdout]
+#                                    [--dry-run] [--timestamp]
+#
+# Exit codes:
+#   0 = success
+#   1 = pack path missing / construct.yaml missing
+#   2 = required tooling missing (yq, jq)
+# =============================================================================
+set -euo pipefail
+
+export LC_ALL=C
+export TZ=UTC
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PACK_PATH=""
+OUTPUT=""
+TO_STDOUT=0
+DRY_RUN=0
+WITH_TIMESTAMP=0
+
+usage() { sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)    usage; exit 0 ;;
+    -o|--output)  OUTPUT="$2"; shift 2 ;;
+    --stdout)     TO_STDOUT=1; shift ;;
+    --dry-run)    DRY_RUN=1; shift ;;
+    --timestamp)  WITH_TIMESTAMP=1; shift ;;
+    -*)           echo "[bfz-construct-gen] ERROR: unknown flag $1" >&2; exit 2 ;;
+    *) if [[ -z "$PACK_PATH" ]]; then PACK_PATH="$1"; else echo "[bfz-construct-gen] ERROR: unexpected arg: $1" >&2; exit 2; fi; shift ;;
+  esac
+done
+
+[[ -n "$PACK_PATH" ]] || { usage >&2; exit 1; }
+PACK_PATH=$(cd "$PACK_PATH" 2>/dev/null && pwd) || { echo "[bfz-construct-gen] ERROR: pack path missing: $PACK_PATH" >&2; exit 1; }
+YAML="$PACK_PATH/construct.yaml"
+[[ -f "$YAML" ]] || { echo "[bfz-construct-gen] ERROR: construct.yaml not found at $YAML" >&2; exit 1; }
+
+command -v yq >/dev/null 2>&1 || { echo "[bfz-construct-gen] ERROR: yq v4+ required" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "[bfz-construct-gen] ERROR: jq required" >&2; exit 2; }
+
+PACK_JSON=$(yq -o=json '.' "$YAML")
+
+get() { echo "$PACK_JSON" | jq -r "$1 // empty"; }
+
+SLUG=$(get '.slug')
+NAME=$(get '.name')
+VERSION=$(get '.version')
+DESCRIPTION=$(get '.description')
+SHORT_DESCRIPTION=$(get '.short_description')
+AUTHOR=$(get '.author')
+LICENSE=$(get '.license')
+SCHEMA_VERSION=$(get '.schema_version')
+
+# --------------------------------------------------------------------------
+# Personas — merge construct.yaml `personas:` list + identity/<HANDLE>.md
+# --------------------------------------------------------------------------
+mapfile -t yaml_personas < <(echo "$PACK_JSON" | jq -r '(.personas // [])[] | select(. != "")')
+declare -a identity_files=()
+if [[ -d "$PACK_PATH/identity" ]]; then
+  while IFS= read -r f; do
+    base=$(basename "$f" .md)
+    # Persona handles are uppercase_letters / digits / underscores (e.g. ALEXANDER, OSTROM, KEEPER, BARTH).
+    [[ "$base" =~ ^[A-Z][A-Z0-9_]+$ ]] || continue
+    identity_files+=("$f")
+  done < <(find "$PACK_PATH/identity" -maxdepth 1 -name '*.md' -print | LC_ALL=C sort)
+fi
+
+# --------------------------------------------------------------------------
+# Skills — pull description from SKILL.md frontmatter `description:` or first H1
+# --------------------------------------------------------------------------
+frontmatter_desc() {
+  local md="$1"
+  [[ -f "$md" ]] || { echo ""; return; }
+  # Inline form: "description: foo bar"
+  local desc
+  desc=$(awk '/^---/{f=!f; next} f && /^description:/{sub(/^description:[[:space:]]*/,""); print; exit}' "$md")
+  # Block scalar indicators (| or >) with no value after — pull first non-empty continuation line.
+  if [[ "$desc" == "|" || "$desc" == ">" || "$desc" == "|-" || "$desc" == ">-" || "$desc" == "|+" || "$desc" == ">+" ]]; then
+    desc=$(awk '
+      /^---/{f=!f; next}
+      f && /^description:[[:space:]]*[|>]/{ in_block=1; next }
+      in_block && /^[A-Za-z_][A-Za-z0-9_]*:/{ exit }
+      in_block && NF{ sub(/^[[:space:]]+/,""); print; exit }
+    ' "$md")
+  fi
+  # Fall back to first markdown H1.
+  if [[ -z "$desc" ]]; then
+    desc=$(awk '!/^---/ && /^#[[:space:]]/{sub(/^#+[[:space:]]*/,""); print; exit}' "$md")
+  fi
+  echo "$desc"
+}
+
+skill_line() {
+  local skill_dir="$1" slug="$2"
+  local desc
+  desc=$(frontmatter_desc "$skill_dir/SKILL.md")
+  [[ -z "$desc" ]] && desc="(no description)"
+  printf -- "- \`%s\` — %s\n" "$slug" "$desc"
+}
+
+skills_block=""
+while IFS= read -r slug; do
+  [[ -z "$slug" ]] && continue
+  path=$(echo "$PACK_JSON" | jq -r --arg s "$slug" '(.skills // [])[] | select(.slug == $s) | .path // empty' | head -1)
+  [[ -z "$path" ]] && path="skills/$slug"
+  line=$(skill_line "$PACK_PATH/$path" "$slug")
+  skills_block+="$line"$'\n'
+done < <(echo "$PACK_JSON" | jq -r '(.skills // [])[] | .slug // empty' | LC_ALL=C sort)
+
+# --------------------------------------------------------------------------
+# Commands — name → description (from command markdown frontmatter / H1)
+# --------------------------------------------------------------------------
+command_line() {
+  local name="$1" path="$2"
+  local desc
+  desc=$(frontmatter_desc "$PACK_PATH/$path")
+  [[ -z "$desc" ]] && desc="(no description)"
+  printf -- "- \`/%s\` — %s\n" "$name" "$desc"
+}
+
+commands_block=""
+while IFS= read -r row; do
+  [[ -z "$row" ]] && continue
+  name=$(echo "$row" | jq -r '.name // empty')
+  path=$(echo "$row" | jq -r '.path // empty')
+  [[ -z "$name" ]] && continue
+  line=$(command_line "$name" "$path")
+  commands_block+="$line"$'\n'
+done < <(echo "$PACK_JSON" | jq -c '(.commands // [])[]' | LC_ALL=C sort)
+
+# --------------------------------------------------------------------------
+# Composes with
+# --------------------------------------------------------------------------
+composes_block=""
+while IFS= read -r x; do
+  [[ -z "$x" ]] && continue
+  composes_block+="- $x"$'\n'
+done < <(echo "$PACK_JSON" | jq -r '(.composes_with // [])[]' | LC_ALL=C sort -u)
+[[ -z "$composes_block" ]] && composes_block="_None declared._"$'\n'
+
+# --------------------------------------------------------------------------
+# Streams — reads/writes
+# --------------------------------------------------------------------------
+reads_list=$(echo "$PACK_JSON" | jq -r '(.reads // .streams.reads // [])[] // empty' | LC_ALL=C sort -u)
+writes_list=$(echo "$PACK_JSON" | jq -r '(.writes // .streams.writes // [])[] // empty' | LC_ALL=C sort -u)
+
+fmt_list() {
+  local l="$1"
+  if [[ -z "$l" ]]; then
+    echo "_not declared_"
+    return
+  fi
+  while IFS= read -r t; do
+    [[ -z "$t" ]] && continue
+    echo "- $t"
+  done <<< "$l"
+}
+
+# --------------------------------------------------------------------------
+# Grimoires read/write paths (construct.yaml declarations)
+# SEED §12 — "grimoire path IS the interface"
+# --------------------------------------------------------------------------
+grimoires_reads=$(echo "$PACK_JSON"  | jq -r '((.composition_paths.reads // .grimoires.reads // []))[] // empty'  | LC_ALL=C sort -u)
+grimoires_writes=$(echo "$PACK_JSON" | jq -r '((.composition_paths.writes // .grimoires.writes // []))[] // empty' | LC_ALL=C sort -u)
+
+# Fallback scan: if neither list is declared, grep construct.yaml for grimoires/ paths
+if [[ -z "$grimoires_reads$grimoires_writes" ]]; then
+  mapfile -t fallback_paths < <(grep -oE 'grimoires/[A-Za-z0-9._-]+[/A-Za-z0-9._-]*' "$YAML" 2>/dev/null | LC_ALL=C sort -u)
+  if (( ${#fallback_paths[@]} > 0 )); then
+    grimoires_writes=$(printf '%s\n' "${fallback_paths[@]}")
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# Drift detection — CLAUDE.md missing explicit grimoires section
+# --------------------------------------------------------------------------
+drift_notice=""
+if [[ -f "$PACK_PATH/CLAUDE.md" ]]; then
+  if ! grep -qiE 'grimoires?/' "$PACK_PATH/CLAUDE.md"; then
+    drift_notice="> ⚠ SEED §12 drift — pack \`CLAUDE.md\` does not reference \`grimoires/\`. The canonical declaration lives in \`construct.yaml\`; regenerate CLAUDE.md or add the section manually."$'\n\n'
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# Compose document
+# --------------------------------------------------------------------------
+HEADER_TITLE="${NAME:-$SLUG}"
+SHORT="${SHORT_DESCRIPTION:-$DESCRIPTION}"
+
+doc=""
+doc+="<!-- Generated by .claude/scripts/butterfreezone-construct-gen.sh -->"$'\n'
+doc+="<!-- Canonical source: construct.yaml · do not edit by hand -->"$'\n\n'
+doc+="# $HEADER_TITLE"$'\n\n'
+if [[ -n "$SHORT" ]]; then
+  doc+="> $SHORT"$'\n\n'
+fi
+
+if [[ -n "$drift_notice" ]]; then
+  doc+="$drift_notice"
+fi
+
+doc+="## About"$'\n\n'
+doc+="| field | value |"$'\n'
+doc+="|---|---|"$'\n'
+doc+="| slug | \`$SLUG\` |"$'\n'
+doc+="| version | \`${VERSION:-?}\` |"$'\n'
+doc+="| schema_version | \`${SCHEMA_VERSION:-?}\` |"$'\n'
+doc+="| author | ${AUTHOR:-?} |"$'\n'
+doc+="| license | ${LICENSE:-?} |"$'\n\n'
+
+if [[ -n "$DESCRIPTION" && "$DESCRIPTION" != "$SHORT" ]]; then
+  doc+="$DESCRIPTION"$'\n\n'
+fi
+
+# Personas
+if (( ${#yaml_personas[@]} > 0 )) || (( ${#identity_files[@]} > 0 )); then
+  doc+="## Personas"$'\n\n'
+  declare -a seen=()
+  for p in "${yaml_personas[@]}" "${identity_files[@]}"; do
+    if [[ "$p" == *.md ]]; then
+      handle=$(basename "$p" .md)
+      rel=${p#$PACK_PATH/}
+      line="- \`@$handle\` → [\`$rel\`]($rel)"
+    else
+      handle="$p"
+      if [[ -f "$PACK_PATH/identity/$handle.md" ]]; then
+        rel="identity/$handle.md"
+        line="- \`@$handle\` → [\`$rel\`]($rel)"
+      else
+        line="- \`@$handle\`"
+      fi
+    fi
+    case " ${seen[*]} " in *" $handle "*) continue ;; esac
+    seen+=("$handle")
+    doc+="$line"$'\n'
+  done
+  doc+=$'\n'
+fi
+
+# Skills
+if [[ -n "$skills_block" ]]; then
+  doc+="## Skills"$'\n\n'
+  doc+="$skills_block"
+  doc+=$'\n'
+fi
+
+# Commands
+if [[ -n "$commands_block" ]]; then
+  doc+="## Commands"$'\n\n'
+  doc+="$commands_block"
+  doc+=$'\n'
+fi
+
+# Composes with
+doc+="## Composes with"$'\n\n'
+doc+="$composes_block"
+doc+=$'\n'
+
+# Streams
+doc+="## Streams"$'\n\n'
+doc+="**Reads**:"$'\n\n'
+doc+=$(fmt_list "$reads_list")
+doc+=$'\n\n'
+doc+="**Writes**:"$'\n\n'
+doc+=$(fmt_list "$writes_list")
+doc+=$'\n\n'
+if [[ -z "$reads_list$writes_list" ]]; then
+  doc+="> Declare \`reads:\` and \`writes:\` in \`construct.yaml\` to enable doctrine §3 pipe compatibility checks."$'\n\n'
+fi
+
+# Grimoires
+doc+="## Grimoires read/write (SEED §12)"$'\n\n'
+if [[ -z "$grimoires_reads$grimoires_writes" ]]; then
+  doc+="_No grimoires paths declared. Without a declaration this construct cannot participate in path-based composition — see SEED §12 for the convention._"$'\n\n'
+else
+  if [[ -n "$grimoires_reads" ]]; then
+    doc+="**Reads from**:"$'\n\n'
+    while IFS= read -r p; do [[ -z "$p" ]] && continue; doc+="- \`$p\`"$'\n'; done <<< "$grimoires_reads"
+    doc+=$'\n'
+  fi
+  if [[ -n "$grimoires_writes" ]]; then
+    doc+="**Writes to**:"$'\n\n'
+    while IFS= read -r p; do [[ -z "$p" ]] && continue; doc+="- \`$p\`"$'\n'; done <<< "$grimoires_writes"
+    doc+=$'\n'
+  fi
+  doc+="> The grimoire path IS the interface — constructs writing to the same path compose automatically."$'\n\n'
+fi
+
+# Install
+doc+="## Install"$'\n\n'
+doc+='```bash'$'\n'
+doc+="/constructs install $SLUG"$'\n'
+doc+='```'$'\n\n'
+
+doc+="## Provenance"$'\n\n'
+doc+="- Canonical spec: \`construct.yaml\`"$'\n'
+doc+="- Generator: \`.claude/scripts/butterfreezone-construct-gen.sh\`"$'\n'
+doc+="- Doctrine: \`bonfire-construct-pipe-doctrine.md\` §3 typed streams · §4 composition · §14.2 Operator-Model"$'\n'
+if (( WITH_TIMESTAMP )); then
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  doc+="- Generated at: $ts"$'\n'
+fi
+
+# --------------------------------------------------------------------------
+# Emit
+# --------------------------------------------------------------------------
+if (( TO_STDOUT )); then
+  printf '%s' "$doc"
+  exit 0
+fi
+
+OUTPUT="${OUTPUT:-$PACK_PATH/CONSTRUCT-README.md}"
+if (( DRY_RUN )); then
+  echo "[bfz-construct-gen] would write → $OUTPUT (${#doc} bytes)"
+  printf '%s' "$doc" | head -10
+  echo "..."
+  exit 0
+fi
+
+printf '%s' "$doc" > "$OUTPUT"
+echo "[bfz-construct-gen] wrote $OUTPUT"

--- a/.claude/scripts/construct-compose.sh
+++ b/.claude/scripts/construct-compose.sh
@@ -1,0 +1,470 @@
+#!/usr/bin/env bash
+# =============================================================================
+# construct-compose.sh — composition runner (cycle-005 L1)
+# =============================================================================
+# Reads a composition YAML from grimoires/compositions/<name>.yaml and
+# executes its pipe chain: validates type compatibility at chain-build time,
+# sequences stages via construct-invoke.sh entry/exit, pipes stdin/stdout
+# between stages, emits a final summary at the requested read-mode.
+#
+# Doctrine:
+#   §3  — typed streams (Signal/Verdict/Artifact/Intent/Operator-Model)
+#   §4  — composition = pipe chain spec
+#   §5  — runner is the shell-equivalent layer (layer 4 in §5.1)
+#   §13.1 — shell-first, no TypeScript
+#   §14.3 — three read-modes (glance / orient / intervene)
+#   §16.4 — agent-transparency invariant: active set + trajectory on every stage
+#
+# Usage:
+#   construct-compose.sh <composition-name> [options]
+#   construct-compose.sh feel-audit --target src/app/ui/Button.tsx
+#
+# Options:
+#   --target PATH           Input artifact path (binds composition.inputs[type=Artifact])
+#   --input JSON            Raw JSON value for the first-stage stdin (overrides --target)
+#   --dry-run               Validate + print plan; no trajectory emitted, no stages run
+#   --run-id ID             Override generated run_id (useful in tests)
+#   --executor PATH         Override stage executor (env LOA_COMPOSE_STAGE_EXECUTOR)
+#   --compositions-dir DIR  Override compositions search dir (default: grimoires/compositions)
+#   --glance                Summary: 1 line (default)
+#   --orient                Summary: 3-6 lines, per-stage durations
+#   --intervene             Summary: full JSON blob on stderr
+#   -h, --help              Print this help
+#
+# Exit codes:
+#   0 = success
+#   1 = composition missing or malformed
+#   2 = type-compatibility failure (reported with stage + expected vs produced)
+#   3 = stage execution failure
+#   4 = final-output schema validation failure
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+DEFAULT_COMPOSITIONS_DIR="${LOA_COMPOSITIONS_DIR:-$PROJECT_ROOT/grimoires/compositions}"
+TRAJECTORY_FILE="${LOA_TRAJECTORY_FILE:-$PROJECT_ROOT/.run/construct-trajectory.jsonl}"
+FEEDBACK_FILE="${LOA_FEEDBACK_FILE:-$PROJECT_ROOT/.run/feedback-v3.jsonl}"
+SCHEMA_VERSION="1.0.0"
+
+# --------------------------------------------------------------------------
+# Args
+# --------------------------------------------------------------------------
+COMPOSITION_NAME=""
+TARGET_PATH=""
+RAW_INPUT=""
+DRY_RUN=0
+RUN_ID=""
+STAGE_EXECUTOR="${LOA_COMPOSE_STAGE_EXECUTOR:-}"
+COMPOSITIONS_DIR="$DEFAULT_COMPOSITIONS_DIR"
+READ_MODE="glance"
+
+usage() {
+  sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+die() {
+  local code="${1:-1}"
+  shift || true
+  echo "[construct-compose] ERROR: $*" >&2
+  exit "$code"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)           usage; exit 0 ;;
+    --target)            TARGET_PATH="$2"; shift 2 ;;
+    --input)             RAW_INPUT="$2"; shift 2 ;;
+    --dry-run)           DRY_RUN=1; shift ;;
+    --run-id)            RUN_ID="$2"; shift 2 ;;
+    --executor)          STAGE_EXECUTOR="$2"; shift 2 ;;
+    --compositions-dir)  COMPOSITIONS_DIR="$2"; shift 2 ;;
+    --glance)            READ_MODE="glance"; shift ;;
+    --orient)            READ_MODE="orient"; shift ;;
+    --intervene)         READ_MODE="intervene"; shift ;;
+    --) shift; break ;;
+    -*) die 1 "unknown flag: $1" ;;
+    *)  if [[ -z "$COMPOSITION_NAME" ]]; then COMPOSITION_NAME="$1"; else die 1 "unexpected positional: $1"; fi; shift ;;
+  esac
+done
+
+[[ -n "$COMPOSITION_NAME" ]] || { usage >&2; die 1 "composition name required"; }
+
+# --------------------------------------------------------------------------
+# Tool dependencies
+# --------------------------------------------------------------------------
+command -v yq >/dev/null 2>&1 || die 1 "yq (v4+) required — install via 'brew install yq' or equivalent"
+command -v jq >/dev/null 2>&1 || die 1 "jq required"
+
+# --------------------------------------------------------------------------
+# Composition load
+# --------------------------------------------------------------------------
+COMPOSITION_FILE="$COMPOSITIONS_DIR/$COMPOSITION_NAME.yaml"
+[[ -f "$COMPOSITION_FILE" ]] || die 1 "composition not found: $COMPOSITION_FILE"
+
+COMPOSITION_JSON=$(yq -o=json '.' "$COMPOSITION_FILE" 2>/dev/null) \
+  || die 1 "failed to parse YAML: $COMPOSITION_FILE"
+
+STAGE_COUNT=$(echo "$COMPOSITION_JSON" | jq -r '.chain | length')
+(( STAGE_COUNT > 0 )) || die 1 "composition '$COMPOSITION_NAME' has empty chain"
+
+# --------------------------------------------------------------------------
+# run_id
+# --------------------------------------------------------------------------
+if [[ -z "$RUN_ID" ]]; then
+  RUN_ID=$(uuidgen 2>/dev/null \
+           || python3 -c "import uuid; print(uuid.uuid4())" 2>/dev/null \
+           || echo "compose-$(date +%s)-$$")
+fi
+
+# --------------------------------------------------------------------------
+# Persona resolution — first persona of the stage's construct
+# --------------------------------------------------------------------------
+resolve_persona() {
+  local slug="$1"
+  local resolver="$SCRIPT_DIR/construct-resolve.sh"
+  local persona=""
+  if [[ -x "$resolver" ]]; then
+    persona=$("$resolver" resolve "$slug" --json 2>/dev/null \
+              | jq -r '.construct.personas[0] // empty' 2>/dev/null || echo "")
+  fi
+  if [[ -z "$persona" ]]; then
+    # Fallback: uppercase slug prefix
+    persona=$(echo "$slug" | tr '[:lower:]' '[:upper:]')
+  fi
+  echo "$persona"
+}
+
+# --------------------------------------------------------------------------
+# Type-compatibility check (chain-build-time)
+# --------------------------------------------------------------------------
+# Per doctrine §4: every pipe edge's types must align. A stage's `reads` must
+# be satisfiable by the union of composition inputs + all prior stages' writes.
+# --------------------------------------------------------------------------
+produced_types=()
+inputs_types=$(echo "$COMPOSITION_JSON" | jq -r '.inputs[]?.type // empty')
+while IFS= read -r t; do
+  [[ -z "$t" ]] && continue
+  produced_types+=("$t")
+done <<< "$inputs_types"
+
+set_contains() {
+  local needle="$1"; shift
+  for x in "$@"; do
+    [[ "$x" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+# Pre-flight: verify every stage's reads ⊆ produced-so-far
+for (( i=0; i<STAGE_COUNT; i++ )); do
+  stage_json=$(echo "$COMPOSITION_JSON" | jq -c ".chain[$i]")
+  stage_label=$(echo "$stage_json" | jq -r '.stage // (. | tostring)')
+  reads=$(echo "$stage_json" | jq -r '(.reads // [])[]')
+  while IFS= read -r r; do
+    [[ -z "$r" ]] && continue
+    if ! set_contains "$r" "${produced_types[@]}"; then
+      produced_csv=$(IFS=, ; echo "${produced_types[*]}")
+      die 2 "type mismatch at stage $stage_label: reads '$r' but upstream has produced only [$produced_csv]"
+    fi
+  done <<< "$reads"
+  writes=$(echo "$stage_json" | jq -r '(.writes // [])[]')
+  while IFS= read -r w; do
+    [[ -z "$w" ]] && continue
+    set_contains "$w" "${produced_types[@]}" || produced_types+=("$w")
+  done <<< "$writes"
+done
+
+# --------------------------------------------------------------------------
+# Plan output
+# --------------------------------------------------------------------------
+print_plan() {
+  echo "[construct-compose] composition=$COMPOSITION_NAME run_id=$RUN_ID stages=$STAGE_COUNT" >&2
+  for (( i=0; i<STAGE_COUNT; i++ )); do
+    local s construct skill reads writes stage_label
+    s=$(echo "$COMPOSITION_JSON" | jq -c ".chain[$i]")
+    stage_label=$(echo "$s" | jq -r '.stage // empty')
+    construct=$(echo "$s" | jq -r '.construct')
+    skill=$(echo "$s" | jq -r '.skill // "<none>"')
+    reads=$(echo "$s" | jq -r '(.reads // []) | join(",")')
+    writes=$(echo "$s" | jq -r '(.writes // []) | join(",")')
+    printf "[construct-compose] stage %s: %s::%s reads=[%s] writes=[%s]\n" \
+      "${stage_label:-$((i+1))}" "$construct" "$skill" "$reads" "$writes" >&2
+  done
+}
+
+if (( DRY_RUN )); then
+  print_plan
+  echo "[construct-compose] dry-run OK — type compatibility verified, no stages executed" >&2
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# Initial stdin payload for stage 1
+# --------------------------------------------------------------------------
+emit_initial_payload() {
+  if [[ -n "$RAW_INPUT" ]]; then
+    printf '%s' "$RAW_INPUT"
+    return
+  fi
+  # Build a seed payload that carries composition inputs to stage 1 via stdin.
+  # Stage 1's reads determine which typed fields we populate.
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local target_path="$TARGET_PATH"
+  [[ -z "$target_path" ]] && target_path="<unspecified>"
+  jq -n \
+    --arg run_id "$RUN_ID" \
+    --arg composition "$COMPOSITION_NAME" \
+    --arg ts "$ts" \
+    --arg target "$target_path" \
+    --arg schema_version "$SCHEMA_VERSION" \
+    '{
+      _compose_meta: {
+        run_id: $run_id,
+        composition: $composition,
+        timestamp: $ts,
+        schema_version: $schema_version
+      },
+      inputs: {
+        target: $target
+      }
+    }'
+}
+
+# --------------------------------------------------------------------------
+# Default stage executor (stub)
+#
+# Produces a schema-valid placeholder row for the primary type in `writes`.
+# Designed to be swapped via --executor / $LOA_COMPOSE_STAGE_EXECUTOR when
+# real LLM-driven skill dispatch ships (cycle-006+ orchestrator).
+#
+# Stdin: previous stage output (JSON, may be empty on stage 1 if no inputs)
+# Args: construct_slug skill persona stage_label writes_csv run_id session_id
+# Stdout: JSON row conforming to the PRIMARY write type's schema
+# --------------------------------------------------------------------------
+default_stage_executor() {
+  local construct="$1" skill="$2" persona="$3" stage_label="$4" writes_csv="$5" run_id="$6" session_id="$7"
+  local primary_type
+  primary_type=$(echo "$writes_csv" | awk -F',' '{print $1}')
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Carry forward prior stage output for transparency.
+  local prior=""
+  if [[ ! -t 0 ]]; then
+    prior=$(cat -)
+  fi
+
+  case "$primary_type" in
+    Signal)
+      jq -n \
+        --arg ts "$ts" --arg source "$construct/$skill" --arg persona "$persona" \
+        --arg observation "[stub] stage $stage_label · $construct/$skill executed over upstream payload" \
+        --arg schema_version "$SCHEMA_VERSION" --arg run_id "$run_id" --arg session_id "$session_id" \
+        --argjson prior "${prior:-null}" \
+        '{
+          stream_type: "Signal",
+          schema_version: $schema_version,
+          timestamp: $ts,
+          source: $source,
+          observation: $observation,
+          tags: ["stub", "composition", $persona],
+          session_id: $session_id,
+          run_id: $run_id,
+          _prior: $prior
+        }'
+      ;;
+    Verdict)
+      jq -n \
+        --arg ts "$ts" --arg source "$persona" --arg schema_version "$SCHEMA_VERSION" \
+        --arg run_id "$run_id" --arg session_id "$session_id" \
+        --arg verdict "[stub] stage $stage_label · $construct/$skill judgment placeholder — swap executor for real skill dispatch" \
+        --arg glance "[stub $persona] stage $stage_label verdict" \
+        --argjson prior "${prior:-null}" \
+        '{
+          stream_type: "Verdict",
+          schema_version: $schema_version,
+          timestamp: $ts,
+          source: $source,
+          verdict: $verdict,
+          severity: "info",
+          evidence: [],
+          glance: $glance,
+          session_id: $session_id,
+          run_id: $run_id,
+          _prior: $prior
+        }'
+      ;;
+    Artifact)
+      jq -n \
+        --arg ts "$ts" --arg producer "$construct/$skill" --arg schema_version "$SCHEMA_VERSION" \
+        --arg run_id "$run_id" --arg session_id "$session_id" \
+        --arg path "${TARGET_PATH:-/tmp/stub-artifact}" \
+        '{
+          stream_type: "Artifact",
+          schema_version: $schema_version,
+          timestamp: $ts,
+          path: $path,
+          producer: $producer,
+          media_type: "application/x-stub",
+          session_id: $session_id,
+          run_id: $run_id
+        }'
+      ;;
+    Intent)
+      jq -n \
+        --arg ts "$ts" --arg schema_version "$SCHEMA_VERSION" --arg run_id "$run_id" \
+        --arg intent "[stub] stage $stage_label · $construct/$skill intent placeholder" \
+        '{
+          stream_type: "Intent",
+          schema_version: $schema_version,
+          timestamp: $ts,
+          intent: $intent,
+          run_id: $run_id
+        }'
+      ;;
+    Operator-Model)
+      jq -n \
+        --arg ts "$ts" --arg schema_version "$SCHEMA_VERSION" --arg run_id "$run_id" \
+        '{
+          stream_type: "Operator-Model",
+          schema_version: $schema_version,
+          timestamp: $ts,
+          expertise: [],
+          run_id: $run_id
+        }'
+      ;;
+    *)
+      die 3 "stage $stage_label declares unknown primary write type '$primary_type'"
+      ;;
+  esac
+}
+
+# --------------------------------------------------------------------------
+# Execute chain
+# --------------------------------------------------------------------------
+now_ms() {
+  python3 -c "import time; print(int(time.time()*1000))" 2>/dev/null \
+    || echo "$(($(date +%s) * 1000))"
+}
+
+start_ms=$(now_ms)
+print_plan
+
+declare -a STAGE_DURATIONS=()
+declare -a STAGE_OUTCOMES=()
+declare -a STAGE_LABELS=()
+declare -a STAGE_SESSIONS=()
+
+current_payload=$(emit_initial_payload)
+
+for (( i=0; i<STAGE_COUNT; i++ )); do
+  stage_json=$(echo "$COMPOSITION_JSON" | jq -c ".chain[$i]")
+  stage_label=$(echo "$stage_json" | jq -r '.stage // empty')
+  [[ -z "$stage_label" ]] && stage_label="$((i+1))"
+  construct=$(echo "$stage_json" | jq -r '.construct')
+  skill=$(echo "$stage_json" | jq -r '.skill // "<none>"')
+  writes_csv=$(echo "$stage_json" | jq -r '(.writes // []) | join(",")')
+  persona=$(resolve_persona "$construct")
+
+  # Entry row — construct-invoke prints session_id on stdout, trajectory on disk.
+  session_id=$("$SCRIPT_DIR/construct-invoke.sh" entry "$persona" "$construct" "/compose:$COMPOSITION_NAME#$stage_label" 2>/dev/null || echo "")
+  [[ -z "$session_id" ]] && session_id="compose-${RUN_ID}-stage-${stage_label}"
+
+  t0_ms=$(now_ms)
+
+  # Execute stage — default stub or operator-supplied executor.
+  stage_output=""
+  exec_rc=0
+  if [[ -n "$STAGE_EXECUTOR" && -x "$STAGE_EXECUTOR" ]]; then
+    stage_output=$(printf '%s' "$current_payload" | "$STAGE_EXECUTOR" \
+      "$construct" "$skill" "$persona" "$stage_label" "$writes_csv" "$RUN_ID" "$session_id") || exec_rc=$?
+  else
+    stage_output=$(printf '%s' "$current_payload" | default_stage_executor \
+      "$construct" "$skill" "$persona" "$stage_label" "$writes_csv" "$RUN_ID" "$session_id") || exec_rc=$?
+  fi
+
+  t1_ms=$(now_ms)
+  dur_ms=$(( t1_ms - t0_ms ))
+  (( dur_ms >= 0 )) || dur_ms=0
+
+  outcome="completed"
+  if (( exec_rc != 0 )); then
+    outcome="failed"
+    "$SCRIPT_DIR/construct-invoke.sh" exit "$persona" "$construct" "$dur_ms" "$outcome" "/compose:$COMPOSITION_NAME#$stage_label" >/dev/null 2>&1 || true
+    die 3 "stage $stage_label ($construct/$skill) executor exited $exec_rc"
+  fi
+
+  # Exit row
+  "$SCRIPT_DIR/construct-invoke.sh" exit "$persona" "$construct" "$dur_ms" "$outcome" "/compose:$COMPOSITION_NAME#$stage_label" >/dev/null 2>&1 || true
+
+  STAGE_DURATIONS+=("$dur_ms")
+  STAGE_OUTCOMES+=("$outcome")
+  STAGE_LABELS+=("$stage_label:$construct/$skill")
+  STAGE_SESSIONS+=("$session_id")
+
+  current_payload="$stage_output"
+done
+
+end_ms=$(now_ms)
+total_ms=$(( end_ms - start_ms ))
+(( total_ms >= 0 )) || total_ms=0
+
+# --------------------------------------------------------------------------
+# Final output validation — if last stage writes a known stream type,
+# validate against its schema. Failure routes to exit 4.
+# --------------------------------------------------------------------------
+last_writes=$(echo "$COMPOSITION_JSON" | jq -r '(.chain[-1].writes // [])[0] // empty')
+if [[ -n "$last_writes" ]]; then
+  if ! "$SCRIPT_DIR/stream-validate.sh" "$last_writes" "$current_payload" 2>/dev/null; then
+    echo "[construct-compose] final output failed $last_writes schema validation:" >&2
+    "$SCRIPT_DIR/stream-validate.sh" "$last_writes" "$current_payload" || true
+    echo "[construct-compose] raw final output follows on stdout; exit 4" >&2
+    printf '%s\n' "$current_payload"
+    exit 4
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# Final payload to stdout (the chain's last output)
+# --------------------------------------------------------------------------
+printf '%s\n' "$current_payload"
+
+# --------------------------------------------------------------------------
+# Summary per read-mode (to stderr so stdout stays pipe-clean)
+# --------------------------------------------------------------------------
+case "$READ_MODE" in
+  glance)
+    local_stages=${#STAGE_DURATIONS[@]}
+    echo "✓ compose $COMPOSITION_NAME · stages=$local_stages · ${total_ms}ms · run=${RUN_ID:0:8}" >&2
+    ;;
+  orient)
+    echo "compose $COMPOSITION_NAME · run_id=$RUN_ID · total=${total_ms}ms" >&2
+    for (( i=0; i<${#STAGE_LABELS[@]}; i++ )); do
+      echo "  stage ${STAGE_LABELS[$i]} · ${STAGE_DURATIONS[$i]}ms · ${STAGE_OUTCOMES[$i]}" >&2
+    done
+    echo "  final writes: ${last_writes:-<untyped>}" >&2
+    ;;
+  intervene)
+    jq -n \
+      --arg composition "$COMPOSITION_NAME" \
+      --arg run_id "$RUN_ID" \
+      --argjson total_ms "$total_ms" \
+      --arg final_type "$last_writes" \
+      --argjson stages "$(printf '%s\n' "${STAGE_LABELS[@]}" | jq -R . | jq -s .)" \
+      --argjson durations "$(printf '%s\n' "${STAGE_DURATIONS[@]}" | jq -s .)" \
+      --argjson outcomes "$(printf '%s\n' "${STAGE_OUTCOMES[@]}" | jq -R . | jq -s .)" \
+      --argjson sessions "$(printf '%s\n' "${STAGE_SESSIONS[@]}" | jq -R . | jq -s .)" \
+      '{
+        composition: $composition,
+        run_id: $run_id,
+        total_ms: $total_ms,
+        final_type: $final_type,
+        stages: $stages,
+        durations_ms: $durations,
+        outcomes: $outcomes,
+        session_ids: $sessions
+      }' >&2
+    ;;
+esac

--- a/.claude/scripts/construct-validate.sh
+++ b/.claude/scripts/construct-validate.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# =============================================================================
+# construct-validate.sh — pre-install / pre-publish manifest validator (cycle-005 L4)
+# =============================================================================
+# Validates a construct pack directory against the cycle-005 checks surfaced
+# by F28 (missing commands declarations) and SEED §12 (grimoires read/write
+# convention on CLAUDE.md). Emits Verdict stream rows per doctrine §3 on
+# failure; each finding carries severity and evidence.
+#
+# Usage:
+#   construct-validate.sh <pack-path> [--json] [--strict]
+#
+# Checks:
+#   1. construct.yaml present + parseable
+#   2. required fields: schema_version, slug, name, version, description
+#   3. skills[].path resolves to a filesystem directory
+#   4. persona routes declared: identity/<HANDLE>.md file OR personas: list
+#   5. /-commands OR persona handles exist (F28 closure gate)
+#   6. streams declared: reads / writes not empty (warn only)
+#   7. CLAUDE.md contains an explicit grimoires read/write declaration (SEED §12)
+#
+# Severity tiers:
+#   critical — missing construct.yaml / unparseable
+#   high     — missing required field, broken skill path
+#   medium   — no routes (F28), missing grimoires section (§12)
+#   low      — empty stream declarations (advisory)
+#   info     — pack passes all hard checks
+#
+# Exit codes:
+#   0 = no high or critical findings
+#   1 = at least one high/critical (or medium if --strict)
+#   2 = pack path does not exist
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+SCHEMA_VERSION="1.0.0"
+
+OUTPUT_JSON=0
+STRICT=0
+PACK_PATH=""
+
+usage() { sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --json)    OUTPUT_JSON=1; shift ;;
+    --strict)  STRICT=1; shift ;;
+    -*) echo "[construct-validate] ERROR: unknown flag $1" >&2; exit 2 ;;
+    *) if [[ -z "$PACK_PATH" ]]; then PACK_PATH="$1"; else echo "[construct-validate] ERROR: unexpected positional: $1" >&2; exit 2; fi; shift ;;
+  esac
+done
+
+[[ -n "$PACK_PATH" ]] || { usage >&2; exit 2; }
+PACK_PATH="$(cd "$PACK_PATH" 2>/dev/null && pwd)" || { echo "[construct-validate] ERROR: pack path does not exist: $PACK_PATH" >&2; exit 2; }
+
+command -v yq >/dev/null 2>&1 || { echo "[construct-validate] ERROR: yq v4+ required" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "[construct-validate] ERROR: jq required" >&2; exit 2; }
+
+declare -a FINDINGS=()
+
+emit_finding() {
+  local severity="$1" check="$2" message="$3" evidence="${4:-}"
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local row
+  row=$(jq -n \
+    --arg sv "$severity" --arg ck "$check" --arg msg "$message" \
+    --arg ev "$evidence" --arg ts "$ts" \
+    --arg schema_version "$SCHEMA_VERSION" --arg pack "$PACK_PATH" \
+    '{
+      stream_type: "Verdict",
+      schema_version: $schema_version,
+      timestamp: $ts,
+      source: "construct-validate",
+      verdict: ("[" + $ck + "] " + $msg),
+      severity: $sv,
+      evidence: ([$ev] | map(select(. != ""))),
+      subject: $pack,
+      tags: [$ck]
+    }')
+  FINDINGS+=("$row")
+}
+
+PACK_YAML="$PACK_PATH/construct.yaml"
+if [[ ! -f "$PACK_YAML" ]]; then
+  emit_finding critical construct_yaml "construct.yaml not found in pack root" "$PACK_PATH"
+else
+  PACK_JSON=$(yq -o=json '.' "$PACK_YAML" 2>/dev/null) || PACK_JSON=""
+  if [[ -z "$PACK_JSON" ]]; then
+    emit_finding critical construct_yaml "construct.yaml failed to parse" "$PACK_YAML"
+  else
+    # Required fields
+    for field in schema_version slug name version description; do
+      val=$(echo "$PACK_JSON" | jq -r --arg f "$field" '.[$f] // empty')
+      [[ -z "$val" ]] && emit_finding high required_field "construct.yaml missing required field '$field'" "$PACK_YAML"
+    done
+
+    # skills[].path resolution
+    mapfile -t skills < <(echo "$PACK_JSON" | jq -r '(.skills // [])[] | .path // empty')
+    for s in "${skills[@]}"; do
+      [[ -z "$s" ]] && continue
+      if [[ ! -d "$PACK_PATH/$s" && ! -L "$PACK_PATH/$s" ]]; then
+        emit_finding high skill_path "skills[].path does not resolve: $s" "$PACK_YAML"
+      fi
+    done
+
+    # Commands consistency (if declared) — every commands[].path must exist
+    mapfile -t cmd_paths < <(echo "$PACK_JSON" | jq -r '(.commands // [])[] | .path // empty')
+    for c in "${cmd_paths[@]}"; do
+      [[ -z "$c" ]] && continue
+      if [[ ! -f "$PACK_PATH/$c" ]]; then
+        emit_finding high command_path "commands[].path does not resolve: $c" "$PACK_YAML"
+      fi
+    done
+
+    # F28 gate — pack must declare at least one route: commands OR persona handles
+    cmd_count=$(echo "$PACK_JSON" | jq '(.commands // []) | length')
+    persona_count=0
+    if [[ -d "$PACK_PATH/identity" ]]; then
+      persona_count=$(find "$PACK_PATH/identity" -maxdepth 1 -name '*.md' -print | while read -r f; do base=$(basename "$f" .md); [[ "$base" =~ ^[A-Z][A-Z0-9_]+$ ]] && echo 1; done | wc -l | tr -d ' ')
+    fi
+    listed_personas=$(echo "$PACK_JSON" | jq '(.personas // []) | length')
+    if (( cmd_count == 0 && persona_count == 0 && listed_personas == 0 )); then
+      emit_finding medium route_declared "F28: pack declares neither commands: nor personas — operator can only route by slug/name" "$PACK_YAML"
+    fi
+
+    # Stream declarations — warn if empty
+    reads_count=$(echo "$PACK_JSON" | jq '(.reads // .streams.reads // []) | length')
+    writes_count=$(echo "$PACK_JSON" | jq '(.writes // .streams.writes // []) | length')
+    if (( reads_count == 0 )); then
+      emit_finding low streams "construct declares no 'reads:' stream types — pipe composition will be ambiguous" "$PACK_YAML"
+    fi
+    if (( writes_count == 0 )); then
+      emit_finding low streams "construct declares no 'writes:' stream types — pipe composition will be ambiguous" "$PACK_YAML"
+    fi
+  fi
+fi
+
+# SEED §12 — CLAUDE.md must carry explicit grimoires read/write declaration
+CLAUDE_MD="$PACK_PATH/CLAUDE.md"
+if [[ -f "$CLAUDE_MD" ]]; then
+  if ! grep -qiE 'grimoires?/' "$CLAUDE_MD"; then
+    emit_finding medium grimoires_section \
+      "CLAUDE.md contains no grimoires/ path reference — SEED §12 convention: 'grimoire path IS the interface'" \
+      "$CLAUDE_MD"
+  else
+    # Must reference at least one of: 'Writes to', 'Reads from', 'writes:' or 'reads:'
+    if ! grep -qiE '(writes to|reads from|writes:|reads:)' "$CLAUDE_MD"; then
+      emit_finding medium grimoires_section \
+        "CLAUDE.md mentions grimoires/ but lacks explicit read/write declaration — SEED §12" \
+        "$CLAUDE_MD"
+    fi
+  fi
+else
+  emit_finding medium claude_md "pack is missing CLAUDE.md — operator-facing description not declared" "$PACK_PATH"
+fi
+
+# Exit-code calculation
+worst="info"
+for row in "${FINDINGS[@]}"; do
+  sev=$(echo "$row" | jq -r '.severity')
+  case "$sev" in
+    critical) worst="critical" ;;
+    high) [[ "$worst" != "critical" ]] && worst="high" ;;
+    medium) [[ "$worst" != "critical" && "$worst" != "high" ]] && worst="medium" ;;
+    low) [[ "$worst" == "info" ]] && worst="low" ;;
+  esac
+done
+
+# Output
+if (( OUTPUT_JSON == 1 )); then
+  # Emit JSON array of Verdict rows
+  if (( ${#FINDINGS[@]} == 0 )); then
+    echo "[]"
+  else
+    printf '%s\n' "${FINDINGS[@]}" | jq -s '.'
+  fi
+else
+  echo "# construct-validate · $PACK_PATH"
+  if (( ${#FINDINGS[@]} == 0 )); then
+    echo "  ✓ all checks passed"
+  else
+    for row in "${FINDINGS[@]}"; do
+      sev=$(echo "$row" | jq -r '.severity')
+      msg=$(echo "$row" | jq -r '.verdict')
+      ev=$(echo "$row" | jq -r '.evidence[0] // "-"')
+      printf "  [%s] %s\n    → %s\n" "$sev" "$msg" "$ev"
+    done
+  fi
+  echo "# worst: $worst · total: ${#FINDINGS[@]}"
+fi
+
+case "$worst" in
+  critical|high) exit 1 ;;
+  medium)        (( STRICT )) && exit 1 || exit 0 ;;
+  *) exit 0 ;;
+esac

--- a/.claude/scripts/constructs-auth.sh
+++ b/.claude/scripts/constructs-auth.sh
@@ -144,12 +144,21 @@ cmd_setup() {
 cmd_validate() {
     local api_key
     api_key=$(get_api_key 2>/dev/null || echo "")
-    
+
     if [[ -z "$api_key" ]]; then
         echo "❌ No API key configured" >&2
+        echo "" >&2
+        echo "Free packs install without authentication — only premium packs need a key." >&2
+        echo "" >&2
+        echo "To configure:" >&2
+        echo "  1. Visit https://www.constructs.network/account" >&2
+        echo "  2. Copy your API key (sk_...)" >&2
+        echo "  3. Run:    .claude/scripts/constructs-auth.sh setup <key>" >&2
+        echo "     or set: export LOA_CONSTRUCTS_API_KEY=sk_your_key" >&2
         return 1
     fi
-    
+
+
     local registry_url
     registry_url=$(get_registry_url)
     

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -1280,6 +1280,7 @@ Usage: constructs-install.sh <command> [arguments]
 
 Commands:
     pack <slug>              Install a pack from the registry
+    upgrade <slug>           Upgrade a single installed pack (git pull or re-fetch)
     skill <vendor/slug>      Install a skill from the registry
     uninstall pack <slug>    Uninstall a pack
     uninstall skill <slug>   Uninstall a skill
@@ -1301,6 +1302,7 @@ Environment Variables:
 
 Examples:
     constructs-install.sh pack gtm-collective
+    constructs-install.sh upgrade gtm-collective
     constructs-install.sh skill thj/terraform-assistant
     constructs-install.sh uninstall pack gtm-collective
     constructs-install.sh link-commands all

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -723,6 +723,26 @@ PYEOF
         esac
     fi
 
+    # Manifest validation (cycle-005 L4) — F28-class checks + SEED §12 grimoires convention
+    # Default: warn on HIGH/CRITICAL, advisory on MEDIUM/LOW. Set LOA_STRICT_VALIDATION=1 to block.
+    local manifest_validator="$SCRIPT_DIR/construct-validate.sh"
+    if [[ -x "$manifest_validator" ]]; then
+        echo "  Validating manifest..."
+        local manifest_rc=0
+        local manifest_report
+        manifest_report=$("$manifest_validator" "$pack_dir" 2>&1) || manifest_rc=$?
+        if (( manifest_rc != 0 )); then
+            print_warning "  Manifest validation surfaced findings:"
+            printf '%s\n' "$manifest_report" | sed 's/^/    /'
+            if [[ "${LOA_STRICT_VALIDATION:-0}" == "1" ]]; then
+                print_error "  Aborting install (LOA_STRICT_VALIDATION=1)"
+                return 1
+            fi
+        else
+            print_success "  Manifest clean"
+        fi
+    fi
+
     # Update registry meta
     update_pack_meta "$pack_slug" "$pack_dir"
 

--- a/.claude/scripts/constructs-list.sh
+++ b/.claude/scripts/constructs-list.sh
@@ -67,6 +67,7 @@ emit_pack_json() {
     local source_json="$pack_dir/.source.json"
 
     local name="" version="" description="" visibility="" schema_version="" skill_count=0 command_count=0
+    local reads_count=0 writes_count=0
     if [[ -f "$yaml" ]]; then
         name=$(yq -r '.name // ""' "$yaml" 2>/dev/null)
         version=$(yq -r '.version // ""' "$yaml" 2>/dev/null)
@@ -75,6 +76,26 @@ emit_pack_json() {
         schema_version=$(yq -r '.schema_version // ""' "$yaml" 2>/dev/null)
         skill_count=$(yq -r '(.skills // []) | length' "$yaml" 2>/dev/null)
         command_count=$(yq -r '(.commands // []) | length' "$yaml" 2>/dev/null)
+        # cycle-005 L7 · surface stream declarations (doctrine §3)
+        reads_count=$(yq -r '(.reads // .streams.reads // []) | length' "$yaml" 2>/dev/null)
+        writes_count=$(yq -r '(.writes // .streams.writes // []) | length' "$yaml" 2>/dev/null)
+    fi
+
+    # cycle-005 L7 · persona handles (yaml declaration OR identity/<HANDLE>.md filenames)
+    local personas_json="[]"
+    if [[ -f "$yaml" ]]; then
+        personas_json=$(yq -o=json '.personas // []' "$yaml" 2>/dev/null || echo "[]")
+        # If empty list, probe identity dir
+        if [[ "$(echo "$personas_json" | jq 'length')" == "0" && -d "$pack_dir/identity" ]]; then
+            personas_json=$(
+                find "$pack_dir/identity" -maxdepth 1 -name '*.md' -print 2>/dev/null \
+                  | while read -r f; do
+                      base=$(basename "$f" .md)
+                      [[ "$base" =~ ^[A-Z][A-Z0-9_]+$ ]] && printf '%s\n' "$base"
+                    done | LC_ALL=C sort -u | jq -R . | jq -sc .
+            )
+            [[ -z "$personas_json" ]] && personas_json="[]"
+        fi
     fi
 
     local source_repo="" source_commit="" installed_at="" source_state="no_source_json"
@@ -112,6 +133,9 @@ emit_pack_json() {
         --arg schema_version "$schema_version" \
         --argjson skill_count "${skill_count:-0}" \
         --argjson command_count "${command_count:-0}" \
+        --argjson reads_count "${reads_count:-0}" \
+        --argjson writes_count "${writes_count:-0}" \
+        --argjson personas "$personas_json" \
         --arg source_repo "$source_repo" \
         --arg source_commit "$source_commit" \
         --arg installed_at "$installed_at" \
@@ -121,6 +145,8 @@ emit_pack_json() {
         '{slug:$slug, name:$name, version:$version, description:$description,
           visibility:$visibility, schema_version:$schema_version,
           skill_count:$skill_count, command_count:$command_count,
+          reads_count:$reads_count, writes_count:$writes_count,
+          personas:$personas,
           source_repo:$source_repo, source_commit:$source_commit,
           installed_at:$installed_at, source_state:$source_state,
           drift_state:$drift_state, pack_dir:$pack_dir}'
@@ -176,6 +202,8 @@ case "$MODE" in
             "  \(.name)\n" +
             "  \(.description)\n" +
             "  skills: \(.skill_count) · commands: \(.command_count) · schema_v\(.schema_version)\n" +
+            "  personas: " + (if (.personas | length) > 0 then (.personas | map("@" + .) | join(", ")) else "(none declared)" end) + "\n" +
+            "  streams: reads=\(.reads_count) writes=\(.writes_count)" + (if (.reads_count + .writes_count) == 0 then " ⚠ undeclared" else "" end) + "\n" +
             "  state: \(.source_state) · drift: \(.drift_state)\n" +
             (if .source_repo != "" then "  source: \(.source_repo) @ \(.source_commit)\n" else "  source: (no .source.json — untracked install)\n" end)'
         ;;

--- a/.claude/scripts/constructs-publish.sh
+++ b/.claude/scripts/constructs-publish.sh
@@ -198,7 +198,26 @@ do_validate() {
         fail=$((fail + 1))
     fi
 
-    # 10. Package size reasonable (< 10MB)
+    # 10. Manifest validation (cycle-005 L4) — F28 + SEED §12 convention checks
+    local manifest_validator="$SCRIPT_DIR/construct-validate.sh"
+    if [[ -x "$manifest_validator" ]]; then
+        local mv_rc=0
+        "$manifest_validator" "$path" >/dev/null 2>&1 || mv_rc=$?
+        if (( mv_rc == 0 )); then
+            results+=('{"check":"manifest_validate","status":"pass","detail":"construct-validate all checks passed"}')
+            pass=$((pass + 1))
+        else
+            # Fetch findings JSON for detail
+            local mv_report
+            mv_report=$("$manifest_validator" "$path" --json 2>/dev/null || echo '[]')
+            local mv_count
+            mv_count=$(echo "$mv_report" | jq 'length' 2>/dev/null || echo 0)
+            results+=("$(jq -n --arg cnt "$mv_count" '{check:"manifest_validate",status:"fail",detail:("construct-validate surfaced "+$cnt+" finding(s) — run: construct-validate.sh <path>")}')")
+            fail=$((fail + 1))
+        fi
+    fi
+
+    # 11. Package size reasonable (< 10MB)
     local size_kb
     size_kb=$(du -sk "$path" 2>/dev/null | cut -f1)
     if [[ "$size_kb" -lt 10240 ]]; then

--- a/.claude/scripts/stream-validate.sh
+++ b/.claude/scripts/stream-validate.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# =============================================================================
+# stream-validate.sh — JSON Schema validator for construct stream rows (cycle-005 L2)
+# =============================================================================
+# Validates a Signal / Verdict / Artifact / Intent / Operator-Model JSON payload
+# against its schema at .claude/schemas/<type-slug>.schema.json.
+#
+# Usage:
+#   stream-validate.sh <stream_type> <json-string>
+#   stream-validate.sh <stream_type> --file <path>
+#   stream-validate.sh <stream_type> -           # read JSON from stdin
+#
+# Stream types: Signal | Verdict | Artifact | Intent | Operator-Model
+#
+# Exit codes:
+#   0 = valid
+#   1 = schema validation failed (message on stderr)
+#   2 = unknown stream type or schema file missing
+#   3 = validator engine unavailable (python3+jsonschema required)
+#
+# Doctrine §3 + §14.2 — stream typing enforced at pipe edges.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+SCHEMA_DIR="${LOA_SCHEMA_DIR:-$PROJECT_ROOT/.claude/schemas}"
+
+usage() {
+  sed -n '2,24p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Map Stream-Type name → slug used in schema filename.
+schema_slug() {
+  case "$1" in
+    Signal)         echo "signal" ;;
+    Verdict)        echo "verdict" ;;
+    Artifact)       echo "artifact" ;;
+    Intent)         echo "intent" ;;
+    Operator-Model) echo "operator-model" ;;
+    *)              return 1 ;;
+  esac
+}
+
+main() {
+  if [[ $# -lt 2 ]]; then
+    usage >&2
+    exit 2
+  fi
+
+  local stream_type="$1"
+  local arg2="$2"
+  local payload
+
+  local slug
+  if ! slug=$(schema_slug "$stream_type"); then
+    echo "[stream-validate] ERROR: unknown stream_type '$stream_type'. Expected one of: Signal, Verdict, Artifact, Intent, Operator-Model." >&2
+    exit 2
+  fi
+
+  local schema_file="$SCHEMA_DIR/${slug}.schema.json"
+  if [[ ! -f "$schema_file" ]]; then
+    echo "[stream-validate] ERROR: schema file missing: $schema_file" >&2
+    exit 2
+  fi
+
+  if [[ "$arg2" == "--file" ]]; then
+    [[ $# -ge 3 ]] || { echo "[stream-validate] ERROR: --file requires a path argument." >&2; exit 2; }
+    payload=$(cat "$3")
+  elif [[ "$arg2" == "-" ]]; then
+    payload=$(cat -)
+  else
+    payload="$arg2"
+  fi
+
+  # Sanity-check: payload is valid JSON.
+  if ! echo "$payload" | jq -e . >/dev/null 2>&1; then
+    echo "[stream-validate] ERROR: payload is not valid JSON." >&2
+    exit 1
+  fi
+
+  # Sanity-check: declared stream_type matches.
+  local declared
+  declared=$(echo "$payload" | jq -r '.stream_type // empty')
+  if [[ -n "$declared" && "$declared" != "$stream_type" ]]; then
+    echo "[stream-validate] ERROR: payload declares stream_type='$declared' but validator invoked with '$stream_type'." >&2
+    exit 1
+  fi
+
+  # Prefer python3+jsonschema (full draft-07). Fall back to jq required-field check.
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import jsonschema" >/dev/null 2>&1; then
+    local payload_tmp
+    payload_tmp=$(mktemp -t stream-validate-payload.XXXXXX.json)
+    # shellcheck disable=SC2064  # expand trap path now
+    trap "rm -f '$payload_tmp'" EXIT
+    printf '%s' "$payload" > "$payload_tmp"
+    python3 - "$schema_file" "$stream_type" "$payload_tmp" <<'PY'
+import json
+import sys
+
+schema_path, stream_type, payload_path = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    with open(payload_path) as fh:
+        payload = json.load(fh)
+except json.JSONDecodeError as exc:
+    print(f"[stream-validate] ERROR: JSON decode failed: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+with open(schema_path) as fh:
+    schema = json.load(fh)
+
+from jsonschema import Draft7Validator  # type: ignore
+
+validator = Draft7Validator(schema)
+errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.absolute_path))
+if errors:
+    print(f"[stream-validate] {stream_type} INVALID:", file=sys.stderr)
+    for err in errors[:20]:
+        loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
+        print(f"  - {loc}: {err.message}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+    exit $?
+  fi
+
+  # Fallback validator — required-field presence only, no full schema semantics.
+  echo "[stream-validate] WARNING: python3/jsonschema missing — running degraded required-field-only validation." >&2
+  local required
+  required=$(jq -r '.required // [] | .[]' "$schema_file")
+  local missing=()
+  while IFS= read -r field; do
+    [[ -z "$field" ]] && continue
+    if ! echo "$payload" | jq -e --arg f "$field" '.[$f] != null' >/dev/null 2>&1; then
+      missing+=("$field")
+    fi
+  done <<< "$required"
+
+  if (( ${#missing[@]} > 0 )); then
+    echo "[stream-validate] $stream_type INVALID: missing required field(s): ${missing[*]}" >&2
+    exit 1
+  fi
+  exit 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.claude/skills/validating-construct-manifest/SKILL.md
+++ b/.claude/skills/validating-construct-manifest/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: validating-construct-manifest
+description: Pre-install / pre-publish manifest linter for construct packs. Emits Verdict stream rows on findings. Gates `constructs install` and `constructs publish` against F28-class breakage and SEED §12 grimoires-convention drift.
+---
+
+# Validating Construct Manifest
+
+> Caught at install-time is cheap. Caught at publish-time still cheap. Caught by an operator at `/feel` not resolving is expensive.
+
+## Purpose
+
+Validate a construct pack directory before it lands in a registry or a local install. Surfaces:
+
+1. **Required-field gates** — missing `schema_version`, `slug`, `name`, `version`, `description` in `construct.yaml`
+2. **Path resolution** — `skills[].path` and `commands[].path` entries that don't resolve
+3. **F28 closure** — pack declares neither `commands:` nor persona handles (operator can only route by slug/name)
+4. **Stream declarations** — empty `reads:` / `writes:` arrays (doctrine §3 pipe compatibility is ambiguous)
+5. **SEED §12 grimoires convention** — `CLAUDE.md` must contain an explicit `grimoires/<path>` read/write declaration; known drift surfaces here
+
+Each finding is a **Verdict stream row** (doctrine §3.2) — severity-tagged, evidence-cited, pipeable downstream.
+
+## Invocation
+
+```bash
+# Run directly (shell-first, no agent needed)
+.claude/scripts/construct-validate.sh <pack-path>
+.claude/scripts/construct-validate.sh <pack-path> --json     # Verdict[] on stdout
+.claude/scripts/construct-validate.sh <pack-path> --strict   # MEDIUM → exit 1
+```
+
+Install / publish integration:
+
+- `constructs-install.sh` calls the validator after license check. Findings print to the console. Set `LOA_STRICT_VALIDATION=1` to abort install on HIGH/CRITICAL.
+- `constructs-publish.sh` adds a `manifest_validate` check to the 10-point pre-publish report.
+
+## Severity tiers
+
+| Tier | Meaning | Install behavior | Publish behavior |
+|------|---------|------------------|------------------|
+| `critical` | `construct.yaml` missing or unparseable | Always blocks | Always blocks |
+| `high`     | Required field missing / broken path | Warn by default, block with `LOA_STRICT_VALIDATION=1` | Blocks |
+| `medium`   | F28 route gap, §12 grimoires drift | Advisory | Advisory (unless `--strict`) |
+| `low`      | Empty stream declarations | Advisory | Advisory |
+| `info`     | All checks passed | — | — |
+
+## Checks in detail
+
+### 1 · construct.yaml presence + parseability (`critical`)
+
+The manifest must exist and yq must parse it. This is the only unrecoverable failure.
+
+### 2 · Required fields (`high`)
+
+`schema_version`, `slug`, `name`, `version`, `description` must all be non-empty. These power the registry listing + resolver tiers.
+
+### 3 · Skill path resolution (`high`)
+
+Every entry in `skills: [{path}]` must resolve to a directory (or symlink) under the pack root.
+
+### 4 · Command path resolution (`high`)
+
+Every entry in `commands: [{path}]` must resolve to a file. Rosenzu-class breakage (commands pointing at skill directories) surfaces here.
+
+### 5 · F28 route declaration (`medium`)
+
+If the pack declares no `commands:` AND no persona handles (either via `personas:` in yaml or `identity/<HANDLE>.md` filenames), the operator can only route by slug/name. This surfaces the gap that made `/feel` un-resolvable in cycle-004.
+
+### 6 · Stream declarations (`low`)
+
+Per doctrine §3, packs should declare `reads:` and `writes:` stream types so the composition runner can verify pipe compatibility. Empty arrays are advisory-level.
+
+### 7 · SEED §12 grimoires convention (`medium`)
+
+`CLAUDE.md` must reference `grimoires/<path>` AND include at least one of: `Writes to`, `Reads from`, `writes:`, `reads:`. This is the convention the `construct-base` template already enforces; installed packs that pre-date the template drifted.
+
+The canary here is `artisan` — its `construct.yaml` declares grimoire paths, but its `CLAUDE.md` does not mirror them. L6 butterfreezone adapter regenerates the missing section.
+
+## Output shape
+
+Default (human-readable):
+
+```
+# construct-validate · /Users/.../packs/artisan
+  [low] [streams] construct declares no 'reads:' stream types — pipe composition will be ambiguous
+    → /Users/.../packs/artisan/construct.yaml
+  [medium] [grimoires_section] CLAUDE.md contains no grimoires/ path reference — SEED §12
+    → /Users/.../packs/artisan/CLAUDE.md
+# worst: medium · total: 2
+```
+
+`--json` emits a JSON array of Verdict rows conforming to `.claude/schemas/verdict.schema.json`. Each row carries:
+
+- `stream_type: "Verdict"`
+- `severity`: critical | high | medium | low
+- `verdict`: `[<check>] <message>`
+- `evidence`: `[<file path>]`
+- `subject`: pack path
+- `tags`: `[<check name>]`
+
+Downstream tools (e.g. `constructs-publish.sh`, dashboard surfaces, CI lint jobs) can consume this array directly.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | No HIGH or CRITICAL findings (MEDIUM passes unless `--strict`) |
+| 1 | At least one HIGH/CRITICAL finding, or MEDIUM with `--strict` |
+| 2 | Pack path does not exist / required tooling missing |
+
+## Relationship to other validators
+
+- `constructs-loader.sh validate-pack` — license validation, retained alongside
+- `validate-pack-manifests.mjs` — Zod-based manifest schema check (sandbox packs)
+- `construct-validate.sh` (this) — ecosystem-wide cycle-005 checks, Verdict-emitting
+
+## Related
+
+- Script: `.claude/scripts/construct-validate.sh`
+- Schema: `.claude/schemas/verdict.schema.json`
+- Doctrine: `grimoires/loa-constructs-seed-2026-04-21/bonfire-construct-pipe-doctrine.md` §3.2, §14.2
+- SEED: `grimoires/loa-constructs-seed-2026-04-21/cycle-005-SEED-runtime-integration.md` L4 + §12
+- Sibling skills: `publishing-constructs`, `browsing-constructs`

--- a/.claude/skills/validating-construct-manifest/index.yaml
+++ b/.claude/skills/validating-construct-manifest/index.yaml
@@ -1,0 +1,80 @@
+name: validating-construct-manifest
+version: "1.0.0"
+description: |
+  Pre-install and pre-publish manifest linter for construct packs. Runs
+  F28-class checks (commands / personas declaration), SEED §12 grimoires
+  read/write convention check on CLAUDE.md, and required-field gates on
+  construct.yaml. Emits Verdict stream rows (doctrine §3.2) per finding.
+
+model: haiku
+color: yellow
+
+triggers:
+  - pattern: "/validate-construct"
+    description: "Run manifest checks against a construct pack path"
+
+capabilities:
+  model_tier: haiku
+  danger_level: safe
+  effort_hint: small
+  downgrade_allowed: true
+  execution_hint: sequential
+  requires:
+    native_runtime: false
+    tool_calling: true
+    thinking_traces: false
+    vision: false
+
+dependencies:
+  - tool: yq
+    min_version: "4.0.0"
+    rationale: "Parses construct.yaml"
+  - tool: jq
+    rationale: "Emits Verdict rows + JSON report mode"
+
+inputs:
+  - name: path
+    type: string
+    description: "Path to construct pack directory (contains construct.yaml)"
+    required: true
+  - name: strict
+    type: boolean
+    description: "Treat MEDIUM findings as blocking (exit 1)"
+    required: false
+    default: false
+  - name: json
+    type: boolean
+    description: "Emit findings as a JSON array of Verdict rows on stdout"
+    required: false
+    default: false
+
+outputs:
+  - name: findings
+    type: array
+    description: "List of Verdict stream rows, one per finding"
+  - name: worst_severity
+    type: string
+    description: "Highest severity seen (critical|high|medium|low|info)"
+  - name: exit_code
+    type: integer
+    description: "0 = clean, 1 = has HIGH/CRITICAL (or MEDIUM with --strict), 2 = pack missing"
+
+zones:
+  system: read
+  state: read
+  app: none
+
+streams:
+  reads:
+    - Artifact
+  writes:
+    - Verdict
+
+composes_with:
+  - publishing-constructs
+  - browsing-constructs
+
+related:
+  - script: .claude/scripts/construct-validate.sh
+  - doctrine: grimoires/loa-constructs-seed-2026-04-21/bonfire-construct-pipe-doctrine.md §3.2 §14.2
+  - seed: grimoires/loa-constructs-seed-2026-04-21/cycle-005-SEED-runtime-integration.md L4 + §12

--- a/grimoires/loa-constructs-seed-2026-04-21/bonfire-construct-pipe-doctrine.md
+++ b/grimoires/loa-constructs-seed-2026-04-21/bonfire-construct-pipe-doctrine.md
@@ -764,3 +764,98 @@ Original cycle-003 inheritance queue (§15.7) carried infra-heavy priorities (F2
 ---
 
 *v4 · 2026-04-21-late · Third operator review. Operator OS inverts from canon to starter-template. Hivemind trichotomy cleaned. Composition determinism promoted to cycle-004 primary. Agent transparency becomes doctrine-level invariant. Open playground — "my workflow is one example, not THE workflow."*
+
+---
+
+## 17 · Amendments (v4 → v5, 2026-04-22 post cycle-005 L1/L2/L4/L6 landing)
+
+Cycle-005 shipped the composition runner, stream schemas, manifest validator, and butterfreezone adapter. Running a real chain revealed two structural claims v4 conflated that v5 needs to separate, and one primitive layer v4 left undefined.
+
+### 17.1 · Dispatch-determinism vs output-reproducibility (flatline SKP-002 closure — partial)
+
+The v4 §16.3 "composition determinism" invariant packed two distinct guarantees into one phrase. Running `construct-compose feel-audit <target>` twice surfaces the tension:
+
+**Dispatch-determinism** — the runner's obligation. A composition YAML + input selects the same construct slugs, same skill slugs, same persona handles, same stream types, same ordering *every invocation*. No LLM variance. No hidden routing. Verifiable from trajectory rows alone.
+
+**Output-reproducibility** — not a pipe-layer guarantee. Each stage's *content* comes from an LLM-driven skill whose output varies session-to-session even on identical inputs. A feel-audit verdict changes wording and sometimes surfaces a different finding on re-run.
+
+v4 said "same operator utterance → same construct every time" (dispatch-side) and implicitly suggested same-chain-runs-same-way (output-side). The second claim is false under LLM semantics and v5 doesn't pretend otherwise.
+
+**Promoted to invariant**:
+
+> Compositions MUST be dispatch-deterministic. Compositions MUST NOT be assumed to be output-reproducible. Tooling that needs reproducibility pins model + seed + temperature at the stage boundary; that's a stage-level contract, not a pipe-layer one.
+
+**Consequence for trajectory rows**: an agent comparing two runs of the same composition should diff the *dispatch trail* (constructs touched, stages ordered, stream types) and expect identical rows. Output content diffing is optional, not a doctrine obligation.
+
+**Flatline SKP-002 partial closure**: the determinism claim is now clearly split. SKP-002's full closure (how to pin output reproducibility when an operator wants it) lands in cycle-006+.
+
+### 17.2 · Failure-semantics primitives (flatline SKP-003)
+
+v4 was silent on what a pipe chain does when a stage fails. Cycle-005's runner implements the simplest possible policy (fail-fast, propagate exit code 3) but doctrine v5 names the primitive vocabulary so downstream cycles can choose other policies coherently.
+
+Four primitives, named but not yet all implemented:
+
+| Primitive | What it means | Cycle-005 default |
+|---|---|---|
+| **Timeout** | Stage exceeds duration budget → marked failed | Not enforced (stages are stubs) |
+| **Retry** | Stage failed → runner re-invokes per policy (max attempts, backoff) | Not enforced — one attempt |
+| **Idempotency** | Re-running the same stage on the same input produces the same-schema output even if content varies (see §17.1) | Partially — stubs are idempotent; real stages TBD |
+| **Dead-letter** | Stage permanently failed after retries → payload diverts to a dead-letter stream for operator review | Not implemented — failures surface in exit code only |
+
+A composition MAY declare a `failure_policy:` block per stage. Example (post-cycle-005, not yet consumed):
+
+```yaml
+chain:
+  - stage: 2
+    construct: observer
+    skill: analyzing-gaps
+    reads: [Verdict, Signal]
+    writes: [Verdict]
+    failure_policy:
+      timeout_ms: 30000
+      retry:
+        max_attempts: 3
+        backoff: exponential
+      idempotency_key: "{run_id}-{stage}"
+      dead_letter: .run/deadletter/feel-audit.jsonl
+```
+
+**Invariant** (promoted): every pipe-stage failure MUST be observable. Either the runner propagates exit code + emits a failed-outcome trajectory row, OR the payload routes to a dead-letter stream. Silent-drop is a doctrine violation.
+
+**Flatline SKP-003 partial closure**: the vocabulary is set. Full closure requires a runner that honors failure_policy blocks — cycle-006 target.
+
+### 17.3 · `Verdict` finding type — severity-evidence contract
+
+Cycle-005 L4's `construct-validate.sh` emits findings as Verdict stream rows with `severity` and `evidence` fields. Usage demonstrated that a Verdict row doubles as both:
+
+1. An evaluated judgment (v4 §3.2 original framing)
+2. A structured finding with severity tier (info/low/medium/high/critical) + evidence chain
+
+Both usages already round-trip through `.claude/schemas/verdict.schema.json`. Promoting to doctrine: Verdict rows SHOULD carry `severity` when the producer is an audit / validator / review construct. The `severity` field itself is optional on the schema (preserves backwards compat with feedback-v3-era verdicts), but downstream consumers (dashboards, install gates, bridge reviewers) may key off it.
+
+### 17.4 · Grimoires-as-interface convention (SEED §12 promotion)
+
+The cycle-005 SEED §12 convention was repo-local guidance. After L6 butterfreezone surfaced artisan's CLAUDE.md drift (construct.yaml declares paths; CLAUDE.md does not), the convention is load-bearing enough for doctrine:
+
+> **A construct's declared `grimoires/` read/write paths ARE its filesystem-level composition interface.** Two constructs writing to the same grimoire path compose automatically; no event bus, no handshake. Two constructs where one reads a path the other writes form an implicit pipe edge. This is structurally identical to a typed-stream pipe at the stream layer.
+
+The implication for v5: **pipe compatibility is a two-layer claim**. The stream layer (Signal/Verdict/Artifact/Intent/Operator-Model) gives in-memory typing; the grimoire layer gives filesystem typing. Both must align for a composition to be complete.
+
+Cycle-005 enforces the stream layer via `construct-compose.sh` type check. Cycle-006+ can extend to the grimoire layer: the composition runner reads each stage's declared grimoire paths and warns when two stages overwrite the same path without sequencing.
+
+### 17.5 · Version bump
+
+**v5**. v4 chain-preserved. Amendments:
+
+- Dispatch-determinism vs output-reproducibility split (§17.1)
+- Failure-semantics primitives vocabulary (§17.2)
+- Verdict severity field promoted as canonical for audit/review/validator producers (§17.3)
+- Grimoires-as-interface promoted from SEED §12 to doctrine invariant (§17.4)
+
+Flatline blocker updates:
+- SKP-002 — partially closed by §17.1 split. Full closure (reproducibility knob) deferred.
+- SKP-003 — partially closed by §17.2 vocabulary. Full closure (runner enforcement) deferred to cycle-006.
+
+---
+
+*v5 · 2026-04-22 · Post cycle-005 runtime landing. Two conflated invariants split. Failure-semantics primitives named. Grimoires-as-interface promoted. Four active primitives now have doctrine: Signal/Verdict/Artifact/Intent/Operator-Model for stream typing; timeout/retry/idempotency/dead-letter for failure; stream-layer + grimoire-layer compose for composition completeness.*

--- a/grimoires/loa-constructs-seed-2026-04-21/cycle-005-findings.md
+++ b/grimoires/loa-constructs-seed-2026-04-21/cycle-005-findings.md
@@ -1,0 +1,195 @@
+# Cycle-005 Findings · Runtime + Integration
+
+> **SEED**: [`cycle-005-SEED-runtime-integration.md`](cycle-005-SEED-runtime-integration.md)
+> **Branch**: `feat/spiral-loa-constructs-cycle-005-runtime-integration`
+> **Mode**: Conversational-paired + shell-first (cycle-003/004 precedent)
+> **Date closed**: 2026-04-22
+> **Doctrine state at close**: v5 (§17 amendment landed)
+
+---
+
+## 0 · Summary
+
+9 of 10 legs landed. 1 conditional (L10 `.source.json` three-way-merge) deferred per SEED framing. 5 cycle-005-specific findings surfaced (F30–F34). Q5 self-audit from cycle-004 ("composition execution is still manual") **closed** — `construct-compose feel-audit <target>` now executes all three stages end-to-end with trajectory emission and final-output schema validation.
+
+Upstream PRs opened (2, neither admin-merged): construct-base template v3 and loa `--with-constructs` flag. L5 awaiting @janitooor review per SEED §11.
+
+---
+
+## 1 · Legs shipped
+
+| Leg | Status | AC closure | Delivery |
+|---|---|---|---|
+| **L1** · `construct-compose.sh` runner | ✅ landed | L1.1–L1.6 all met | commit `6b81f68` |
+| **L2** · Stream JSON schemas + validator | ✅ landed | L2.1–L2.5 all met | commit `6b81f68` |
+| **L3** · `construct-base` template v3 | ✅ PR open | L3.1–L3.6 met | [0xHoneyJar/construct-base#11](https://github.com/0xHoneyJar/construct-base/pull/11) |
+| **L4** · `validating-construct-manifest` skill | ✅ landed | L4.1–L4.6 (incl. §12) | commit `f9674b4` |
+| **L5** · Loa `--with-constructs` flag | ⏳ PR open, awaiting Jani | L5.1–L5.5 met, review-gated | [0xHoneyJar/loa#615](https://github.com/0xHoneyJar/loa/pull/615) |
+| **L6** · Butterfreezone construct adapter | ✅ landed | L6.1–L6.5 all met | commit `74386d5` |
+| **L7** · `/constructs` polish | ✅ landed | L7.1–L7.5 all met | commit `b4390d2` |
+| **L8** · E2e proof on feel-audit | ✅ landed | L8.1–L8.4 all met | bats tests green |
+| **L9** · Doctrine v5 §17 amendment | ✅ landed | L9.1–L9.4 all met | commit `ba14244` |
+| **L10** · F24 three-way-merge | ⏸️ deferred | — | explicitly CONDITIONAL per SEED |
+
+**Total lines shipped in loa-constructs**: ~1,050 shell + ~300 JSON schema + ~150 markdown (SKILL.md + findings + doctrine §17). Zero TypeScript. Shell-first discipline (doctrine §13.1) preserved.
+
+**Upstream**: ~130 lines in construct-base (yaml + persona md + readme), ~88 lines in loa (shell + wizard step).
+
+---
+
+## 2 · Findings F30 – F34
+
+### F30 · Construct `.gitignore` made a local draft of cycle-002 SEED invisible
+
+While orienting at cycle-005 kickoff, `git status` surfaced `grimoires/loa-constructs-seed-2026-04-21/cycle-002-SEED-artisan-lifecycle-walk.md` as untracked. It was never committed — an operator's local draft that existed only in this worktree. The file doesn't appear in any git log across any branch.
+
+**Implication**: informal drafts inside `grimoires/loa-constructs-seed-2026-04-21/` are invisible to cycle chain-preservation. Two options:
+
+- **(a)** Commit drafts at `draft/` subdirectory with a `--- status: draft ---` frontmatter so OTLET preserves them even if later superseded.
+- **(b)** Store drafts outside `grimoires/` (e.g. `~/hivemind/self/drafts/`) and only move into the cycle dir once operator-ratified.
+
+Cycle-005 didn't force a choice — the draft was left untracked. Flagging for operator call.
+
+**Closure**: deferred. Doesn't block cycle-005. Route to cycle-006 housekeeping.
+
+### F31 · Installed symlinks lose fidelity after a cache-state divergence
+
+During orient, fast-forwarding `main` surfaced two merge conflicts with untracked `.claude/skills/{tuning-springs,visual-dig}` directories. Origin declared these as symlinks to `~/.loa/constructs/packs/<slug>/skills/<slug>`; the local worktree had full directory copies. Inspection showed the directory contents matched the symlink targets byte-for-byte, so the dirs were safe to remove and let the fast-forward restore symlinks.
+
+**Root cause**: unclear. Possibly an early-cycle-004 state where global sync wrote real directories before the symlink convention settled, and those directories persisted through subsequent cache updates.
+
+**Implication**: global sync should have an integrity check — "is `.claude/skills/<slug>` a symlink where we expected one?" — and offer to repair divergences non-destructively.
+
+**Closure**: cycle-005 resolved locally by comparing + deleting the divergent dirs. Upstream fix is a sync-script guardrail; deferred to cycle-006 housekeeping.
+
+### F32 · 27 of 29 installed packs are §12-drifted
+
+L4 validator run across `~/.loa/constructs/packs/*` surfaced:
+
+- 27 MEDIUM findings (CLAUDE.md missing `grimoires/` reference — SEED §12 drift)
+- 2 CRITICAL findings (`hypha`, `webgl-particles` — `construct.yaml` missing or unparseable)
+- 1 HIGH with 8 findings (`rosenzu` — `commands[].path` entries point at skill directories rather than command markdown files)
+
+The §12 drift is load-bearing: artisan was the SEED-named canary, and the pattern propagated. L6's butterfreezone adapter regenerates the missing section from `construct.yaml` declarations; running `butterfreezone-construct-gen.sh` across the 27 drifted packs would close F32 mechanically.
+
+**Closure**: tooling ships (validator + generator). Mass regeneration of `CONSTRUCT-README.md` files across the ecosystem is a separate follow-up — either operator-initiated `constructs-sweep.sh`-style batch, or per-pack upstream PRs. The `rosenzu` HIGH finding should be a direct upstream PR to correct `commands[].path` semantics.
+
+### F33 · `construct-network-tools` pack does not exist on the registry
+
+L5 SEED names `construct-network-tools` as the bundle slug to install at mount. Registry query surfaces no such pack. The L5 PR ships the flag wiring but the default slug resolves to "install unknown pack, log warning, keep moving" behavior.
+
+**Implication**: L5 is mechanically shipped but semantically incomplete until a pack answering to that slug lands. Options:
+
+- **(a)** Operator creates `construct-network-tools` as a meta-pack that depends on `browsing-constructs` + `publishing-constructs` + `syncing-constructs` + the composition runner integration.
+- **(b)** Default slug changes to an existing pack (e.g. `artisan` or `observer`) until meta-pack lands.
+- **(c)** Leave WITH_CONSTRUCTS default=false until operator picks (a) or (b).
+
+Cycle-005 shipped (c) — the flag exists, default off, clear error if the slug doesn't resolve. Operator call on default pack name routes to cycle-006.
+
+**Closure**: documented in the L5 PR body; awaiting operator + @janitooor feedback.
+
+### F34 · Publish validator report truncates `manifest_validate` detail line
+
+`constructs-publish.sh validate <pack>` surface reports `manifest_validate · construct-validate surfaced 8` with no visible trailing text because the existing 10-point reporter truncates the `detail` JSON field at a fixed column width. Full detail (`construct-validate surfaced 8 finding(s) — run: construct-validate.sh <path>`) lives in the JSON.
+
+**Implication**: the new L4 integration is functionally correct but the operator-facing output hides the "how to investigate" call-to-action. Pre-existing display limitation, not a cycle-005 regression — surfacing for cycle-006 polish.
+
+**Closure**: deferred. `--json` mode exposes the full shape; human-readable mode is the polish target.
+
+---
+
+## 3 · Doctrine v5 compliance — per-leg audit
+
+| Invariant | Landed? |
+|---|---|
+| §3 typed streams (5 primitives) | ✅ L2 schemas + L1 runner validates |
+| §4 pipe chain spec | ✅ L1 runner executes composition YAML |
+| §5 orchestration layer | ✅ partial — L1 is the "shell-equivalent"; Finn tier still future |
+| §13.1 shell-first | ✅ zero TypeScript, zero Python (jsonschema used as lib, not code) |
+| §14.3 read-modes (glance/orient/intervene) | ✅ L1 + constructs-list both |
+| §16.3 composition determinism | ✅ L1 dispatch deterministic; output variance named in §17.1 |
+| §16.4 agent-transparency | ✅ trajectory emission per-stage |
+| §17.1 dispatch-det ≠ output-repro split | ✅ new in v5 |
+| §17.2 failure-semantics primitives | ⏳ vocabulary set, enforcement deferred to cycle-006 |
+| §17.3 Verdict severity-evidence | ✅ L4 validator emits it |
+| §17.4 grimoires-as-interface | ✅ L4 validates + L6 regenerates |
+
+---
+
+## 4 · KANSEI gate (S8, operator-answered)
+
+| # | Question | Agent self-assessment | Operator answer |
+|---|---|---|---|
+| Q1 | Can I run `construct-compose feel-audit target.tsx` and watch all three stages execute end-to-end? | **Y** — bats lock, ~1.5s run, 6 trajectory rows paired, Verdict schema-valid final output. Stub stages until real LLM dispatch (cycle-006+). | _operator_ |
+| Q2 | Does the runner fail-fast on a stream-type mismatch with a clear error? | **Y** — exit 2 on type mismatch, message names stage + expected type + actual produced set. Bats test locks this. | _operator_ |
+| Q3 | Can a new construct author clone `construct-base` and land on the network without understanding doctrine v4 internals? | **Partial pending L3 merge** — template now carries `streams:` + persona handle example + CONSTRUCT-README.md pattern reference. After merge, a fresh `gh repo create --template construct-base` produces a pack that passes `construct-validate.sh` out of the box. | _operator_ |
+| Q4 | Does `mount-loa.sh --with-constructs` give a fresh Loa install construct tools by default? | **Partial pending L5 merge + pack creation** — flag shipped, default off. Default flips to `on` after `construct-network-tools` pack ships (F33). Operator call on pack composition. | _operator_ |
+| Q5 | Free-text: with cycle-005 shipped, what's the first thing you *actually want to use* constructs for? | _operator_ | _operator_ |
+
+Agent score on Q1–Q4: **3 Y + 2 Partial** (L3/L5 merge-gated). No halt criteria triggered; cycle-005 ships contingent on two upstream PRs.
+
+---
+
+## 5 · Cycle-006 inheritance (handoff)
+
+Pre-drafted from SEED §8 + cycle-005 emergence:
+
+1. **Security model + data governance + trust model** (SEED §8.1 · flatline SKP-004/005) — dedicated security cycle
+2. **Namespace collision enforcement** — registry schema work
+3. **`.source.json` backfill for 29 legacy installs** (F22 from cycle-003, never closed)
+4. **Dynamic Labs → Freeside sovereign auth** — operator pivot 2026-04-13
+5. **Supabase → Turso migration** — infra decommission
+6. **Dependency resolution / version constraints** — integration research Gap 2
+7. **`/feel` routing UX reconciliation** — either artisan pack-layer decision (F28 path (a)) OR Operator-OS-aware resolver (F28 path (b))
+8. **JSONL append integrity hardening** (flatline SKP-006) — cycle-007
+9. **Failure-policy enforcement in runner** (doctrine §17.2 closure)
+10. **Real LLM dispatch inside composition stages** — replace stub executor
+11. **F30 grimoires draft policy** — commit under `draft/` or route to hivemind
+12. **F31 symlink-integrity check in global sync**
+13. **F32 ecosystem-wide `CONSTRUCT-README.md` regeneration** — 27 packs drifted
+14. **F33 `construct-network-tools` pack creation** — gates L5 default-flip
+15. **F34 publish-validator display polish** — expose `manifest_validate` detail text
+
+Inheritance list is LONGER than cycle-004's intentionally — the runtime layer landing surfaces the next-tier questions. Cycle-006 framing should pick 3–4 and defer the rest. Security (items 1 + 9) and real-dispatch (item 10) are the two highest-leverage choices.
+
+---
+
+## 6 · Cycle authorship lens
+
+Cycle-005 · agent + integration (runtime + ecosystem-coherence)
+
+Declared at SEED open (§9). Held. Composition runner landed = composition execution is no longer manual. Schema validation at pipe edges closes the "types-only-in-doctrine" gap. Butterfreezone generator makes the §12 grimoires convention mechanically enforceable. L4 validator is the first upstream-facing lint that gates the network on cycle-005 conventions.
+
+---
+
+## 7 · What this cycle proved
+
+1. **Compositions execute as advertised** — doctrine §4 claim is runtime-true. `construct-compose feel-audit <target>` works.
+2. **Type safety on typed streams** — doctrine §3 claim is validator-true. `stream-validate.sh Signal <payload>` returns 0/1 against draft-07 schemas.
+3. **Author flow has a smooth-edge template** (pending L3 merge) — `construct-base` carries streams + persona handles + CONSTRUCT-README.md marker.
+4. **Documentation is generated, not maintained** — butterfreezone adapter proves out on the artisan canary + gtm-collective.
+5. **Ecosystem-wide §12 drift is detectable + fixable** — 27-pack finding is a tractable one-command batch.
+6. **The Q5 self-audit from cycle-004 closes** — composition execution no longer manual.
+
+Two upstream PRs (L3 + L5) are where this lands in operator view. Neither admin-merged per SEED §11. Both carry clear test plans and non-breaking risk profiles.
+
+---
+
+## 8 · What didn't land
+
+- **L10** F24 `.source.json` three-way-merge: CONDITIONAL per SEED; skipped cleanly.
+- **Real LLM dispatch in stage executor**: explicitly stubbed. Default executor emits schema-valid placeholder rows. Real stages land via cycle-006 (`LOA_COMPOSE_STAGE_EXECUTOR` env var / `--executor` flag).
+- **Failure-policy enforcement**: v5 §17.2 sets the vocabulary; runner still fails fast. Cycle-006 target.
+- **Ecosystem-wide CONSTRUCT-README.md regeneration**: L6 proves on artisan; 27-pack batch is operator-scheduled follow-up.
+
+---
+
+## 9 · Supersession
+
+Supersedes cycle-004 §8.1 inheritance queue for items 2 (composition runner), 4 (F26 template freshness), and the stream-type enforcement strand of SKP-002. All three were cycle-004 carryovers that cycle-005 closed.
+
+F29 (`.claude/constructs/` gitignore) remains closed by cycle-004 L5's migration to `grimoires/compositions/`. Cycle-005 extended the pattern: stream schemas ship under `.claude/schemas/`, where they ARE tracked — no repeat of F29.
+
+---
+
+*Cycle-005 close · 2026-04-22 · 9/10 legs landed, 2 upstream review-gated, 5 new findings surfaced. Doctrine v5 active. Runner ships; compositions execute.*

--- a/tests/cycle-005-compose-runner.bats
+++ b/tests/cycle-005-compose-runner.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+# cycle-005-compose-runner.bats — L8 e2e proof for construct-compose.sh (cycle-005 L1)
+#
+# Locks behavior of the composition runner:
+#   - dry-run validates type compatibility without executing
+#   - live run executes all stages sequentially, emits trajectory rows,
+#     produces schema-valid final output, respects --run-id
+#   - type-mismatch composition fails loud at the right stage
+#   - three read-modes (glance / orient / intervene) behave per doctrine §14.3
+#
+# SEED: grimoires/loa-constructs-seed-2026-04-21/cycle-005-SEED-runtime-integration.md (AC-L8.*)
+
+bats_require_minimum_version 1.5.0
+
+RUNNER=".claude/scripts/construct-compose.sh"
+VALIDATOR=".claude/scripts/stream-validate.sh"
+
+setup() {
+  TEST_COMPOSITIONS_DIR=$(mktemp -d /tmp/compose-test.XXXXXX)
+  TEST_RUN_FILE=$(mktemp /tmp/compose-run.XXXXXX.jsonl)
+  export LOA_TRAJECTORY_FILE="$TEST_RUN_FILE"
+}
+
+teardown() {
+  rm -rf "$TEST_COMPOSITIONS_DIR"
+  rm -f "$TEST_RUN_FILE"
+}
+
+@test "dry-run on feel-audit validates plan without executing" {
+  before=$(wc -l < "$TEST_RUN_FILE" 2>/dev/null || echo 0)
+  run "$RUNNER" feel-audit --target src/Button.tsx --dry-run
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "composition=feel-audit"
+  echo "$output" | grep -q "stage 1: artisan::decomposing-feel"
+  echo "$output" | grep -q "stage 3: observer::analyzing-gaps"
+  echo "$output" | grep -q "dry-run OK"
+  after=$(wc -l < "$TEST_RUN_FILE" 2>/dev/null || echo 0)
+  [ "$before" = "$after" ]
+}
+
+@test "live run on feel-audit executes 3 stages, emits 6 trajectory rows, final output is schema-valid Verdict" {
+  RUN_ID="bats-$$-$(date +%s)"
+  before=$(wc -l < "$TEST_RUN_FILE" 2>/dev/null || echo 0)
+  run --separate-stderr "$RUNNER" feel-audit --target src/Button.tsx --run-id "$RUN_ID" --glance
+  [ "$status" -eq 0 ]
+
+  final_json="$output"
+  # Final output MUST be a valid Verdict row with the overridden run_id
+  echo "$final_json" | jq -e '.stream_type == "Verdict"' >/dev/null
+  echo "$final_json" | jq -e --arg id "$RUN_ID" '.run_id == $id' >/dev/null
+
+  # Validate against Verdict schema
+  run "$VALIDATOR" Verdict "$final_json"
+  [ "$status" -eq 0 ]
+
+  # Trajectory delta must be 6 (3 entry + 3 exit)
+  after=$(wc -l < "$TEST_RUN_FILE" 2>/dev/null || echo 0)
+  delta=$((after - before))
+  [ "$delta" -eq 6 ]
+
+  # Session IDs paired: each entry's session_id appears in the next exit
+  recent=$(tail -6 "$TEST_RUN_FILE")
+  entries=$(echo "$recent" | jq -r 'select(.event=="entry") | .session_id' | sort)
+  exits=$(echo "$recent"   | jq -r 'select(.event=="exit")  | .session_id' | sort)
+  [ "$entries" = "$exits" ]
+}
+
+@test "type-mismatch composition fails at exact stage with clear error" {
+  cat > "$TEST_COMPOSITIONS_DIR/broken.yaml" <<'YAML'
+name: broken
+chain:
+  - stage: 1
+    construct: artisan
+    skill: decomposing-feel
+    reads: [Artifact]
+    writes: [Signal]
+  - stage: 2
+    construct: observer
+    skill: analyzing-gaps
+    reads: [Verdict]
+    writes: [Verdict]
+inputs:
+  - type: Artifact
+    name: target
+YAML
+  run "$RUNNER" broken --dry-run --compositions-dir "$TEST_COMPOSITIONS_DIR"
+  [ "$status" -eq 2 ]
+  echo "$output" | grep -q "type mismatch at stage 2"
+  echo "$output" | grep -q "reads 'Verdict'"
+}
+
+@test "missing composition file exits 1 with legible error" {
+  run "$RUNNER" nonexistent --dry-run --compositions-dir "$TEST_COMPOSITIONS_DIR"
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "composition not found"
+}
+
+@test "orient read-mode prints per-stage timings to stderr" {
+  run bash -c "$RUNNER feel-audit --target t.tsx --orient 2>&1 >/dev/null"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "run_id="
+  echo "$output" | grep -q "stage 1:artisan/decomposing-feel"
+  echo "$output" | grep -q "stage 3:observer/analyzing-gaps"
+  echo "$output" | grep -q "final writes: Verdict"
+}
+
+@test "intervene read-mode emits structured JSON summary" {
+  run bash -c "$RUNNER feel-audit --target t.tsx --intervene 2>&1 >/dev/null"
+  [ "$status" -eq 0 ]
+  # Extract JSON from output — it's the trailing JSON block on stderr
+  # Grab the last JSON object from the output
+  json=$(printf '%s\n' "$output" | awk '/^{/,/^}$/' | tail -n +1)
+  echo "$json" | jq -e '.composition == "feel-audit"' >/dev/null
+  echo "$json" | jq -e '.stages | length == 3' >/dev/null
+  echo "$json" | jq -e '.final_type == "Verdict"' >/dev/null
+}


### PR DESCRIPTION
## Summary

Cycle-005 per [`cycle-005-SEED-runtime-integration.md`](grimoires/loa-constructs-seed-2026-04-21/cycle-005-SEED-runtime-integration.md). Closes the Q5 self-audit gap from cycle-004 — composition execution is no longer manual. `construct-compose feel-audit <target>` now executes all three stages end-to-end with paired trajectory rows, per-stage timings, and final-output schema validation.

**9 of 10 legs landed. 2 upstream PRs open (L3 construct-base, L5 Loa). L10 CONDITIONAL per SEED; deferred cleanly.**

## What shipped (in-repo)

| Leg | Deliverable | Commit |
|---|---|---|
| **L1** | `construct-compose.sh` runner — type-check + pipe chain + trajectory | `6b81f68` |
| **L2** | 5 stream schemas (Signal/Verdict/Artifact/Intent/Operator-Model) + `stream-validate.sh` | `6b81f68` |
| **L4** | `validating-construct-manifest` skill + `construct-validate.sh` + install/publish gates | `f9674b4` |
| **L6** | `butterfreezone-construct-gen.sh` — per-pack CONSTRUCT-README.md | `74386d5` |
| **L7** | `/constructs` polish — personas + streams in `constructs-list --orient`, `upgrade` visible in help, clearer auth error | `b4390d2` |
| **L8** | `tests/cycle-005-compose-runner.bats` — 6 tests, all green | `6b81f68` |
| **L9** | Doctrine v5 §17 — dispatch-det ≠ output-repro split, failure primitives, grimoires-as-interface | `ba14244` |
| **close** | `cycle-005-findings.md` — F30–F34, KANSEI gate, cycle-006 inheritance | `2824b66` |

## Upstream PRs (not admin-merged)

| Repo | Leg | PR | Governance |
|---|---|---|---|
| `0xHoneyJar/construct-base` | L3 template v3 — streams + persona handle + CONSTRUCT-README.md pattern | [#11](https://github.com/0xHoneyJar/construct-base/pull/11) | admin-merge OK per SEED §11 |
| `0xHoneyJar/loa` | L5 `--with-constructs` flag + `/loa-setup` Step 5 | [#615](https://github.com/0xHoneyJar/loa/pull/615) | **PR-only** — awaiting @janitooor review |

## Why

Cycle-004 closed with "composition execution is still manual" as the operator's Q5 self-audit. Running a feel-audit required 3 separate `Skill()` invocations. Cycle-005 ships the runner that wraps them.

Secondary pressure: integration research (2026-04-22) mapped a ~30% gap in consumer + author flows concentrated in five places — composition runner, schema validation, template freshness, Loa bundling, and construct-base not reflecting v3 conventions. Cycle-005 addresses all five.

## Risk

- **No breaking changes.** All new scripts (`construct-compose.sh`, `construct-validate.sh`, `butterfreezone-construct-gen.sh`, `stream-validate.sh`) are additive. Existing scripts gain optional hook points (install/publish validator calls) that default to advisory, not blocking.
- **Stream schemas additive-evolution.** All schemas declare `additionalProperties: true` and `schema_version: 1.0.0`. Future minor bumps must stay additive-compatible.
- **L4 validator is advisory by default** at install time. Set `LOA_STRICT_VALIDATION=1` to promote HIGH/CRITICAL findings to blocking aborts.
- **L1 runner uses stub stage executor.** Real LLM dispatch inside stages lands via `--executor` / `$LOA_COMPOSE_STAGE_EXECUTOR` in cycle-006+. The stub emits schema-valid placeholder rows so the pipe is observable end-to-end today.

## Findings surfaced (F30–F34)

See [`cycle-005-findings.md`](grimoires/loa-constructs-seed-2026-04-21/cycle-005-findings.md) §2 for detail. Highlights:

- **F32** · 27 of 29 installed packs have §12 grimoires drift in `CLAUDE.md` — tooling (L4 + L6) makes this tractable as a batch follow-up.
- **F33** · `construct-network-tools` pack doesn't exist yet — L5 ships the flag, operator picks the default slug in cycle-006.
- **F30/F31/F34** — housekeeping items deferred to cycle-006.

## Test plan

- [x] `bats tests/cycle-005-compose-runner.bats` — 6/6 green (dry-run, live 3-stage, type mismatch, missing composition, orient mode, intervene mode)
- [x] `stream-validate.sh` smoke against all 5 stream types
- [x] `construct-validate.sh` across 29 installed packs — finds real F28 and §12 drift without false positives
- [x] `butterfreezone-construct-gen.sh ~/.loa/constructs/packs/artisan --stdout` — idempotent (byte-identical re-runs)
- [x] `constructs-list --orient` shows personas + streams + ⚠ undeclared warning
- [x] `constructs-install.sh --help` advertises `upgrade <slug>` (AC-L7.2)
- [ ] Pending: operator KANSEI Q5 free-text answer (drives cycle-006 framing)

## Governance

Per [SEED §11](grimoires/loa-constructs-seed-2026-04-21/cycle-005-SEED-runtime-integration.md):
- `0xHoneyJar/loa-constructs` (this PR): operator-owned — admin-merge OK after review.
- `0xHoneyJar/construct-base`: admin-merge OK — sibling PR #11 linked above.
- `0xHoneyJar/loa`: **PR-only**, @janitooor review requested — sibling PR #615 linked above.

Cycle-005 does not gate on Jani-PR merge; if L5 takes longer than the cycle window, it carries to cycle-006 as an "in-flight" item.

## References

- SEED: [`cycle-005-SEED-runtime-integration.md`](grimoires/loa-constructs-seed-2026-04-21/cycle-005-SEED-runtime-integration.md)
- Findings: [`cycle-005-findings.md`](grimoires/loa-constructs-seed-2026-04-21/cycle-005-findings.md)
- Doctrine: [`bonfire-construct-pipe-doctrine.md`](grimoires/loa-constructs-seed-2026-04-21/bonfire-construct-pipe-doctrine.md) v5 §17

Closes AC-L1.1–L1.6, L2.1–L2.5, L4.1–L4.6, L6.1–L6.5, L7.1–L7.5, L8.1–L8.4, L9.1–L9.4. L3 + L5 closure pending upstream merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)