### PR TITLE
feat(schemas): composition.schema.json + validator integration

### DIFF
--- a/.claude/schemas/README.md
+++ b/.claude/schemas/README.md
@@ -14,6 +14,7 @@ These schemas provide structured output validation for Loa's agent system, ensur
 | `sdd.schema.json` | Software Design Document | `grimoires/loa/sdd.md` (YAML frontmatter) |
 | `sprint.schema.json` | Sprint Plan | `grimoires/loa/sprint.md` (YAML frontmatter) |
 | `trajectory-entry.schema.json` | Agent reasoning trace | `grimoires/loa/a2a/trajectory/*.jsonl` |
+| `composition.schema.json` | Runtime composition (workflow chain) | `grimoires/compositions/*.yaml` |
 
 ## Usage
 

--- a/.claude/schemas/composition.schema.json
+++ b/.claude/schemas/composition.schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://loa.dev/schemas/composition.schema.json",
+  "title": "Loa Composition",
+  "description": "Schema for grimoires/compositions/*.yaml — runtime expert chains executed by compose-run.sh. A composition declares which constructs collaborate on what, with declared streams + iteration boundaries. The shape emerges from naming what the workflow provides; the schema enforces consistency, not prescription.",
+  "type": "object",
+  "required": ["schema_version", "kind", "name", "description", "intent", "chain"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Composition schema version. Bump on breaking changes to this schema."
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["workflow", "frame"],
+      "description": "Composition kind. 'workflow' = runtime expert chain (current default, doctrine v4 §15.2). 'frame' = reserved for cycle-007+ frame-kind compositions."
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+      "minLength": 2,
+      "maxLength": 64,
+      "description": "Composition slug. Must match the filename (without .yaml extension). Kebab-case."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 20,
+      "description": "What this composition does, in one or two sentences. Lead with what it provides."
+    },
+    "intent": {
+      "type": "string",
+      "minLength": 30,
+      "description": "Operator-voice statement of the workflow's intent. The 'I want X out of this' framing in the operator's words."
+    },
+    "backend": {
+      "type": "string",
+      "enum": ["headless-tmux", "teamcreate"],
+      "description": "Runtime backend (doctrine v6 §18.4). 'headless-tmux' is cycle-006 default; 'teamcreate' ships in cycle-007."
+    },
+    "inputs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Input" },
+      "description": "Declared inputs the composition accepts. Operators bind these at invocation time."
+    },
+    "iterate": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "minItems": 2,
+        "maxItems": 2,
+        "items": { "type": "integer", "minimum": 1 },
+        "description": "Pair [stage_a, stage_b] of stage numbers that iterate together."
+      },
+      "description": "Iteration loops between pairs of stages. Each pair must reference stage numbers that exist in chain[].stage. Cap behavior is runner-controlled (--max-iterations)."
+    },
+    "chain": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/Stage" },
+      "description": "Ordered list of stages. Stage numbers must be 1-indexed and contiguous."
+    },
+    "outputs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Output" },
+      "description": "Declared outputs the composition produces. Destination paths typically use .run/compose/<run_id>/..."
+    },
+    "compose_with": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$" },
+      "description": "Construct slugs this composition orchestrates. Should match the unique set of chain[].construct values."
+    },
+    "composes_symmetrically_with": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": ".+ (↔|<->) .+",
+        "description": "Symmetric pair declaration in the form 'A ↔ B' or 'A <-> B'."
+      },
+      "description": "Confirmed symmetric construct/skill pairs surfaced by GECKO §2 or by operator validation."
+    },
+    "invocation_examples": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/InvocationExample" },
+      "description": "Example operator utterances and how they resolve to this composition (or sub-chains of it)."
+    },
+    "when_to_use": {
+      "type": "string",
+      "description": "Plain-prose guidance on when this composition is the right tool. May include WHEN-NOT-TO-USE bullets."
+    },
+    "known_limitations": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Surfaced limitations — cost, reproducibility, runner gaps, etc. Empty array discouraged; honest enumeration preferred."
+    },
+    "references": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "minProperties": 1,
+        "maxProperties": 1,
+        "additionalProperties": { "type": "string" },
+        "description": "Single-key reference entry. Keys are snake_case identifiers (e.g. 'doctrine', 'runner', 'exemplar_eye_hand'); values are paths or URLs."
+      },
+      "description": "Pointers to doctrine, runner scripts, exemplar compositions, related skills."
+    },
+    "operator_note": {
+      "type": "string",
+      "description": "Free-form note for downstream operators, especially when the composition serves as a teaching artifact. Use a YAML literal block scalar (|) for multi-line content."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "Composition revision number (strict semver X.Y.Z). Increment on substantive changes to chain, inputs, or outputs."
+    },
+    "authored_at": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO date (YYYY-MM-DD)."
+    },
+    "authored_by": {
+      "type": "string",
+      "description": "Who/what authored this composition. Free-form."
+    }
+  },
+  "$defs": {
+    "StreamType": {
+      "type": "string",
+      "enum": ["Signal", "Verdict", "Artifact", "Intent", "Operator-Model", "Question"],
+      "description": "Stream type per pipe doctrine. Question is reserved for cycle-007+."
+    },
+    "Mode": {
+      "type": "string",
+      "enum": ["fresh", "persistent"],
+      "description": "Stage execution mode. 'fresh' = clean subprocess per invocation (no prior context). 'persistent' = teammate accumulates register depth across iterations."
+    },
+    "Role": {
+      "type": "string",
+      "enum": ["primary", "craft-gate", "cross-reference", "cross_reference"],
+      "description": "Stage role. 'primary' = owns the substantive work. 'craft-gate' = validates against quality standard. 'cross-reference' = enriches a Verdict with second-construct context."
+    },
+    "Input": {
+      "type": "object",
+      "required": ["type", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "$ref": "#/$defs/StreamType" },
+        "name": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
+        "description": { "type": "string" },
+        "required": { "type": "boolean", "default": false },
+        "source": { "type": "string", "description": "Optional source hint (e.g., '/hivemind skill', 'operator argument')." }
+      }
+    },
+    "Output": {
+      "type": "object",
+      "required": ["type", "destination"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "$ref": "#/$defs/StreamType" },
+        "destination": { "type": "string", "description": "Path or path template. May contain <run_id> placeholder." },
+        "description": { "type": "string" },
+        "schema": { "type": "string", "description": "Optional JSON Schema path for output validation (e.g., .claude/schemas/feedback-v3.schema.json)." },
+        "notes": { "type": "string" }
+      }
+    },
+    "Stage": {
+      "type": "object",
+      "required": ["stage", "construct", "skill"],
+      "additionalProperties": false,
+      "properties": {
+        "stage": { "type": "integer", "minimum": 1, "description": "1-indexed stage number; must be contiguous within chain." },
+        "construct": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-/]*[a-z0-9]$", "description": "Construct slug (e.g. 'artisan', 'the-mint')." },
+        "skill": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$", "description": "Skill slug within the construct." },
+        "persona": { "type": "string", "pattern": "^[A-Z][A-Z_]*$", "description": "Optional persona handle (uppercase, e.g. 'ALEXANDER', 'MINT')." },
+        "mode": { "$ref": "#/$defs/Mode" },
+        "reads": { "type": "array", "items": { "$ref": "#/$defs/StreamType" } },
+        "writes": { "type": "array", "items": { "$ref": "#/$defs/StreamType" } },
+        "role": { "$ref": "#/$defs/Role" },
+        "iterates_with": { "type": "integer", "minimum": 1, "description": "Companion stage number for iteration. Must reference an entry in iterate[]." },
+        "iterate_until": { "type": "string", "description": "Termination predicate for the iteration loop (operator/runner-defined)." },
+        "notes": { "type": "string", "description": "What this stage does and why this expert was chosen." }
+      }
+    },
+    "InvocationExample": {
+      "type": "object",
+      "required": ["operator_utterance", "resolves_to"],
+      "additionalProperties": false,
+      "properties": {
+        "operator_utterance": { "type": "string", "description": "The natural-language way an operator might invoke this composition." },
+        "resolves_to": { "type": "string", "description": "What chain or sub-chain executes for this utterance." }
+      }
+    }
+  }
+}

