### PR TITLE
feat(compositions): all four shipped compositions wear Hivemind Lab labels (Dec 2025 canon)

### DIFF
--- a/grimoires/compositions/collection-with-codex.yaml
+++ b/grimoires/compositions/collection-with-codex.yaml
@@ -46,6 +46,18 @@ intent: >
 
 backend: headless-tmux
 
+# Hivemind Lab labels (Dec 2025 canon). Construct-emitter pattern —
+# generative collection + queryable codex. Serves end users (collection
+# holders, community) whose JTBD is identity expression through traits
+# + insider belonging through lore.
+hivemind_labels:
+  product_area: "NFT Minting Flow / Collection + Codex"
+  workstream: experimentation
+  jtbd:
+    category: social
+    description: "Let Me Express My Identity — traits, lore, and provenance let holders signal who they are in this world"
+  source: team-internal
+
 inputs:
   - type: Artifact
     name: references
@@ -180,15 +192,27 @@ outputs:
       Full asset bundle — per-trait renders, manifest.json,
       knowledge-graph nodes/edges, identity stubs, ready to ship
       as a construct repo.
+    hivemind_labels:
+      artifact_type: product-spec
+      learning_status: directionally-correct
   - type: Artifact
     destination: .run/compose/<run_id>/taste.md
     description: Synthesized canon (the visual constitution)
+    hivemind_labels:
+      artifact_type: product-spec
+      learning_status: strongly-validated
   - type: Artifact
     destination: .run/compose/<run_id>/tdrs/
     description: Locked rules as TDRs (forbidden / signature / swag)
+    hivemind_labels:
+      artifact_type: atomic-learning
+      learning_status: directionally-correct
   - type: Verdict
     destination: .run/compose/<run_id>/curation.jsonl
     description: Per-iteration selection trail
+    hivemind_labels:
+      artifact_type: atomic-learning
+      learning_status: directionally-correct
   - type: Signal
     destination: .run/compose/<run_id>/orchestrator.jsonl
 
