### PR TITLE
feat(registry): register codex-review construct

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -26,6 +26,12 @@ constructs:
     category: analytics
     author: 0xHoneyJar
 
+  codex-review:
+    git_url: https://github.com/0xHoneyJar/construct-codex-review.git
+    description: "Lean adversarial code review for diffs via codex CLI — FAGAN persona, structured JSON findings, convergence loop"
+    category: engineering
+    author: 0xHoneyJar
+
   gecko:
     git_url: https://github.com/0xHoneyJar/construct-gecko.git
     description: "Ecosystem intelligence — patrol, observe, diagnose, report"


### PR DESCRIPTION
## Summary
- Adds `codex-review` to the public construct registry
- Repo: https://github.com/0xHoneyJar/construct-codex-review
- Persona: **FAGAN** (after Michael Fagan, formal code inspection — IBM 1976)

## What this construct does

Lean adversarial code review for unified diffs (and individual files). Single GPT pass via codex CLI, structured JSON findings with line-anchored `current_code` + `fixed_code` blocks, 3-iteration convergence cap. Default model `gpt-5.5`; override via `CODEX_REVIEW_MODEL`.

## Responsibility split from Flatline

This construct intentionally **does not overlap** with Flatline:

| Surface | Tool |
|---|---|
| PRD / SDD / Sprint planning | Flatline (multi-persona, scored arbitration) |
| Code diff after implementation | **codex-review** (single-persona, structured findings) |

See `grimoires/loa/specs/arch-codex-review.md` for the full architecture (was authored in this repo as the design artifact).

## Composition

Pairs with `codex-rescue` in [`code-implement-and-review`](https://github.com/0xHoneyJar/loa-compositions/blob/main/compositions/delivery/code-implement-and-review.yaml) (PR open against loa-compositions in parallel). Stage 1 implements; stage 2 FAGANs the diff; iterate 1↔2 until APPROVED or cap.

## Vendoring provenance

The construct vendors three libs from this repo at `df1c0304` (v2.35.0):
- `lib-codex-exec.sh` (unchanged)
- `lib-content.sh` (unchanged)
- `lib-security.sh` (config key renamed `flatline_protocol.secret_scanning.patterns` → `codex_review.secret_patterns` for decoupling; log prefix rebranded)

See `VENDOR.md` in the construct repo for the full pin + re-vendor procedure.

## Test plan
- [ ] `yq eval '.constructs."codex-review"' registry.yaml` returns the entry
- [ ] `npx constructs-cli install codex-review` resolves the git URL (after merge)
- [ ] No alphabetical ordering regression in `registry.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)