--- a/.claude/scripts/schema-validator.sh
+++ b/.claude/scripts/schema-validator.sh
@@ -163,6 +163,9 @@ detect_schema() {
     elif [[ "$file_path" == *"grimoires/loa/sprint"* ]]; then
         echo "sprint"
         return 0
+    elif [[ "$file_path" == *"grimoires/compositions/"*.yaml ]] || [[ "$file_path" == *"compositions/"*.yaml ]]; then
+        echo "composition"
+        return 0
     fi
 
     # No match
@@ -517,6 +520,23 @@ run_assertions() {
         *.jsonl)
             head -1 "$file_path" > "$temp_json"
             ;;
+        *.yaml|*.yml)
+            # Convert YAML document to JSON for schema validation
+            if command -v yq >/dev/null 2>&1; then
+                yq eval -o=json '.' "$file_path" > "$temp_json" || {
+                    [[ "$json_output" == "true" ]] && echo '{"status":"error","message":"yq YAML→JSON conversion failed","assertions":[]}' || print_error "yq conversion failed for: $file_path"
+                    return 1
+                }
+            elif command -v python3 >/dev/null 2>&1; then
+                python3 -c 'import sys, yaml, json; json.dump(yaml.safe_load(open(sys.argv[1])), sys.stdout, default=str)' "$file_path" > "$temp_json" || {
+                    [[ "$json_output" == "true" ]] && echo '{"status":"error","message":"python YAML→JSON conversion failed","assertions":[]}' || print_error "python conversion failed for: $file_path"
+                    return 1
+                }
+            else
+                [[ "$json_output" == "true" ]] && echo '{"status":"error","message":"No YAML parser available (need yq or python3 with PyYAML)","assertions":[]}' || print_error "No YAML parser available"
+                return 1
+            fi
+            ;;
         *.md)
             if ! extract_frontmatter "$file_path" > "$temp_json"; then
                 if [[ "$json_output" == "true" ]]; then