@@ -256,6 +280,6 @@ operator_note: |
   as TDRs (stage 5), knowledge graph materialized (stage 6 — same
   shape as mibera-codex's _codex/data/graph.json).
 
-version: "1.0.0"
+version: "1.1.0"
 authored_at: "2026-04-25"
 authored_by: gumi composition (collection + codex export)

--- a/grimoires/compositions/feel-audit.yaml
+++ b/grimoires/compositions/feel-audit.yaml
@@ -22,6 +22,16 @@ intent: >
   compliance — produce an evidence-grounded Verdict that combines
   artisan's material decomposition with observer's cross-surface friction map."
 
+# Hivemind Lab labels (Dec 2025 canon). Audit work is discovery —
+# understanding what's broken before any solution is proposed.
+hivemind_labels:
+  product_area: "Design System"
+  workstream: discovery
+  jtbd:
+    category: personal
+    description: "Help Me Feel Smart — operator wants their craft validated against the canon"
+  source: team-internal
+
 inputs:
   - type: Artifact
     name: target
@@ -74,12 +84,18 @@ outputs:
     destination: .run/feedback-v3.jsonl
     schema: .claude/schemas/feedback-v3.schema.json
     description: Final feel-audit verdict with evidence chain
+    hivemind_labels:
+      artifact_type: atomic-learning
+      learning_status: directionally-correct
   - type: Signal
     destination: .run/construct-trajectory.jsonl
     description: Invocation trail for all three stages
   - type: Artifact
     destination: optional — taste token file if inscribe stage added
     description: Inscribed-taste token, derived (cycle-005 L5-extension candidate)
+    hivemind_labels:
+      artifact_type: product-spec
+      learning_status: directionally-correct
 
 compose_with:
   - artisan
@@ -116,6 +132,6 @@ references:
   - contract: grimoires/loa-constructs-seed-2026-04-21/cycle-004-L2-invocation-contract.md
   - predecessor: loa-constructs-cycle-001 .claude/constructs/compositions/feel-audit.yaml (folklore)
 
-version: "2.0.0"
+version: "2.1.0"
 authored_at: "2026-04-21"
 authored_by: cycle-004 L5 (agent-walk)

--- a/grimoires/compositions/feel-image.yaml
+++ b/grimoires/compositions/feel-image.yaml
@@ -37,6 +37,17 @@ intent: >
 
 backend: headless-tmux
 
+# Hivemind Lab labels (Dec 2025 canon). Site-art delivery serves the
+# end user's first impression of brand trust + craft. JTBD: brand
+# signals "this is real, has taste" → personal: Reassure Me This Is Safe.
+hivemind_labels:
+  product_area: "Marketing Site / Brand Surface"
+  workstream: delivery
+  jtbd:
+    category: personal
+    description: "Reassure Me This Is Safe — visual craft signals the brand is real, considered, trustworthy"
+  source: team-internal
+
 inputs:
   - type: Artifact
     name: canon
@@ -145,15 +156,24 @@ outputs:
   - type: Artifact
     destination: .run/compose/<run_id>/final-image.png
     description: Final composited site-art image with brand lockup
+    hivemind_labels:
+      artifact_type: product-spec
+      learning_status: strongly-validated
   - type: Artifact
     destination: .run/compose/<run_id>/direction-brief.md
     description: ALEXANDER's full creative direction (kept for the team — internal IP context preserved here, sanitized prompt stays in stage 2)
+    hivemind_labels:
+      artifact_type: experiment-design
+      learning_status: directionally-correct
   - type: Signal
     destination: .run/compose/<run_id>/orchestrator.jsonl
     description: Pipe graph + per-stage trajectory
   - type: Verdict
     destination: .run/compose/<run_id>/curation.jsonl
     description: Per-iteration kept/killed log with reasons (selection-test evidence chain)
+    hivemind_labels:
+      artifact_type: atomic-learning
+      learning_status: directionally-correct
 
 compose_with:
   - artisan
@@ -225,6 +245,6 @@ operator_note: |
   read-only data skills over the schema. Two halves, one construct, both
   shippable. See also: collection-with-codex.yaml (the worked example).
 
-version: "1.0.0"
+version: "1.1.0"
 authored_at: "2026-04-25"
 authored_by: cycle-004 reference composition (feel→image, gumi explainer)

--- a/grimoires/compositions/website-scaffold.yaml
+++ b/grimoires/compositions/website-scaffold.yaml
@@ -40,6 +40,19 @@ intent: >
 # via `--backend teamcreate` once cycle-007 ships that executor.
 backend: headless-tmux
 
+# Hivemind Lab labels (Dec 2025 canon). Full-stack site authoring
+# delivers production work for end users who arrive cold to a site.
+# JTBD: visitors landing for the first time need to find the why
+# (functional: Find Information) AND feel the brand is real
+# (personal: Reassure Me This Is Safe — could be either).
+hivemind_labels:
+  product_area: "New Site Build / Marketing Surface"
+  workstream: delivery
+  jtbd:
+    category: functional
+    description: "Find Information — visitor wants to learn what this is, why it matters, in under 10 seconds"
+  source: team-internal
+
 inputs:
   - type: Artifact
     name: target
@@ -180,6 +193,9 @@ outputs:
   - type: Artifact
     destination: .run/compose/<run_id>/final-product-structure.json
     description: Structured product specification — pages, nav, journey
+    hivemind_labels:
+      artifact_type: product-spec
+      learning_status: directionally-correct
   - type: Signal
     destination: .run/compose/<run_id>/orchestrator.jsonl
     description: Orchestrator trajectory (pipe graph + stream activity)
@@ -228,6 +244,6 @@ references:
   - runner: .claude/scripts/compose-run.sh (cycle-006 L-backend)
   - executor: .claude/scripts/stage-executor-tmux.sh (cycle-006 L-backend)
 
-version: "1.0.0"
+version: "1.1.0"
 authored_at: "2026-04-23"
 authored_by: cycle-006 L-composition (operator + agent)


### PR DESCRIPTION
## Summary

Every composition in \`grimoires/compositions/\` now carries Hivemind Laboratory labels per Eileen's Dec 2025 canon. Linear-era discipline applied to the registry — each artifact emitted by a composition declares its tie to user truth.

## What changed

| Composition | Version | product_area | workstream | jtbd |
|---|---|---|---|---|
| **feel-audit** | 2.0.0 → 2.1.0 | Design System | discovery | personal / Help Me Feel Smart |
| **feel-image** | 1.0.0 → 1.1.0 | Marketing Site / Brand Surface | delivery | personal / Reassure Me This Is Safe |
| **website-scaffold** | 1.0.0 → 1.1.0 | New Site Build / Marketing Surface | delivery | functional / Find Information |
| **collection-with-codex** | 1.0.0 → 1.1.0 | NFT Minting Flow / Collection + Codex | experimentation | social / Let Me Express My Identity |

All emit \`source: team-internal\` for now (operator-initiated work). Per-output labels declared where the artifact's nature differs (e.g., \`feel-image\` outputs three distinct types: \`product-spec\` for final image, \`experiment-design\` for direction brief, \`atomic-learning\` for curation log).

## The funnel

Every artifact emitted by any of these five compositions (plus \`tasteful-disable\` v1.3.1 in \`loa-compositions\`) now declares:

- artifact_type (one of 11 Dec-canon types)
- learning_status (5-level confidence)
- + composition-level product_area / workstream / jtbd / source for context

This is the Linear-era Library lookup mechanized: query by JTBD or product_area, prior atomic-learnings surface. Eileen's Step-6 magic moment becomes data infrastructure.

## Notes on JTBD interpretation

\`feel-audit\` and \`feel-image\` serve the operator's craft more than end users directly. JTBD descriptions reach toward the user-truth tie where it exists (visual craft → brand trust → safety; audit → operator competence → confidence to ship). Where the stretch is real, the description names it honestly rather than forcing a fit.

## Test plan

- [x] All 4 validate clean against composition.schema.json (Dec 2025 canon, just-merged)
- [x] Versions bumped (semver minor for additive metadata)
- [x] Composition-level + per-output labels both attached where distinguishing
- [ ] Future: add \`triage-and-validate\` composition that runs Eileen's six-step scenario end-to-end (deferred, separate cycle)

## References

- Eileen's "Linear Issue Label Taxonomy Guide" (Dec 2025)
- Schema: composition.schema.json (this repo, Dec canon merged in #208)
- Companion: \`tasteful-disable\` v1.3.1 in loa-compositions (already wears labels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)