### PR TITLE
schema(v1.2): catch up to registry reality — additive sweep

### DIFF
--- a/.claude/schemas/VERSIONING.md
+++ b/.claude/schemas/VERSIONING.md
@@ -104,7 +104,7 @@ Cross-repo consumers (e.g. `loa-compositions/.github/workflows/validate-schema.y
 
 | Schema | Current | Notes |
 |--------|---------|-------|
-| `composition.schema.json` | **1.1** | v1.1 added 2026-04-27: `surface_class`, `thinking_effort` (top-level + per-stage), `vocabulary_governance` (per-stage), `codex_mode` (per-stage). Cycle-002 followup, additive. Refactor 2026-04-27: HivemindLabels extracted to standalone schema and `$ref`'d. No version bump (consumer-facing shape unchanged). |
+| `composition.schema.json` | **1.2** | v1.1 added 2026-04-27: `surface_class`, `thinking_effort` (top-level + per-stage), `vocabulary_governance` (per-stage), `codex_mode` (per-stage). Refactor: HivemindLabels extracted to standalone schema. v1.2 (this entry) catches schema up to registry reality — adds 11 stage-level field shapes, output `emit_when`, top-level `changelog`/`depends_on`/`upstream_composition`, mode `blocking`, 4 new role enums, half-stage numbers, relaxed `name`/`persona`/`skill`/`composes_symmetrically_with`/`known_limitations`. All additive; v1.0/v1.1 YAMLs validate unchanged. |
 | `hivemind-labels.schema.json` | **1.0** | New 2026-04-27. Extracted from `composition.schema.json $defs/HivemindLabels` so it can be `$ref`'d by other schemas (prd/sdd/sprint/canvas types) and external consumers (Linear sync, dashboards, MCP wrappers) without dragging the composition schema graph behind it. |
 | `prd.schema.json` | (existing) | Pre-doctrine; no formal versioning yet. |
 | `sdd.schema.json` | (existing) | Pre-doctrine; no formal versioning yet. |
@@ -123,7 +123,8 @@ PRD/SDD/Sprint/Trajectory schemas adopt this policy on their next bump. Until th
 |---------|------|--------|-----------------|-----|
 | 1.0 | 2026-04-25 | Initial schema | — | #206 |
 | 1.1 | 2026-04-27 | Add `surface_class`, `thinking_effort`, `vocabulary_governance`, `codex_mode`. Hivemind labels deeply integrated (already in v1.0). | ✅ All v1.0 docs validate unchanged | #215 |
-| 1.1 (refactor) | 2026-04-27 | HivemindLabels extracted to standalone `hivemind-labels.schema.json` v1.0; composition references via external `$ref`. Consumer-facing shape unchanged — same fields, same enums. | ✅ All v1.0/v1.1 docs validate unchanged. ⚠ Offline consumers must now fetch both schemas. | (this PR) |
+| 1.1 (refactor) | 2026-04-27 | HivemindLabels extracted to standalone `hivemind-labels.schema.json` v1.0; composition references via external `$ref`. Consumer-facing shape unchanged — same fields, same enums. | ✅ All v1.0/v1.1 docs validate unchanged. ⚠ Offline consumers must now fetch both schemas. | #216 |
+| 1.2 | 2026-04-27 | Schema catches up to registry reality after strict ajv CI surfaced drift: stage `name`, `invokes`, `capture_method`, `brief_structure`, `transport_preference`, `verify_identifiers`, `when`, `on_absent`/`on_present_*`, `probes`; output `emit_when`; top-level `changelog`, `depends_on`, `upstream_composition`. Mode +`blocking`. Role +`dispatcher`/`engineering-handoff`/`gate`/`hard-stop`. Stage allows half-numbers (1.5, 6.5). `name` pattern widened to 5 parts. `skill` pattern allows colon (cross-construct refs like `codex:rescue`). `persona` pattern relaxed to free string. `composes_symmetrically_with` accepts unidirectional `→`. `known_limitations` accepts string OR array. | ✅ All 12 registry YAMLs validate; v1.0/v1.1 YAMLs validate unchanged. | (this PR) |
 
 ### hivemind-labels.schema.json
 

--- a/.claude/schemas/composition.schema.json
+++ b/.claude/schemas/composition.schema.json
@@ -9,8 +9,8 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "enum": ["1.0", "1.1"],
-      "description": "Composition schema version. Enum-locked for explicit audit trail (no pattern matching). v1.0 baseline. v1.1 adds optional cycle-002 followup fields (surface_class, thinking_effort, vocabulary_governance, codex_mode) — additive only; v1.0 YAMLs validate against v1.1 unchanged. Breaking changes require major bump + migration plan. See VERSIONING.md."
+      "enum": ["1.0", "1.1", "1.2"],
+      "description": "Composition schema version. Enum-locked for explicit audit trail (no pattern matching). v1.0 baseline. v1.1 adds optional cycle-002 followup fields (surface_class, thinking_effort, vocabulary_governance, codex_mode). v1.2 catches schema up to registry reality — adds optional stage shapes (name, invokes, capture_method, brief_structure, transport_preference, verify_identifiers, ground-canon predicates), output emit_when, top-level changelog/depends_on/upstream_composition, plus mode+blocking and role+dispatcher/engineering-handoff/gate/hard-stop enums. All additive; v1.0/v1.1 YAMLs validate unchanged. Breaking changes require major bump + migration plan. See VERSIONING.md."
     },
     "kind": {
       "type": "string",
@@ -19,10 +19,10 @@
     },
     "name": {
       "type": "string",
-      "pattern": "^[a-z][a-z0-9]*(-[a-z][a-z0-9]*){1,2}$",
+      "pattern": "^[a-z][a-z0-9]*(-[a-z][a-z0-9]*){1,4}$",
       "minLength": 4,
       "maxLength": 64,
-      "description": "Composition slug. Must match the filename (without .yaml extension). Verb-first kebab-case (gRPC-style: 'verb-noun' reads as 'do this thing'). 2-3 parts: 2-part for base compositions, 3-part for project specializations. Bases: audit-feel, direct-render, research-scaffold, mint-codex, triage-pause, find-construct. Specializations: direct-render-mibera, mint-codex-cubquest. The first word is always the operator action (verb-form); subsequent words refine target / approach / project context."
+      "description": "Composition slug. Must match the filename (without .yaml extension). Verb-first kebab-case (gRPC-style: 'verb-noun' reads as 'do this thing'). 2-5 parts (v1.2 widened from 2-3). Bases: audit-feel, direct-render, research-scaffold. Multi-part: code-implement-and-review (4 parts), listen-and-weave. The first word is always the operator action; subsequent words refine target / approach / project context."
     },
     "description": {
       "type": "string",
@@ -75,10 +75,10 @@
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": ".+ (↔|<->) .+",
-        "description": "Symmetric pair declaration in the form 'A ↔ B' or 'A <-> B'."
+        "pattern": ".+ (↔|<->|→|->) .+",
+        "description": "Composition pair declaration. v1.0/v1.1: symmetric only ('A ↔ B' / 'A <-> B'). v1.2: also accepts unidirectional ('A → B' / 'A -> B') for one-way composition (e.g. the-weaver → crucible)."
       },
-      "description": "Confirmed symmetric construct/skill pairs surfaced by GECKO §2 or by operator validation."
+      "description": "Confirmed construct/skill composition pairs surfaced by GECKO §2 or by operator validation. Symmetric (↔) or unidirectional (→)."
     },
     "invocation_examples": {
       "type": "array",
@@ -90,9 +90,11 @@
       "description": "Plain-prose guidance on when this composition is the right tool. May include WHEN-NOT-TO-USE bullets."
     },
     "known_limitations": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "Surfaced limitations — cost, reproducibility, runner gaps, etc. Empty array discouraged; honest enumeration preferred."
+      "oneOf": [
+        { "type": "array", "items": { "type": "string" } },
+        { "type": "string" }
+      ],
+      "description": "Surfaced limitations — cost, reproducibility, runner gaps, etc. v1.0/v1.1: array of strings. v1.2: also accepts a single multi-line string (YAML literal/folded block scalar) for prose-shaped limitations sections. Empty discouraged; honest enumeration preferred."
     },
     "references": {
       "type": "array",
@@ -134,6 +136,25 @@
     "authored_by": {
       "type": "string",
       "description": "Who/what authored this composition. Free-form."
+    },
+    "changelog": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "v1.2: Versioned change history for this composition. Each item is a single string in the form '<version> (<date>): <summary>'. Append-only; newest entries first or last by convention (registry convention: newest last)."
+    },
+    "depends_on": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "v1.2: External dependencies this composition relies on at runtime. Common keys: `constructs` (array of construct slugs), `tools` (array of CLI/MCP names), `compositions` (array of upstream composition paths). Permissive shape so new dependency types can be added.",
+      "properties": {
+        "constructs": { "type": "array", "items": { "type": "string" } },
+        "tools": { "type": "array", "items": { "type": "string" } },
+        "compositions": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "upstream_composition": {
+      "type": "string",
+      "description": "v1.2: Path to the canonical 'parent' composition this one specializes or extends. When a composition copies another's structure with minor variations, name the upstream so the lineage is legible."
     }
   },
   "$defs": {
@@ -144,13 +165,22 @@
     },
     "Mode": {
       "type": "string",
-      "enum": ["fresh", "persistent"],
-      "description": "Stage execution mode. 'fresh' = clean subprocess per invocation (no prior context). 'persistent' = teammate accumulates register depth across iterations."
+      "enum": ["fresh", "persistent", "blocking"],
+      "description": "Stage execution mode. 'fresh' = clean subprocess per invocation (no prior context). 'persistent' = teammate accumulates register depth across iterations. 'blocking' (v1.2) = stage halts the chain on emit, waits for explicit operator continuation (used in triage / sorry-for-ur-loss workstreams)."
     },
     "Role": {
       "type": "string",
-      "enum": ["primary", "craft-gate", "cross-reference", "cross_reference"],
-      "description": "Stage role. 'primary' = owns the substantive work. 'craft-gate' = validates against quality standard. 'cross-reference' = enriches a Verdict with second-construct context."
+      "enum": [
+        "primary",
+        "craft-gate",
+        "cross-reference",
+        "cross_reference",
+        "dispatcher",
+        "engineering-handoff",
+        "gate",
+        "hard-stop"
+      ],
+      "description": "Stage role. 'primary' = owns the substantive work. 'craft-gate' = validates against quality standard. 'cross-reference' = enriches a Verdict with second-construct context. v1.2 additions: 'dispatcher' = routes to downstream sub-compositions; 'engineering-handoff' = passes implementation work to a delegation-mode construct (codex/etc); 'gate' = generic gate stage (broader than craft-gate); 'hard-stop' = stage that terminates the chain when triggered."
     },
     "Input": {
       "type": "object",
@@ -174,6 +204,10 @@
         "description": { "type": "string" },
         "schema": { "type": "string", "description": "Optional JSON Schema path for output validation (e.g., .claude/schemas/feedback-v3.schema.json)." },
         "notes": { "type": "string" },
+        "emit_when": {
+          "type": "string",
+          "description": "v1.2: Conditional emission predicate. Output is only produced when this condition holds (e.g., 'stage 4 verdict.passed == true', 'on_chain_failure'). Free-form prose; runner-interpreted."
+        },
         "hivemind_labels": {
           "$ref": "https://loa.dev/schemas/hivemind-labels.schema.json",
           "description": "Per-output Hivemind Laboratory labels. Use to declare what KIND of artifact this output is (artifact_type) and how confident we are (learning_status). Composition-level labels in `hivemind_labels` apply by default; per-output overrides where needed."
@@ -182,13 +216,25 @@
     },
     "Stage": {
       "type": "object",
-      "required": ["stage", "construct", "skill"],
+      "required": ["stage", "construct"],
       "additionalProperties": false,
       "properties": {
-        "stage": { "type": "integer", "minimum": 1, "description": "1-indexed stage number; must be contiguous within chain." },
+        "stage": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Stage number. v1.0/v1.1: 1-indexed contiguous integers. v1.2: half-stages allowed (1.5, 6.5, etc.) for gate / craft-gate / cross-reference inserts between primary stages — runner sorts by value."
+        },
         "construct": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-/]*[a-z0-9]$", "description": "Construct slug (e.g. 'artisan', 'the-mint')." },
-        "skill": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$", "description": "Skill slug within the construct." },
-        "persona": { "type": "string", "pattern": "^[A-Z][A-Z_]*$", "description": "Optional persona handle (uppercase, e.g. 'ALEXANDER', 'MINT')." },
+        "skill": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9:_/-]*[a-z0-9]$",
+          "description": "Skill slug within the construct. v1.2: pattern allows ':' for cross-construct skill refs (e.g. 'codex:rescue'), '_' and '/' for namespaced skills. Optional in v1.2 — gate / hard-stop stages may omit skill (operator-driven, no skill dispatch)."
+        },
+        "persona": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional persona handle. v1.0/v1.1 convention: uppercase (e.g. 'ALEXANDER', 'MINT'). v1.2 relaxes to free-form string — registry has lowercase ('codex'), hyphenated ('CODEX-RESCUE'), and prose-tagged values."
+        },
         "mode": { "$ref": "#/$defs/Mode" },
         "reads": { "type": "array", "items": { "$ref": "#/$defs/StreamType" } },
         "writes": { "type": "array", "items": { "$ref": "#/$defs/StreamType" } },
@@ -210,6 +256,57 @@
             { "$ref": "#/$defs/ThinkingEffortBlock" }
           ],
           "description": "v1.1: Stage-level override. String tier (cheap, common) OR full canonical-def object (when this stage owns the family definition for the composition)."
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+          "description": "v1.2: Stage label. kebab-case verb-or-noun phrase (e.g. 'iterate-with-pixelmark', 'compose-canon-doc'). Optional but encouraged — gives stages a human-readable handle distinct from their construct/skill identity."
+        },
+        "invokes": {
+          "type": "string",
+          "description": "v1.2: Path to a sub-composition this stage delegates to (composition delegation pattern). Stage's construct/skill describe the dispatcher; invokes points at the delegated chain. Typically a path like 'compositions/delivery/feel-iterate.yaml'."
+        },
+        "capture_method": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "v1.2: Method by which this stage captures operator feedback / artifact / signal. Freeform object — common pattern is `{ preferred: { tool, loop, ... }, fallback: { tool, when, ... } }`. Permissive shape so the field can evolve without schema churn; conventional sub-keys (tool, loop, canonical_source, installation_pattern, port_acceptance) recur across the registry."
+        },
+        "brief_structure": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "v1.2: Ordered list of brief-shape lines (often with inline `# comment` annotations). Used by skills that author briefs as their primary artifact (e.g. compose-canon-doc, dispatch). Each item is a brief field name; the comment after `#` explains its semantics."
+        },
+        "transport_preference": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "v1.2: Preferred tool / transport for invoking this stage, ordered by preference (with fallbacks). Each item may include an inline `# comment` explaining the preference. Common in stages that wrap external CLIs (codex, mcp tools) where multiple invocation paths exist."
+        },
+        "verify_identifiers": {
+          "type": "string",
+          "description": "v1.2: Multi-line verification protocol. Prose describing how this stage probes operator-supplied identifiers (URLs, deployment IDs, commits) before propagating them. Used in dispatch/cross-reference stages to prevent garbage-in-garbage-out."
+        },
+        "when": {
+          "type": "string",
+          "description": "v1.2: Predicate / condition under which this stage runs. Used in conditional / gate stages (ground-canon, on-demand cross-reference). Free-form prose; runner interprets per-composition."
+        },
+        "on_absent": {
+          "type": "array",
+          "items": { "oneOf": [ { "type": "string" }, { "type": "object" } ] },
+          "description": "v1.2: Ground-canon stage shape — actions when probed canon source is absent. Items are either action strings OR `{<choice-label>: <description>}` objects for operator-halt branching."
+        },
+        "on_present_and_fresh": {
+          "type": "array",
+          "items": { "oneOf": [ { "type": "string" }, { "type": "object" } ] },
+          "description": "v1.2: Ground-canon stage shape — actions when probed canon is present and fresh (within freshness window)."
+        },
+        "on_present_but_stale": {
+          "type": "array",
+          "items": { "oneOf": [ { "type": "string" }, { "type": "object" } ] },
+          "description": "v1.2: Ground-canon stage shape — actions when probed canon is present but stale (outside freshness window)."
+        },
+        "probes": {
+          "type": "array",
+          "description": "v1.2: Ground-canon stage shape — list of probe definitions. Items vary in shape (path probes, command probes, file-existence probes); permissive."
         }
       }
     },