@@ -714,6 +734,23 @@ validate_file() {
         *.jsonl)
             # Validate first line for trajectory entries
             head -1 "$file_path" > "$temp_json"
+            ;;
+        *.yaml|*.yml)
+            # Convert YAML document to JSON for schema validation
+            if command -v yq >/dev/null 2>&1; then
+                yq eval -o=json '.' "$file_path" > "$temp_json" || {
+                    [[ "$json_output" == "true" ]] && echo '{"status":"error","message":"yq YAML→JSON conversion failed","assertions":[]}' || print_error "yq conversion failed for: $file_path"
+                    return 1
+                }
+            elif command -v python3 >/dev/null 2>&1; then
+                python3 -c 'import sys, yaml, json; json.dump(yaml.safe_load(open(sys.argv[1])), sys.stdout, default=str)' "$file_path" > "$temp_json" || {
+                    [[ "$json_output" == "true" ]] && echo '{"status":"error","message":"python YAML→JSON conversion failed","assertions":[]}' || print_error "python conversion failed for: $file_path"
+                    return 1
+                }
+            else
+                [[ "$json_output" == "true" ]] && echo '{"status":"error","message":"No YAML parser available (need yq or python3 with PyYAML)","assertions":[]}' || print_error "No YAML parser available"
+                return 1
+            fi
             ;;
         *.md)
             if ! extract_frontmatter "$file_path" > "$temp_json"; then

