### PR TITLE
feat(compositions): gRPC-style rename — strict verb-noun naming

### DIFF
--- a/.claude/schemas/composition.schema.json
+++ b/.claude/schemas/composition.schema.json
@@ -19,10 +19,10 @@
     },
     "name": {
       "type": "string",
-      "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$",
-      "minLength": 2,
+      "pattern": "^[a-z][a-z0-9]*-[a-z][a-z0-9]*$",
+      "minLength": 4,
       "maxLength": 64,
-      "description": "Composition slug. Must match the filename (without .yaml extension). Kebab-case."
+      "description": "Composition slug. Must match the filename (without .yaml extension). Strict verb-noun kebab-case (gRPC-style: 'verb-noun' reads as 'do this thing'). Examples: audit-feel, compose-art, scaffold-website, mint-collection, pause-feature, find-construct. The verb is the operator action; the noun is the target or output type."
     },
     "description": {
       "type": "string",

--- a/grimoires/compositions/audit-feel.yaml
+++ b/grimoires/compositions/audit-feel.yaml
@@ -12,7 +12,7 @@
 
 schema_version: "1.0"
 kind: workflow                        # doctrine v4 §15.2 (vs. frame-kind)
-name: feel-audit
+name: audit-feel
 description: >
   Surface material-quality issues during FEEL sessions using
   observer critique for audit depth.

--- a/grimoires/compositions/compose-art.yaml
+++ b/grimoires/compositions/compose-art.yaml
@@ -20,7 +20,7 @@
 
 schema_version: "1.0"
 kind: workflow
-name: feel-image
+name: compose-art
 description: >
   Eye-and-hand site-art production. Artisan distills creative
   direction from the codebase's visual canon; The Mint executes

--- a/grimoires/compositions/mint-collection.yaml
+++ b/grimoires/compositions/mint-collection.yaml
@@ -30,7 +30,7 @@
 
 schema_version: "1.0"
 kind: workflow
-name: collection-with-codex
+name: mint-collection
 description: >
   Generative art collection production with codex-shape construct
   export. Synthesizes taste from references, decomposes traits with

--- a/grimoires/compositions/scaffold-website.yaml
+++ b/grimoires/compositions/scaffold-website.yaml
@@ -23,7 +23,7 @@
 
 schema_version: "1.0"
 kind: workflow                          # doctrine v4 §15.2
-name: website-scaffold
+name: scaffold-website
 description: >
   Author-grade website scaffolding — from research to product
   structure. Seven stages, two iteration loops, one opinionated


### PR DESCRIPTION
Composition names = methods on a Compositions service. Operator invokes them like RPC: `compose-run audit-feel(target) -> Verdict`.

| Was | Now | Reads as |
|---|---|---|
| feel-audit | **audit-feel** | audit feel of X |
| feel-image | **compose-art** | compose art (from canon) |
| website-scaffold | **scaffold-website** | scaffold website |
| collection-with-codex | **mint-collection** | mint a collection (NFT canonical + the-mint does the work) |

Schema tightening: name pattern was permissive kebab; now strict `^[a-z][a-z0-9]*-[a-z][a-z0-9]*$` (exactly verb-noun, two parts). Mechanical enforcement.

Pattern names in SHAPES.md (audit-pair / eye-hand / etc.) stay noun-phrases — two layers, two rules. Patterns describe structure (the class); composition names describe work (the method).

Companion PRs:
- construct-creator: explore-ecosystem → find-construct + SHAPES.md exemplar links updated
- loa-compositions: tasteful-disable → pause-feature + README