@@ -244,7 +341,11 @@
         "rationale": { "type": "string" },
         "runtime_translation": { "type": "object" },
         "promptable_steering": { "type": "string" },
-        "affects_in_this_composition": { "type": "array", "items": { "type": "string" } }
+        "affects_in_this_composition": {
+          "type": "array",
+          "items": { "oneOf": [ { "type": "string" }, { "type": "object" } ] },
+          "description": "v1.2: items are stage-effect descriptions; usually strings, occasionally objects when an unquoted colon-bearing prose value gets parsed as a key-value pair."
+        }
       }
     },
     "VocabularyGovernance": {


### PR DESCRIPTION
## Summary

Strict ajv CI surfaced 7/12 registry YAMLs using fields the schema didn't sanction. Per the [schema-as-bridges doctrine](https://github.com/zkSoju/hivemind/blob/main/wiki/concepts/composition-schema-as-bridge.md), the schema follows the registry — bumps to v1.2 to absorb the observed patterns.

All additive. v1.0/v1.1 YAMLs validate unchanged. After this bump: **12/12 registry YAMLs pass strict ajv validation**.

## Why this is the right doctrine

> *"Engine reads schema, doesn't own its evolution. When loa-compositions PRs add new YAML shapes, the schema in loa-constructs catches up via PR; the schema is the consensus contract, not unilateral."* — `arch-composition-schema-sync.md`

Compositions encode culture (workflows that survived shipping). When their shape evolves, the schema's job is to absorb it so the bridge keeps holding. The alternative — forcing 12 culture-tested YAMLs to conform to an undershipped schema — would damage the moat for no engineering gain.

## Changes

### Stage shape additions (11 fields)

| Field | Why |
|---|---|
| `name` | kebab-case stage label (e.g. `iterate-with-pixelmark`) — common across registry |
| `invokes` | sub-composition delegation (`compositions/delivery/feel-iterate.yaml`) |
| `capture_method` | operator-feedback capture spec (preferred + fallback shapes); permissive `additionalProperties: true` |
| `brief_structure` | ordered list of brief field names with inline comments |
| `transport_preference` | preferred CLI/MCP order with fallbacks |
| `verify_identifiers` | multi-line probe protocol prose |
| `when` | gate predicate |
| `on_absent` / `on_present_and_fresh` / `on_present_but_stale` | ground-canon stage actions (items: string OR object) |
| `probes` | freeform probe defs |

### Output addition

- `emit_when` — conditional emission predicate

### Top-level additions

- `changelog` — array of `"version (date): summary"` strings
- `depends_on` — `{ constructs, tools, compositions }` object
- `upstream_composition` — parent composition path

### Enum extensions

- `mode` + `"blocking"` (triage / sorry-for-ur-loss workstreams)
- `role` + `"dispatcher"`, `"engineering-handoff"`, `"gate"`, `"hard-stop"`

### Pattern relaxations (registry has these in the wild)

| Field | v1.0/v1.1 | v1.2 |
|---|---|---|
| `stage` | integer | number (half-stages 1.5, 6.5 for gate inserts) |
| `name` (composition) | 2-3 parts | 2-5 parts (e.g. `code-implement-and-review`) |
| `skill` (stage) | kebab-only, required | allow `:` for cross-construct refs (`codex:rescue`), `_`/`/` for namespaced; **optional** in v1.2 (gate stages may omit) |
| `persona` | pattern `^[A-Z][A-Z_]*$` | pattern dropped (registry has lowercase, hyphenated, prose) |
| `composes_symmetrically_with` items | `↔` / `<->` only | also `→` / `->` for unidirectional |
| `known_limitations` | array of strings | array OR single string (YAML literal blocks) |
| `thinking_effort.affects_in_this_composition` items | string | string OR object (handles unquoted-colon parse-as-object case) |

## Test plan

- [x] `jq empty` — schema is valid JSON
- [x] All 12 `loa-compositions/compositions/**/*.yaml` validate strict (12/12 pass) under bun + ajv 2020-12
- [x] `audit-feel.yaml` reference composition still passes
- [x] `schema_version` enum updated to `["1.0", "1.1", "1.2"]`
- [x] VERSIONING.md changelog appended

## Backward compat

✅ All v1.0/v1.1 YAMLs validate unchanged. All additions are optional or pattern relaxations. No required fields added; one (`skill`) was made optional.

## What's next

This unblocks the [loa-compositions cross-repo CI PR](https://github.com/0xHoneyJar/loa-compositions) — strict ajv validation lands as a blocking gate (not advisory) once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)