### PR TITLE
feat(schemas/composition): hivemind_labels — December 2025 canon (supersedes June)

### DIFF
--- a/.claude/schemas/composition.schema.json
+++ b/.claude/schemas/composition.schema.json
@@ -175,30 +175,52 @@
     "HivemindLabels": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Hivemind Laboratory taxonomy (CultureTech's experimentation framework, per Eileen Jun 2024). Anti-spiral tether — binds composition outputs to user truth so AI work doesn't drift from the problem it should serve.",
+      "description": "Hivemind Laboratory taxonomy (CultureTech's experimentation framework). Anti-spiral tether — binds composition outputs to user truth so AI work doesn't drift. Canonical: Eileen Dec 2025 'Linear Issue Label Taxonomy Guide' (supersedes Jun 2024 v1).",
       "properties": {
         "artifact_type": {
           "type": "string",
-          "enum": ["user-truth-canvas", "experiment-proposal", "atomic-learning", "product-spec"],
-          "description": "Hivemind Lab artifact category. user-truth-canvas = story of a user problem. experiment-proposal = the plan for testing. atomic-learning = a single reusable insight. product-spec = what + why of a feature."
+          "enum": [
+            "user-truth-canvas",
+            "experiment-design",
+            "atomic-learning",
+            "product-spec",
+            "bug-report",
+            "incident-postmortem",
+            "competitor-analysis",
+            "user-interview-synthesis",
+            "technical-rfc",
+            "launch-plan",
+            "meeting-notes"
+          ],
+          "description": "Hivemind Lab artifact category (11 types per Dec 2025 canon). atomic-learning is the most valuable artifact — a single, validated, reusable insight."
+        },
+        "workstream": {
+          "type": "string",
+          "enum": ["discovery", "delivery", "experimentation", "tech-debt", "sorry-for-ur-loss"],
+          "description": "What kind of work is this? discovery = understanding problem space. delivery = building production features. experimentation = minimal versions to test a hypothesis. tech-debt = refactor/upgrade. sorry-for-ur-loss = emergency, app on fire."
+        },
+        "priority": {
+          "type": "string",
+          "enum": ["urgent", "high", "medium", "low"],
+          "description": "How important right now? urgent = system down / all-hands. high = major feature broken, fix this sprint. medium = workaround exists. low = cosmetic."
         },
         "product_area": {
           "type": "string",
-          "description": "Where in the product this work lives. Free-form per project (e.g., 'App Performance', 'Onboarding', 'Wallet Integration', 'Henlo Arcade')."
+          "description": "Where in the product this lives. Free-form per project (e.g., 'Onboarding', 'Wallet Integration', 'NFT Minting Flow', 'Governance Dashboard', 'User Profile', 'Core App Performance', 'Design System', or project-specific like 'Henlo Arcade')."
         },
         "jtbd": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Job-to-be-done. Why should users care?",
+          "description": "Job-to-be-done. Why does the user care? The most important question we can answer.",
           "properties": {
             "category": {
               "type": "string",
               "enum": ["functional", "personal", "social"],
-              "description": "functional = perform an action. personal = internal feeling. social = outward expression."
+              "description": "functional = perform action (Make Transaction, Find Information, Organize Assets). personal = internal feeling (Reassure Me This Is Safe, Help Me Feel Smart, Give Me Peace of Mind, Reduce My Anxiety). social = outward expression (Help Me Look Smart Cool, Help Me Feel Like An Insider, Let Me Express My Identity)."
             },
             "description": {
               "type": "string",
-              "description": "The user job in plain language (e.g., 'Make a transaction', 'Gives me peace of mind', 'Help me look smart')."
+              "description": "The user job in plain language. Use Dec 2025 canonical phrasing where applicable."
             }
           },
           "required": ["category", "description"]
@@ -208,22 +230,21 @@
           "enum": [
             "strongly-validated",
             "directionally-correct",
-            "cant-make-conclusion",
             "hypothesis-failed",
-            "smol-evidence"
+            "smol-evidence",
+            "cant-make-a-conclusion"
           ],
-          "description": "How sure are we? strongly-validated = lots of quant+qual data. directionally-correct = supported by feedback, not data-proven. cant-make-conclusion = ambiguous. hypothesis-failed = clear evidence we were wrong. smol-evidence = single comment / tiny signal."
+          "description": "How sure are we? strongly-validated = quant+qual proof. directionally-correct = strong qual feedback, not data-proven. hypothesis-failed = clear evidence initial belief was wrong (valuable learning). smol-evidence = single comment. cant-make-a-conclusion = ambiguous evidence."
         },
         "source": {
           "type": "string",
           "enum": [
-            "discord-twitter-dm-feedback",
+            "team-internal",
+            "dm-to-team-member",
             "analytics-anomaly",
-            "team-ideas-brainstorm",
-            "support-ticket-trending",
-            "competitor-action"
+            "discord-support-or-feedback"
           ],
-          "description": "How do we know this matters?"
+          "description": "How do we know this matters? team-internal = internal team idea. dm-to-team-member = direct user/external conversation. analytics-anomaly = metrics. discord-support-or-feedback = community channels (consolidates June's discord+support). NOTE per Dec 2025: competitor signals moved from source to artifact_type (competitor-analysis)."
         }
       }
     },


### PR DESCRIPTION
## Summary

Updates \`HivemindLabels\` to reflect Eileen's December 2025 "Linear Issue Label Taxonomy Guide" — the canonical, mature version of CultureTech's Hivemind Laboratory framework. Supersedes the June 2024 schema landed in #207.

Operator confirms: "this is the methodology which works for us."

## Diff

| Group | June (was) | December (now) |
|---|---|---|
| **artifact_type** | 4 enum values | **11 enum values**. Added: bug-report, incident-postmortem, competitor-analysis, user-interview-synthesis, technical-rfc, launch-plan, meeting-notes. Renamed: experiment-proposal → experiment-design |
| **workstream** | — | **NEW group**: discovery / delivery / experimentation / tech-debt / sorry-for-ur-loss |
| **priority** | — | **NEW group**: urgent / high / medium / low |
| **product_area** | free-form | (unchanged; description expanded with Dec examples) |
| **jtbd** | 3 categories + freeform | Same shape; description block expanded with Dec's 10 canonical user jobs |
| **learning_status** | 5 values | 5 values. Wording shift: \`cant-make-conclusion\` → \`cant-make-a-conclusion\` |
| **source** | 5 values | **4 values**, restructured: removed support-ticket-trending (merged) + competitor-action (moved to artifact_type). Added dm-to-team-member. Renamed for Dec consistency. |

## Why now

The June canon was authored against the v1 doc (operator-shared earlier this session). Eileen sent the Dec doc minutes after merge. Updating in same session before the spec drifts. Only one composition currently consumes the labels (\`tasteful-disable\` v1.3) — updating in lockstep on the loa-compositions side.

## Test plan

- [x] All 4 shipped compositions in this repo still validate (none use hivemind_labels yet)
- [x] tasteful-disable v1.3 enums updated in lockstep (separate commit on loa-compositions)
- [x] Schema parses as Draft 2020-12
- [ ] Future compositions using June values (none currently exist outside tasteful-disable) will need migration — flagged in CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)