### PR TITLE
feat(seed): register codex-review in GIT_CONFIGS

### DIFF
--- a/scripts/seed-forge-packs.ts
+++ b/scripts/seed-forge-packs.ts
@@ -237,6 +237,10 @@ const GIT_CONFIGS: Record<string, { gitUrl: string; gitRef: string }> = {
     gitUrl: 'https://github.com/0xHoneyJar/construct-vocabulary-bank.git',
     gitRef: 'main',
   },
+  'codex-review': {
+    gitUrl: 'https://github.com/0xHoneyJar/construct-codex-review.git',
+    gitRef: 'main',
+  },
 };
 
 interface PackManifest {


### PR DESCRIPTION
## Summary
Adds `codex-review` to `scripts/seed-forge-packs.ts:GIT_CONFIGS` so the daily `sync-constructs.yml` workflow registers the construct in the production DB.

Construct repo: https://github.com/0xHoneyJar/construct-codex-review
Composition consuming it: 0xHoneyJar/loa-compositions#8 (merged)

## Why this PR (not registry.yaml)

PR #213 attempted the same registration via root `registry.yaml`. Closed after digging:
- Zero code reads root `registry.yaml` (verified via grep across `apps/`, `packages/`, `scripts/`, `.claude/`)
- Only 2 commits in its entire history (init + my closed PR)
- Created **after** `discover-constructs.ts` (one month earlier) — looks vestigial

`GIT_CONFIGS` in `scripts/seed-forge-packs.ts` is what `sync-constructs.yml` actually consumes (`bun scripts/seed-forge-packs.ts`). One-line add; daily 06:30 UTC sync picks it up.

## Broader context (separate decisions)

There are 12 other construct-* repos in `0xHoneyJar/` that are also missing from `GIT_CONFIGS`:

```
archivist, arneson, creator, daemon, freeside, gauntlet, gygax,
hivemind-os, kansei, noether, rosenzu, ruggy
```

The "right" fix per `docs/architecture/registry-ingest.md` is the cycle-008 work:
1. Install a PAT with `org:read` scope as a CI secret so `--auto-discover` works in `sync-constructs.yml`, OR
2. Wire the GitHub org webhook → `POST /v1/admin/ingest` flow

This PR is the narrow stop-gap for `codex-review`. Whether to bulk-add the other 12 (or fix the auto-discover gap properly) is a separate decision — flagging it so it doesn't get lost.

## Test plan
- [ ] After merge: tomorrow's `sync-constructs.yml` cron run (06:30 UTC) registers `codex-review`
- [ ] Or trigger manually: `gh workflow run sync-constructs.yml --repo 0xHoneyJar/loa-constructs -f only=codex-review`
- [ ] Verify at `https://api.constructs.network/v1/constructs/codex-review` returns the pack

🤖 Generated with [Claude Code](https://claude.com/claude-code)