### PR TITLE
feat(schemas/composition): hivemind_labels — Hivemind Lab taxonomy as artifact-grounding contract

### DIFF
--- a/.claude/schemas/composition.schema.json
+++ b/.claude/schemas/composition.schema.json
@@ -109,6 +109,10 @@
       "type": "string",
       "description": "Free-form note for downstream operators, especially when the composition serves as a teaching artifact. Use a YAML literal block scalar (|) for multi-line content."
     },
+    "hivemind_labels": {
+      "$ref": "#/$defs/HivemindLabels",
+      "description": "Composition-level Hivemind Laboratory taxonomy. Names the user-truth context this whole workflow serves (product area + JTBD + source). Optional but encouraged — anti-spiral tether."
+    },
     "version": {
       "type": "string",
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
@@ -161,7 +165,66 @@
         "destination": { "type": "string", "description": "Path or path template. May contain <run_id> placeholder." },
         "description": { "type": "string" },
         "schema": { "type": "string", "description": "Optional JSON Schema path for output validation (e.g., .claude/schemas/feedback-v3.schema.json)." },
-        "notes": { "type": "string" }
+        "notes": { "type": "string" },
+        "hivemind_labels": {
+          "$ref": "#/$defs/HivemindLabels",
+          "description": "Per-output Hivemind Laboratory labels. Use to declare what KIND of artifact this output is (artifact_type) and how confident we are (learning_status). Composition-level labels in `hivemind_labels` apply by default; per-output overrides where needed."
+        }
+      }
+    },
+    "HivemindLabels": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Hivemind Laboratory taxonomy (CultureTech's experimentation framework, per Eileen Jun 2024). Anti-spiral tether — binds composition outputs to user truth so AI work doesn't drift from the problem it should serve.",
+      "properties": {
+        "artifact_type": {
+          "type": "string",
+          "enum": ["user-truth-canvas", "experiment-proposal", "atomic-learning", "product-spec"],
+          "description": "Hivemind Lab artifact category. user-truth-canvas = story of a user problem. experiment-proposal = the plan for testing. atomic-learning = a single reusable insight. product-spec = what + why of a feature."
+        },
+        "product_area": {
+          "type": "string",
+          "description": "Where in the product this work lives. Free-form per project (e.g., 'App Performance', 'Onboarding', 'Wallet Integration', 'Henlo Arcade')."
+        },
+        "jtbd": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Job-to-be-done. Why should users care?",
+          "properties": {
+            "category": {
+              "type": "string",
+              "enum": ["functional", "personal", "social"],
+              "description": "functional = perform an action. personal = internal feeling. social = outward expression."
+            },
+            "description": {
+              "type": "string",
+              "description": "The user job in plain language (e.g., 'Make a transaction', 'Gives me peace of mind', 'Help me look smart')."
+            }
+          },
+          "required": ["category", "description"]
+        },
+        "learning_status": {
+          "type": "string",
+          "enum": [
+            "strongly-validated",
+            "directionally-correct",
+            "cant-make-conclusion",
+            "hypothesis-failed",
+            "smol-evidence"
+          ],
+          "description": "How sure are we? strongly-validated = lots of quant+qual data. directionally-correct = supported by feedback, not data-proven. cant-make-conclusion = ambiguous. hypothesis-failed = clear evidence we were wrong. smol-evidence = single comment / tiny signal."
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "discord-twitter-dm-feedback",
+            "analytics-anomaly",
+            "team-ideas-brainstorm",
+            "support-ticket-trending",
+            "competitor-action"
+          ],
+          "description": "How do we know this matters?"
+        }
       }
     },
     "Stage": {


### PR DESCRIPTION
## Summary

Adds optional \`hivemind_labels\` to the composition schema — CultureTech's experimentation framework (per Eileen, Jun 2024) becomes a first-class composition concern. Compositions can now declare what user-truth their work serves.

**The anti-spiral tether**: AI work risks drifting from the problems it should serve. The Hivemind Lab taxonomy ties every artifact back to JTBD / product_area / source / learning_status — exactly the methodology that survived years of Eileen's process discipline.

## What landed

\`HivemindLabels\` \`\$def\` with five dimensions:

| Dimension | Values | Per Eileen |
|---|---|---|
| \`artifact_type\` | enum (4) | user-truth-canvas / experiment-proposal / atomic-learning / product-spec |
| \`product_area\` | string | Free-form per project |
| \`jtbd.{category, description}\` | enum + string | functional / personal / social |
| \`learning_status\` | enum (5) | strongly-validated → smol-evidence |
| \`source\` | enum (5) | discord-feedback → competitor-action |

Two attachment points:

- **Composition-level** (\`hivemind_labels\` at root) — names what the whole workflow serves
- **Per-output** (\`Output.hivemind_labels\`) — tags each emitted artifact (different outputs can be different artifact types — a triage Verdict is an Atomic Learning, the diff.patch is a Product Spec)

## Why now

Operator framing: 'these are Hivemind Laboratory labels — the place where we run experiments under CultureTech. this is the methodology which works for us.'

The schema is the bridge (per [\`contracts-as-bridges\`](https://github.com/0xHoneyJar/loa-constructs/blob/main/.claude/schemas/composition.schema.json)). Today it binds repos. Adding Hivemind metadata makes it bind work to user truth as well — same contract pattern, new dimension.

## Use case (Eileen's Step-6 magic moment)

When a composition produces an Atomic Learning, the output yaml declares it. When the next initiative searches the Library by JTBD or product_area, prior learnings surface — \"we found this learning, we remember it sucked, we start with a better idea.\"

## Test plan

- [x] Optional + additive — all four shipped compositions still validate (\`feel-audit\`, \`feel-image\`, \`website-scaffold\`, \`collection-with-codex\`)
- [x] First composition to wear the labels: \`tasteful-disable v1.3.0\` (lands as separate PR in loa-compositions)
- [x] yq parse + Draft 2020-12 validator pass
- [ ] Post-merge: enrich the four other shipped compositions with hivemind_labels where the user-truth tie is clear (deferred — compositions repo PR after this lands)

## References

- Eileen's Hivemind Laboratory doc (June 24 2024) — operator-shared this turn
- \`tasteful-disable.yaml\` v1.3.0 (loa-compositions) — first composition wearing labels
- contracts-as-bridges doctrine (operator hivemind) — the schema-as-contract pattern this extends

🤖 Generated with [Claude Code](https://claude.com/claude-code)