--- a/grimoires/compositions/collection-with-codex.yaml
+++ b/grimoires/compositions/collection-with-codex.yaml
@@ -256,6 +256,6 @@ operator_note: |
   as TDRs (stage 5), knowledge graph materialized (stage 6 — same
   shape as mibera-codex's _codex/data/graph.json).
 
-version: 1.0
-authored_at: 2026-04-25
+version: "1.0.0"
+authored_at: "2026-04-25"
 authored_by: gumi composition (collection + codex export)

--- a/grimoires/compositions/feel-audit.yaml
+++ b/grimoires/compositions/feel-audit.yaml
@@ -77,9 +77,9 @@ outputs:
   - type: Signal
     destination: .run/construct-trajectory.jsonl
     description: Invocation trail for all three stages
-  - type: Artifact (derived)
+  - type: Artifact
     destination: optional — taste token file if inscribe stage added
-    description: Inscribed-taste token (cycle-005 L5-extension candidate)
+    description: Inscribed-taste token, derived (cycle-005 L5-extension candidate)
 
 compose_with:
   - artisan
@@ -116,6 +116,6 @@ references:
   - contract: grimoires/loa-constructs-seed-2026-04-21/cycle-004-L2-invocation-contract.md
   - predecessor: loa-constructs-cycle-001 .claude/constructs/compositions/feel-audit.yaml (folklore)
 
-version: 2.0
-authored_at: 2026-04-21
+version: "2.0.0"
+authored_at: "2026-04-21"
 authored_by: cycle-004 L5 (agent-walk)

--- a/grimoires/compositions/feel-image.yaml
+++ b/grimoires/compositions/feel-image.yaml
@@ -194,35 +194,37 @@ known_limitations:
 
 references:
   - gist: https://gist.github.com/zkSoju/98d96dcb72320bfc4d43e00a6fdaa245
-  - skills:
-    - construct-artisan/skills/directing-generation/SKILL.md
-    - construct-the-mint/skills/prompting-images/SKILL.md
-    - construct-the-mint/skills/curate/SKILL.md
-    - construct-the-mint/skills/materialize/SKILL.md
-  - companion compositions:
-    - grimoires/compositions/feel-audit.yaml          # artisan ↔ observer (audit pair)
-    - grimoires/compositions/website-scaffold.yaml    # k-hole → the-easel → mint → artisan → the-arcade (full stack)
-    - construct-creator/compositions/explore-ecosystem.yaml  # CURATOR ↔ artisan (wayfinding pair)
+  - skill_directing_generation: construct-artisan/skills/directing-generation/SKILL.md
+  - skill_prompting_images: construct-the-mint/skills/prompting-images/SKILL.md
+  - skill_curate: construct-the-mint/skills/curate/SKILL.md
+  - skill_materialize: construct-the-mint/skills/materialize/SKILL.md
+  - companion_audit_pair: grimoires/compositions/feel-audit.yaml
+  - companion_full_stack: grimoires/compositions/website-scaffold.yaml
+  - companion_wayfinding_pair: construct-creator/compositions/explore-ecosystem.yaml
   - doctrine: bonfire-construct-pipe-doctrine v6 §15.2 (workflow-kind composition)
-  - operator note (for gumi · 2026-04-25):
-      Compositions are *runtime expert chains* — stitched skill calls
-      from multiple constructs, with declared streams + iteration
-      loops. They're not the gen-art-tool surface; they're what
-      runs *underneath* a tool when the tool wants to invoke
-      "directed image production" as a single capability.
-      Gumi's tool is a SURFACE (Layer manager + preview + export).
-      The construct it exports could ship its own composition that
-      wraps feel-image — e.g. `<collection>-cover.yaml` chains
-      <collection>/directing-generation (canon distilled from
-      schema + lore) → the-mint/prompting-images (executes against
-      the layer-set's reference grid) → the-mint/curate (selection
-      against the rarity/swag rubric) → the-mint/materialize
-      (locks the cover with collection wordmark). The codex
-      pattern (mibera-codex shape — browse / query / cross-reference
-      over a knowledge graph) is the OTHER half of what her tool
-      exports — read-only data skills over the schema. Two halves,
-      one construct, both shippable.
 
-version: 1.0
-authored_at: 2026-04-25
+operator_note: |
+  For gumi · 2026-04-25.
+
+  Compositions are runtime expert chains — stitched skill calls from
+  multiple constructs, with declared streams + iteration loops.
+  They're not the gen-art-tool surface; they're what runs *underneath*
+  a tool when the tool wants to invoke "directed image production" as
+  a single capability.
+
+  Gumi's tool is a SURFACE (layer manager + preview + export). The
+  construct it exports could ship its own composition that wraps
+  feel-image — e.g. <collection>-cover.yaml chains
+  <collection>/directing-generation (canon distilled from schema + lore)
+  → the-mint/prompting-images (executes against the layer-set's reference
+  grid) → the-mint/curate (selection against rarity/swag rubric) →
+  the-mint/materialize (locks the cover with collection wordmark).
+
+  The codex pattern (mibera-codex shape — browse / query / cross-reference
+  over a knowledge graph) is the OTHER half of what her tool exports —
+  read-only data skills over the schema. Two halves, one construct, both
+  shippable. See also: collection-with-codex.yaml (the worked example).
+
+version: "1.0.0"
+authored_at: "2026-04-25"
 authored_by: cycle-004 reference composition (feel→image, gumi explainer)

--- a/grimoires/compositions/website-scaffold.yaml
+++ b/grimoires/compositions/website-scaffold.yaml
@@ -228,6 +228,6 @@ references:
   - runner: .claude/scripts/compose-run.sh (cycle-006 L-backend)
   - executor: .claude/scripts/stage-executor-tmux.sh (cycle-006 L-backend)
 
-version: 1.0
-authored_at: 2026-04-23
+version: "1.0.0"
+authored_at: "2026-04-23"
 authored_by: cycle-006 L-composition (operator + agent)


### PR DESCRIPTION
## Summary

Adds the missing JSON Schema for `grimoires/compositions/*.yaml`. Until now compositions were authored by convention with no formal validation — easy to drift on field naming, stream types, mode enums, and reference-block structure.

This PR closes the gap surfaced by the operator on 2026-04-25 ("is there an ideal schema for the composition, there should be").

## What's in the schema

| Field | Constraint |
|---|---|
| `schema_version` | const `"1.0"` |
| `kind` | enum `workflow` / `frame` (frame reserved) |
| `name` | kebab-case slug, must match filename |
| `description`, `intent` | required strings |
| `backend` | enum `headless-tmux` / `teamcreate` |
| `inputs[]` | `{type, name, description?, required?, source?}`; type ∈ stream enum |
| `iterate[]` | array of `[int, int]` stage-number pairs |
| `chain[]` | required; each stage has `stage`, `construct`, `skill`, optional `persona`, `mode` (`fresh` / `persistent`), `reads[]`, `writes[]`, `role` (`primary` / `craft-gate` / `cross-reference`), `iterates_with`, `notes` |
| `outputs[]` | `{type, destination, description?, schema?, notes?}` |
| `compose_with[]`, `composes_symmetrically_with[]` | declared collaboration |
| `invocation_examples[]` | `{operator_utterance, resolves_to}` |
| `when_to_use`, `known_limitations[]` | guidance |
| `references[]` | **single-key entries** (snake_case) — enforced for programmatic indexability |
| `operator_note` | top-level block scalar (not nested under references) |
| `version`, `authored_at`, `authored_by` | strict semver, ISO date string, free-form |

**Stream types**: `Signal | Verdict | Artifact | Intent | Operator-Model | Question` (Question reserved for cycle-007+).

## Validator integration

`schema-validator.sh`:
- `detect_schema()` routes `grimoires/compositions/*.yaml` → `composition`
- New `*.yaml | *.yml` case in the file-handler: YAML→JSON via `yq` (preferred) or `python3` fallback

```bash
.claude/scripts/schema-validator.sh validate grimoires/compositions/feel-audit.yaml
✓ Valid: grimoires/compositions/feel-audit.yaml (schema: composition)
```

## Existing compositions normalized

The schema sets the standard; the four shipped compositions needed minor cleanup to pass strict validation:

- **`feel-audit.yaml`**: `Artifact (derived)` → `Artifact` (parenthetical moved to description); `version`/`authored_at` quoted; `version` bumped `"2.0"` → `"2.0.0"` (strict semver)
- **`feel-image.yaml`**: references block flattened — `skills:` and `companion compositions:` multi-key entries split into single-key snake_case entries; operator note hoisted to top-level `operator_note: |` block scalar; version/date quoted; version → `"1.0.0"`
- **`website-scaffold.yaml`**: version/date quoted; version → `"1.0.0"`
- **`collection-with-codex.yaml`**: version/date quoted; version → `"1.0.0"`

## Test plan

- [x] All four shipped compositions validate clean against the new schema (smoke run via `python3 jsonschema.Draft202012Validator`)
- [x] `schema-validator.sh validate <yaml>` returns ✓ for each composition
- [x] YAML→JSON path uses `yq` (preferred) or `python3 + PyYAML` fallback; either works
- [x] Schema follows JSON Schema Draft 2020-12 (matches existing `construct.schema.json` style)
- [ ] Future: stream-validate.sh integration so `compose-run.sh` runs schema validation on the composition before dispatch (deferred — separate concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)