### PR TITLE
chore(wip): operator skills + composition drafts + cycle tracks + arch specs

### DIFF
--- a/.claude/skills/confidence-decay
+++ b/.claude/skills/confidence-decay
@@ -1,0 +1,1 @@
+../constructs/packs/archivist/skills/confidence-decay

--- a/.claude/skills/crystallizing
+++ b/.claude/skills/crystallizing
@@ -1,0 +1,1 @@
+../constructs/packs/archivist/skills/crystallizing

--- a/.claude/skills/ingesting
+++ b/.claude/skills/ingesting
@@ -1,0 +1,1 @@
+../constructs/packs/archivist/skills/ingesting

--- a/.claude/skills/semantic-synthesis
+++ b/.claude/skills/semantic-synthesis
@@ -1,0 +1,1 @@
+../constructs/packs/archivist/skills/semantic-synthesis

--- a/.claude/skills/supersede
+++ b/.claude/skills/supersede
@@ -1,0 +1,1 @@
+../constructs/packs/archivist/skills/supersede

--- a/grimoires/compositions/collection-with-codex.yaml
+++ b/grimoires/compositions/collection-with-codex.yaml
@@ -1,0 +1,258 @@
+# Composition · collection-with-codex
+# ================================================================
+# Six-stage workflow that produces a generative art collection
+# AND the publishable codex-shape construct that ships alongside
+# it. Composes artisan + the-mint to handle taste extraction,
+# trait distillation, batch generation, curation, rule-locking,
+# and codex materialization.
+#
+# Authored as a worked example for operators building tools that
+# scaffold publishable construct repos as users iterate (e.g.
+# gen-art collection preview tools — gumi's case, 2026-04-25).
+#
+# What the workflow provides:
+#
+#   For the operator (running it):
+#     - A coherent collection (single-stamp + shelf test holds)
+#     - A trait taxonomy with declared signal hierarchy
+#       (load-bearing / textural / modifiers — mibera-codex shape)
+#     - TDRs locking forbidden / signature combinations + swag
+#       scoring formula
+#     - An exportable codex shell ready to publish as a construct
+#
+#   For the end user (collection holder, community):
+#     - A collection that's visually + lore-wise coherent
+#     - A queryable codex (per-trait lore, cross-reference, swag
+#       scoring) — not just images
+#
+# Authored: 2026-04-25
+# ================================================================
+
+schema_version: "1.0"
+kind: workflow
+name: collection-with-codex
+description: >
+  Generative art collection production with codex-shape construct
+  export. Synthesizes taste from references, decomposes traits with
+  signal hierarchy, batch-generates, curates against discipline,
+  locks rules as TDRs, materializes the result as a publishable
+  construct repo.
+
+intent: >
+  "Given a moodboard, a layer brief, and (optionally) an existing
+   visual canon, produce a coherent collection AND a publishable
+   codex-shape construct that exposes per-trait lore, taxonomy,
+   and swag scoring as queryable read-only skills."
+
+backend: headless-tmux
+
+inputs:
+  - type: Artifact
+    name: references
+    description: Moodboard / reference art / existing brand assets
+    required: true
+  - type: Intent
+    name: layer_brief
+    description: >
+      Trait dimensions (visual + non-visual), lore axes, target
+      rarity distribution, signal-hierarchy intent (which traits
+      are load-bearing vs textural vs modifiers).
+    required: true
+  - type: Artifact
+    name: canon
+    description: Existing taste.md / TDRs / persona docs (optional)
+    required: false
+  - type: Operator-Model
+    name: operator_context
+    required: false
+
+# Two iteration loops:
+#   [3, 4] — generate ↔ curate (the live preview loop in the tool)
+#   [2, 5] — taxonomy ↔ TDRs (rules sharpen as taxonomy refines)
+iterate:
+  - [3, 4]
+  - [2, 5]
+
+chain:
+  # ------------------------------------------------------------------
+  - stage: 1
+    construct: artisan
+    skill: synthesizing-taste
+    persona: ALEXANDER
+    mode: fresh
+    reads: [Artifact]
+    writes: [Artifact]
+    role: primary
+    notes: >
+      Extract the visual canon from references — palette tokens
+      (OKLCH), motion language, named treatments, anti-patterns.
+      Outputs taste.md that grounds every downstream stage. If the
+      operator passed an existing canon, this stage refines rather
+      than replaces.
+
+  # ------------------------------------------------------------------
+  - stage: 2
+    construct: artisan
+    skill: distilling-components
+    persona: ALEXANDER
+    mode: persistent
+    reads: [Intent, Artifact]
+    writes: [Artifact]
+    role: primary
+    iterates_with: 5
+    notes: >
+      Turn the brief into a trait taxonomy with signal hierarchy —
+      load-bearing (worldview-defining) / textural (color
+      expression) / modifiers (presence, charisma). Same hierarchy
+      shape as mibera-codex. Persistent so taxonomy refines as TDRs
+      land in stage 5.
+
+  # ------------------------------------------------------------------
+  - stage: 3
+    construct: the-mint
+    skill: mint
+    persona: MINT
+    mode: persistent
+    reads: [Artifact]
+    writes: [Artifact]
+    role: primary
+    iterates_with: 4
+    notes: >
+      Batch generate per-trait reference renders. This is the
+      live-preview loop in the operator's tool — each iteration
+      regenerates the candidate trait set against the current
+      taste + taxonomy. Use LOA_STAGE_MOCK=1 for dev iteration
+      before paying for real generation.
+
+  # ------------------------------------------------------------------
+  - stage: 4
+    construct: the-mint
+    skill: curate
+    persona: MINT
+    mode: fresh
+    reads: [Artifact]
+    writes: [Verdict, Signal]
+    role: craft-gate
+    iterates_with: 3
+    notes: >
+      Selection test against rarity discipline, single-stamp, and
+      shelf-test family resemblance. Kills traits that don't
+      survive; loops back to stage 3 if too many fail. The
+      Verdict carries kept/killed evidence per trait.
+
+  # ------------------------------------------------------------------
+  - stage: 5
+    construct: artisan
+    skill: recording-taste
+    persona: ALEXANDER
+    mode: fresh
+    reads: [Verdict, Artifact]
+    writes: [Artifact]
+    role: primary
+    iterates_with: 2
+    notes: >
+      Lock the rules as TDRs — forbidden combinations, signature
+      combos, swag scoring formula. These become first-class
+      entries in the exported codex's lore layer. Loops back to
+      stage 2 when a TDR contradicts the current taxonomy.
+
+  # ------------------------------------------------------------------
+  - stage: 6
+    construct: the-mint
+    skill: materialize
+    persona: MINT
+    mode: fresh
+    reads: [Artifact, Verdict]
+    writes: [Artifact]
+    role: primary
+    notes: >
+      Produce the exportable codex shell. Per-trait final assets
+      composited, manifest.json written, knowledge-graph
+      nodes/edges generated, identity/persona.yaml stubbed. Output
+      is a mibera-codex-shaped construct repo — read-only skills
+      (browse / query / cross-reference) over the manifest. This
+      is what the operator's tool ships as "export construct."
+
+outputs:
+  - type: Artifact
+    destination: .run/compose/<run_id>/collection/
+    description: >
+      Full asset bundle — per-trait renders, manifest.json,
+      knowledge-graph nodes/edges, identity stubs, ready to ship
+      as a construct repo.
+  - type: Artifact
+    destination: .run/compose/<run_id>/taste.md
+    description: Synthesized canon (the visual constitution)
+  - type: Artifact
+    destination: .run/compose/<run_id>/tdrs/
+    description: Locked rules as TDRs (forbidden / signature / swag)
+  - type: Verdict
+    destination: .run/compose/<run_id>/curation.jsonl
+    description: Per-iteration selection trail
+  - type: Signal
+    destination: .run/compose/<run_id>/orchestrator.jsonl
+
+compose_with:
+  - artisan
+  - the-mint
+
+composes_symmetrically_with:
+  - artisan ↔ the-mint
+  - the-mint/mint ↔ the-mint/curate
+
+invocation_examples:
+  - operator_utterance: "ship a 1k generative collection from this moodboard"
+    resolves_to: full 6-stage pipeline end-to-end
+  - operator_utterance: "preview my layer set at 50 candidates"
+    resolves_to: stages 3-4 in mock mode, 50 renders per iteration
+  - operator_utterance: "export the codex from current state"
+    resolves_to: stage 6 only — emit manifest + skills + identity stubs
+  - operator_utterance: "lock the rules I just settled on"
+    resolves_to: stage 5 — TDR pass, no regeneration
+
+when_to_use: >
+  - Operator has references + layer brief and wants both a
+    coherent collection AND a queryable codex layer
+  - Building tools that scaffold publishable constructs as the
+    operator iterates (gen-art collection preview tools, lore
+    authoring surfaces, character pipelines)
+  - Iterating a collection in public — clients see live previews
+    via stages 3-4 in mock mode, real generation only on commit
+
+known_limitations:
+  - "Stage 6 emits a CODEX-SHAPED construct (mibera-codex pattern). For other construct shapes (skill-pack, agent, tool), this composition is the wrong starting point — see SHAPES.md."
+  - "Rarity discipline (stage 4) is rule-based; can't catch a distribution that satisfies named rules but feels wrong. Operator-in-the-loop closes the gap."
+  - "Image generation cost is real. Stage 3 default is 50 candidates per pass; --max-iterations caps the loop. Use mock mode for dev, real generation only on ship."
+  - "Stage 1 quality is bounded by reference quality. Garbage moodboard → garbage taste → underspecified everything downstream."
+
+references:
+  - exemplar (eye-hand pair): grimoires/compositions/feel-image.yaml
+  - exemplar (codex shape): https://github.com/0xHoneyJar/construct-mibera-codex
+  - skills:
+    - construct-artisan/skills/synthesizing-taste/SKILL.md
+    - construct-artisan/skills/distilling-components/SKILL.md
+    - construct-artisan/skills/recording-taste/SKILL.md
+    - construct-the-mint/skills/mint/SKILL.md
+    - construct-the-mint/skills/curate/SKILL.md
+    - construct-the-mint/skills/materialize/SKILL.md
+  - operator_note: |
+      For gumi · 2026-04-25
+      Your tool's surfaces map to composition stages directly:
+        - preview surface       = stages 3 ↔ 4 running live, mock mode
+        - "save" action         = advance to stage 5 (TDRs lock)
+        - "export construct"    = stage 6 emits a mibera-codex-shaped pack
+      Your work overlaps with the artisan + the-mint skillsets around
+      design / art / craft, which means you don't have to reinvent
+      the feedback mechanisms (single-stamp discipline, shelf test,
+      eye/hand split, selection-test loop) — they're already authored
+      as skills. What you're building is the WEB GUI on top of this
+      pipeline plus the codex-export packaging; the philosophical
+      rails come for free by composing existing constructs.
+      The "lore alongside the art" idea you mentioned is what stages
+      2 + 5 + 6 cover: signal hierarchy declared (stage 2), rules
+      locked as TDRs (stage 5), knowledge graph materialized
+      (stage 6 — same shape as mibera-codex's _codex/data/graph.json).
+
+version: "1.0.0"
+authored_at: "2026-04-25"
+authored_by: gumi composition (collection + codex export)

--- a/grimoires/compositions/feel-image.yaml
+++ b/grimoires/compositions/feel-image.yaml
@@ -1,0 +1,228 @@
+# Composition · feel-image
+# ================================================================
+# Two-construct image production chain. The eye distills creative
+# direction from a codebase's existing FEEL canon; the hand executes
+# reference-based prompts against Images 2.0 with built-in
+# selection discipline; brand marks composite locally.
+#
+# This is the worked example from the operator's gist:
+#   https://gist.github.com/zkSoju/98d96dcb72320bfc4d43e00a6fdaa245
+# Loa ecosystem banner session (2026-04-22) → distilled here as a
+# runnable composition that anyone authoring image-producing
+# constructs can study + invoke.
+#
+# Reads as the canonical artisan ↔ the-mint pair, in the same shape
+# as feel-audit (artisan ↔ observer) and explore-ecosystem
+# (construct-network-tools ↔ artisan).
+#
+# Authored: 2026-04-25
+# ================================================================
+
+schema_version: "1.0"
+kind: workflow
+name: feel-image
+description: >
+  Eye-and-hand site-art production. Artisan distills creative
+  direction from the codebase's visual canon; The Mint executes
+  reference-based Images 2.0 prompts; brand marks composite
+  locally. Single canonical chain for "make me art that belongs
+  in this world."
+
+intent: >
+  "Given a codebase with an established visual canon (taste tokens,
+   TDRs, persona files, reference art) and a brief for a new piece
+   of site art, produce a render that lands inside the canon — not
+   a generic stock image, not a vibes prompt. Eye first, hand
+   second, composite last."
+
+backend: headless-tmux
+
+inputs:
+  - type: Artifact
+    name: canon
+    description: >
+      Path to the codebase's design canon — taste.md, tokens.css,
+      TDRs, identity/ persona files, existing reference art. The
+      source material ALEXANDER reads to extract material vocabulary.
+    required: true
+  - type: Intent
+    name: brief
+    description: >
+      What's the piece for? Hero banner, scene-stack member, card
+      illustration, README art? Where does it land? What's the
+      single-most-important visual element?
+    required: true
+  - type: Artifact
+    name: refs
+    description: >
+      Reference images for the model — composition anchor, palette
+      anchor, optional edit target. See prompting-images SKILL.md
+      for the role table.
+    required: false
+  - type: Operator-Model
+    name: operator_context
+    description: Operator expertise + mode (from /hivemind)
+    required: false
+
+# Iteration loop — stages 2 ↔ 3 cycle until a render passes the
+# selection test, capped by --max-iterations (default 3). Cost
+# discipline: every generation is billed; sharp brief beats volume.
+iterate:
+  - [2, 3]   # prompt → curate (regenerate on selection-test failure)
+
+chain:
+  # ------------------------------------------------------------------
+  - stage: 1
+    construct: artisan
+    skill: directing-generation
+    persona: ALEXANDER
+    mode: persistent
+    reads: [Artifact, Intent, Operator-Model]
+    writes: [Signal, Artifact]
+    role: primary
+    notes: >
+      ALEXANDER reads the canon (taste.md, TDRs, persona docs,
+      reference art) and produces a creative direction brief —
+      OKLCH palette block, named treatments, single-stamp discipline,
+      sanitization map, scene/architectural mapping. Persistent so
+      the brief refines across iteration passes if stage 2 surfaces
+      a gap. This is the EYE — what the model should make.
+
+  # ------------------------------------------------------------------
+  - stage: 2
+    construct: the-mint
+    skill: prompting-images
+    persona: MINT
+    mode: persistent
+    reads: [Signal, Artifact]
+    writes: [Artifact, Signal]
+    role: primary
+    iterates_with: 3
+    notes: >
+      MINT translates the brief into the Images 2.0 three-block
+      template (IMPORTANT DETAILS / REFERENCE GUIDANCE / USE CASE /
+      CONSTRAINTS), assigns reference roles per image, sanitizes
+      against IP guardrails (the strike-replace table), and runs
+      the prompt. Generates 2-4 candidates per pass. Persistent so
+      seed/reference history accumulates across iteration. This is
+      the HAND — how the prompt is structured and executed.
+
+  # ------------------------------------------------------------------
+  - stage: 3
+    construct: the-mint
+    skill: curate
+    persona: MINT
+    mode: fresh
+    reads: [Artifact, Signal]
+    writes: [Verdict, Signal]
+    role: craft-gate
+    iterates_with: 2
+    notes: >
+      MINT runs the selection test against ALEXANDER's brief —
+      single-stamp discipline holds, composition matches anchor,
+      every named treatment visible, all hard negatives satisfied.
+      Kills near-misses (the accumulation of near-misses degrades
+      a set). Loops back to stage 2 if no candidate passes;
+      advances on the first clean pass.
+
+  # ------------------------------------------------------------------
+  - stage: 4
+    construct: the-mint
+    skill: materialize
+    persona: MINT
+    mode: fresh
+    reads: [Verdict, Artifact]
+    writes: [Artifact]
+    role: primary
+    notes: >
+      MINT composites brand marks (logo, wordmark, partnership
+      lockup) onto the winning render via local rsvg-convert +
+      magick — never asks the model to render brand assets. Output:
+      pixel-perfect, retina-safe, deterministic. The
+      composite-vs-generate rule lives here.
+
+outputs:
+  - type: Artifact
+    destination: .run/compose/<run_id>/final-image.png
+    description: Final composited site-art image with brand lockup
+  - type: Artifact
+    destination: .run/compose/<run_id>/direction-brief.md
+    description: ALEXANDER's full creative direction (kept for the team — internal IP context preserved here, sanitized prompt stays in stage 2)
+  - type: Signal
+    destination: .run/compose/<run_id>/orchestrator.jsonl
+    description: Pipe graph + per-stage trajectory
+  - type: Verdict
+    destination: .run/compose/<run_id>/curation.jsonl
+    description: Per-iteration kept/killed log with reasons (selection-test evidence chain)
+
+compose_with:
+  - artisan
+  - the-mint
+composes_symmetrically_with:
+  - artisan ↔ the-mint   # eye ↔ hand — the canonical pair
+
+invocation_examples:
+  - operator_utterance: "make a hero banner from our taste canon"
+    resolves_to: full 4-stage chain end-to-end
+  - operator_utterance: "just direct it, I'll prompt myself"
+    resolves_to: stage 1 only — emit ALEXANDER's brief, halt
+  - operator_utterance: "I have the brief, just generate"
+    resolves_to: stages 2-4 with operator-supplied direction Signal
+  - operator_utterance: "scene stack for the Loa product layers"
+    resolves_to: stage 1 once (shared brief), then stages 2-4 invoked once per scene with shared constraints + per-scene IMPORTANT DETAILS
+
+when_to_use: >
+  - Producing site art for a codebase with an established visual
+    canon (taste.md, TDRs, identity persona present)
+  - Building a banner set / scene stack — same brief, multiple
+    renders, family-resemblance + distinguishability across the set
+  - Refreshing assets where the canon evolved since the last render
+  - NOT for first-time visual-language authoring (use
+    artisan/synthesizing-taste + recording-taste first to establish
+    the canon)
+  - NOT for brand-mark generation (composite locally, never generate)
+  - NOT for codex-shaped work (lore, identity schemas, knowledge
+    graphs) — that's a different surface; see the operator note
+    in references re: gumi's gen-art-collection-preview-tool
+
+known_limitations:
+  - "Image generation cost is real. Stage 2 emits 2-4 candidates per pass and the iterate loop caps at --max-iterations (default 3). Be deliberate about brief quality before invoking — sharp prompt beats volume."
+  - "Stage 1 quality is bounded by canon quality. If the codebase has no taste.md / TDRs / identity, ALEXANDER produces an underspecified brief and the hand has to invent — uncanny output is the symptom."
+  - "Selection-test (stage 3) is rule-based; it can't catch a render that's technically passing every named test but still wrong-feeling. Operator-in-the-loop is the answer; the composition exits to operator on iteration cap."
+  - "Output reproducibility is not guaranteed (LLM + image-model variance, doctrine v5 §17.1). Dispatch is deterministic; renders are not."
+  - "Images 2.0 has exactly three output sizes (1024² / 1024×1536 / 1536×1024). For wider banners, generate at 1536×1024 and crop post-hoc — see prompting-images SKILL.md §'Size and Aspect Constraints'."
+
+references:
+  - gist: https://gist.github.com/zkSoju/98d96dcb72320bfc4d43e00a6fdaa245
+  - skills:
+    - construct-artisan/skills/directing-generation/SKILL.md
+    - construct-the-mint/skills/prompting-images/SKILL.md
+    - construct-the-mint/skills/curate/SKILL.md
+    - construct-the-mint/skills/materialize/SKILL.md
+  - companion compositions:
+    - grimoires/compositions/feel-audit.yaml          # artisan ↔ observer (audit pair)
+    - grimoires/compositions/website-scaffold.yaml    # k-hole → the-easel → mint → artisan → the-arcade (full stack)
+    - construct-creator/compositions/explore-ecosystem.yaml  # CURATOR ↔ artisan (wayfinding pair)
+  - doctrine: bonfire-construct-pipe-doctrine v6 §15.2 (workflow-kind composition)
+  - operator note (for gumi · 2026-04-25):
+      Compositions are *runtime expert chains* — stitched skill calls
+      from multiple constructs, with declared streams + iteration
+      loops. They're not the gen-art-tool surface; they're what
+      runs *underneath* a tool when the tool wants to invoke
+      "directed image production" as a single capability.
+      Gumi's tool is a SURFACE (Layer manager + preview + export).
+      The construct it exports could ship its own composition that
+      wraps feel-image — e.g. `<collection>-cover.yaml` chains
+      <collection>/directing-generation (canon distilled from
+      schema + lore) → the-mint/prompting-images (executes against
+      the layer-set's reference grid) → the-mint/curate (selection
+      against the rarity/swag rubric) → the-mint/materialize
+      (locks the cover with collection wordmark). The codex
+      pattern (mibera-codex shape — browse / query / cross-reference
+      over a knowledge graph) is the OTHER half of what her tool
+      exports — read-only data skills over the schema. Two halves,
+      one construct, both shippable.
+
+version: "1.0.0"
+authored_at: "2026-04-25"
+authored_by: cycle-004 reference composition (feel→image, gumi explainer)

--- a/grimoires/loa/specs/arch-codex-review.md
+++ b/grimoires/loa/specs/arch-codex-review.md
@@ -1,0 +1,741 @@
+# ARCH: codex-review — Lean Code-Review Construct + Composition
+
+> **Mode**: ARCH (Ostrom) + craft lens (Alexander)
+> **Date**: 2026-04-26 (v2 — refined after deep dig of existing scripts)
+> **Persona placeholder**: FAGAN (after Michael Fagan, formal code inspection) — operator override welcome
+> **Composes with**: codex-rescue (or CLI implementer), flatline (boundary, not overlap)
+
+---
+
+## v2 deep-dig findings that changed this spec
+
+After reading lib-codex-exec.sh (full 417 lines), gpt-review-api.sh (full 302 lines), lib-security.sh, lib-content.sh, gpt-review-hook.sh, the schema, the re-review prompt, lib-curl-fallback.sh (skim), normalize-json.sh, inject-gpt-review-gates.sh, and diffing bonfire/.loa vs loa-constructs:
+
+1. **Bonfire and loa-constructs gpt-review-api.sh are IDENTICAL** (`diff` returns empty). Bonfire mirrors loa-constructs. No divergence/cleanup work needed — source from loa-constructs as canonical.
+2. **Vendor list is precise: 3 libs, not 1.** lib-codex-exec.sh + lib-security.sh + lib-content.sh. The `route_review` orchestration with curl/multipass/route-table fallbacks is overkill for V1.
+3. **Re-review prompt is the load-bearing convergence asset** — every word earns its place. "VERIFY. DON'T REINVENT. CONVERGE." Adapting this verbatim with light edits is the right move.
+4. **Auto-approval at API level** — gpt-review-api.sh handles `iter > MAX_ITERATIONS` internally by returning `{verdict:APPROVED, auto_approved:true}`. Composition just increments iter; cap enforcement is in the script. Inherit this.
+5. **Schema is draft-07** in the canonical version, permissive (no `additionalProperties: false`). Match ecosystem; don't upgrade to 2020-12 for this construct.
+6. **Hooks are intentionally being REMOVED in v2.0 of inject-gpt-review-gates.sh** — the comment says "No more skill/command file injection (fragile and redundant). The hooks are comprehensive enough." LOA team already learned the hook lesson. New construct: NO hooks, period.
+7. **lib-content.sh is more sophisticated than I knew** — 4-tier file priority (P0=security, P1=business, P2=config, P3=docs/tests), `bytes/3` token estimation (code-aware), git-diff-aware splitting on `diff --git a/(.+) b/`, `.reviewignore` support via `review-scope.sh`. Inherit verbatim.
+8. **lib-codex-exec.sh has Python3 fallback** for arbitrary-nesting JSON extraction (`raw_decode`). Critical for codex outputs that wrap JSON in markdown or prose.
+9. **System Zone Alert** detects `.claude/` changes in diffs and elevates scrutiny. SKIP for the new construct — project-specific to Loa-mounted projects.
+10. **Bonfire-specific config keys leak**: lib-security.sh reads `flatline_protocol.secret_scanning.patterns[]` — coupling that needs to be either dropped or renamed in the vendored copy.
+
+---
+
+## Reframe (read this first)
+
+**Not** "resurrect the deprecated /gpt-review."
+**Yes** "build a lean SWE-focused code-review construct that fills the diff-review gap flatline doesn't address."
+
+PR #523 deprecated /gpt-review for honest reasons (orphan code, broken tests, silent hooks, flatline absorbed its primary value). Resurrecting verbatim re-fights a settled battle. The new construct learns from those failure modes and occupies a clean responsibility seam.
+
+| Surface | Tool | When |
+|---|---|---|
+| PRD / SDD / Sprint planning | **Flatline Protocol** (Opus + GPT-5.3-codex + Gemini, 4-persona, scored arbitration) | High-stakes, slow, multi-model dissent |
+| Code diff after implementation | **codex-review** (single GPT pass via codex CLI, single persona, structured JSON) | Lean, fast, composable as a stage |
+
+Boundary is enforced by the construct's `when_to_use` doc and the composition's stage scope (diffs only). No overlap with flatline's territory.
+
+---
+
+## Invariants
+
+What MUST NOT change:
+
+- **contracts-as-bridges doctrine** — schemas are bridges, not glue. Composition schema stays in `loa-constructs/.claude/schemas/composition.schema.json`. The new construct's review-finding schema is locally-owned (lives with the construct, not in loa-constructs central schemas).
+- **`lib-codex-exec.sh` is the canonical CLI primitive** — wrapped, never forked. Sourced via path or vendored with version pinning. This is what gives portability (no MCP plugin dependency).
+- **Construct-* repo pattern** — `construct.yaml` at top level as source of truth, no `manifest.json` (loa-constructs cache generates it). Follow `construct-the-easel` shape.
+- **No silently always-on hooks** — explicit invocation only. No PostToolUse fire-and-forget. (This was the primary noise generator that PR #523 removed.)
+- **Tests must pass and reflect actual behavior** — no aspirational asserts. The 22 failing bats tests in the original gpt-review were the canary.
+- **Single persona** — codex-review is one role: strict code reviewer. Flatline's 4-persona system is intentionally separate.
+- **Convergence cap at 3 iterations** — matches gpt-review's pattern. Re-review converges toward approval (don't keep finding new issues post-iteration-1).
+- **Structured JSON output, schema-validated** — never freeform text. The schema IS the prompt's prompt.
+
+---
+
+## Construct repo design
+
+### Repo
+
+`construct-codex-review` — public, MIT license, `0xHoneyJar` org. Follows construct-* convention.
+
+### Structure
+
+```
+construct-codex-review/
+├── README.md
+├── CLAUDE.md
+├── construct.yaml                     ← source of truth (schema_version 3)
+├── identity/
+│   ├── persona.yaml                   ← FAGAN (or operator pick)
+│   └── expertise.yaml
+├── skills/
+│   ├── reviewing-diffs/               ← primary skill
+│   │   ├── SKILL.md
+│   │   └── index.yaml
+│   └── reviewing-files/               ← secondary (review specific files, no diff)
+│       ├── SKILL.md
+│       └── index.yaml
+├── scripts/
+│   ├── codex-review-api.sh            ← lean wrapper (~100 lines)
+│   ├── lib/                           ← VENDORED from loa-constructs/.claude/scripts/
+│   │   ├── lib-codex-exec.sh          ← codex CLI execution backend (cycle-033)
+│   │   ├── lib-security.sh            ← auth + secret redaction + curl auth config
+│   │   └── lib-content.sh             ← 4-tier file priority + token budgeting
+│   └── tests/
+│       └── *.bats                     ← all green, all reflect actual behavior
+├── prompts/
+│   ├── code-review.md                 ← first-review prompt (lean SWE focus)
+│   └── re-review.md                   ← convergence prompt (template substitutions)
+├── schemas/
+│   └── codex-review-finding.schema.json  ← draft-07, locally-owned
+└── VENDOR.md                          ← attribution + version pin for lib-* sources
+```
+
+### Vendor list — precise
+
+After deep dig of gpt-review-api.sh (302 lines, sources 9 libs), the LEAN V1 wrapper sources only THREE:
+
+| Lib | Why vendor | Adaptations needed for portability |
+|---|---|---|
+| `lib-codex-exec.sh` | Foundation — codex CLI capability detection, single invocation, output parsing (incl. Python3 raw_decode fallback for arbitrary nesting), workspace setup with allow-list | None — already portable. Sources lib-security.sh which we also vendor. |
+| `lib-security.sh` | `ensure_codex_auth` (env-only, no .env reads), `redact_secrets` (jq-based key-preserving), `is_sensitive_file` (deny list), `write_curl_auth_config` (header injection guards) | Drop the `flatline_protocol.secret_scanning.patterns[]` config lookup — bonfire-coupled. Use `codex_review.secret_patterns[]` instead, OR drop config-driven extras entirely (V1: hardcoded patterns only). |
+| `lib-content.sh` | 4-tier priority (P0 security / P1 business / P2 config / P3 docs+tests), `estimate_tokens` (bytes/3 code-aware), `prepare_content` (diff-aware truncation), optional `review-scope.sh` integration | None — already portable. Optional `.reviewignore` support if `review-scope.sh` is also vendored. |
+
+### What NOT to vendor (V1)
+
+- **`lib-curl-fallback.sh`** (348 lines) — direct OpenAI API + Hounfour model-invoke. V1 requires codex CLI; if missing, fail with install hint. Add fallback in V2 if needed.
+- **`lib-multipass.sh`** — multipass orchestration (repeated/refining queries). Single-pass is sufficient for diff review.
+- **`lib-route-table.sh`** — declarative route table with precedence chain. Overkill for single-backend codex CLI.
+- **`normalize-json.sh`** — separate utility; lib-codex-exec.sh has its own `parse_codex_output` with the same logic.
+- **`invoke-diagnostics.sh`** — debugging only.
+- **`bash-version-guard.sh`** — Loa-specific.
+- **All hook infrastructure** (`gpt-review-hook.sh`, `inject-gpt-review-gates.sh`, `gpt-review-toggle.sh`, template). The `inject-gpt-review-gates.sh` v2.0 comment EXPLICITLY says "No more skill/command file injection (fragile and redundant)." Loa team already learned the hook lesson. New construct: NO hooks at any layer.
+
+### `VENDOR.md` shape
+
+```markdown
+# Vendored libraries
+
+These files are vendored from
+[loa-constructs](https://github.com/0xHoneyJar/loa-constructs)
+`/.claude/scripts/` at commit <SHA>. Do not edit in place — propose
+upstream changes via PR to loa-constructs first, then re-vendor.
+
+| File | Source | Version | Adaptations |
+|---|---|---|---|
+| lib/lib-codex-exec.sh | loa-constructs/.claude/scripts/lib-codex-exec.sh | <SHA> | None |
+| lib/lib-security.sh | loa-constructs/.claude/scripts/lib-security.sh | <SHA> | Removed flatline_protocol.secret_scanning.patterns lookup |
+| lib/lib-content.sh | loa-constructs/.claude/scripts/lib-content.sh | <SHA> | None |
+
+To re-vendor: `bash scripts/revendor.sh <commit-sha>`.
+```
+
+### `construct.yaml` (schema_version 3)
+
+Following `construct-the-easel`:
+
+```yaml
+schema_version: 3
+name: "Codex Review"
+slug: "codex-review"
+version: "0.1.0"
+description: "Lean adversarial code review for diffs and implementations. Single GPT pass via codex CLI, structured JSON findings, convergence loop. Composes with codex-rescue or any implementer for implement+review workflows."
+short_description: "Diff-scoped code review via codex CLI"
+author: "0xHoneyJar"
+license: "MIT"
+type: "skill-pack"
+visibility: public
+repository: https://github.com/0xHoneyJar/construct-codex-review.git
+
+skills:
+  - slug: reviewing-diffs
+    path: skills/reviewing-diffs
+  - slug: reviewing-files
+    path: skills/reviewing-files
+
+identity:
+  persona: identity/persona.yaml
+  expertise: identity/expertise.yaml
+
+domain: [engineering, code-review, adversarial-review]
+
+expertise:
+  - diff-scoped code review
+  - structured-output review findings
+  - codex CLI integration
+  - convergence loop discipline
+
+compose_with:
+  - codex-rescue          # implementer counterpart (Anthropic's codex MCP)
+  - artisan               # craft-gate cousin (different surface; can compose for UI code reviews)
+  - flatline              # boundary, not overlap (flatline = planning; codex-review = code)
+
+events:
+  emits:
+    - codex-review.finding.created
+    - codex-review.verdict.changed
+    - codex-review.iteration.completed
+  consumes:
+    - implement.diff.created    # any implementer's signal that work is ready to review
+
+golden_path:
+  commands:
+    - "/codex:review-diff <path-to-diff>"
+    - "/codex:review-files <file1> <file2> ..."
+```
+
+### Persona
+
+**Name**: FAGAN (placeholder — operator picks)
+**Lineage**: Michael Fagan invented formal code inspection at IBM (1976). His method shaped modern code review.
+**Disposition**: Strict, evidence-based, line-numbered. Calls fabrication where it exists. Provides actual code fixes, not descriptions. Converges toward approval on re-review (doesn't introduce new issues to delay convergence).
+
+`identity/persona.yaml` shape:
+```yaml
+name: FAGAN
+construct: codex-review
+role: strict code reviewer
+voice: precise, line-anchored, fix-first
+authority: |
+  Find bugs, security issues, and fabrication. Provide actual code fixes for
+  every finding. Ignore style/naming/"could be cleaner" — that's craft-gate
+  territory. Re-review: focus ONLY on whether previous issues were fixed;
+  converge toward approval.
+mandates:
+  - Every finding includes current_code + fixed_code + explanation
+  - Severity is binary: critical | major (no minor; if it's not a bug, don't flag it)
+  - Fabrication check on every review (hardcoded values, stubbed functions, faked results)
+  - Three-iteration cap; re-review converges toward approval
+forbidden:
+  - Style preferences
+  - Naming nits unless genuinely confusing
+  - "Could be cleaner" suggestions
+  - Discovering new issues on iteration 2+ unless the fix introduced them
+```
+
+### Skills
+
+#### `reviewing-diffs` (primary)
+
+`skills/reviewing-diffs/SKILL.md`:
+```markdown
+---
+name: reviewing-diffs
+description: Adversarial code review of a unified diff via codex CLI. Returns structured JSON findings with line-anchored fixes. Convergence loop with 3-iteration cap.
+allowed-tools: [Bash, Read]
+user-invocable: true
+---
+
+# /reviewing-diffs — Diff Code Review
+
+Single-pass GPT code review of a diff. Returns structured JSON.
+
+## Inputs
+- `diff_path` (required) — path to a unified diff file OR `-` for stdin
+- `iteration` (optional, default 1) — for convergence loop; re-review uses iteration ≥ 2 prompt
+- `context_files` (optional) — additional files to load alongside the diff
+
+## Invocation
+`bash scripts/codex-review-api.sh review-diff <diff_path> [--iteration N] [--context-file path]`
+
+## Output
+JSON conforming to `schemas/codex-review-finding.schema.json`:
+- `verdict`: APPROVED | CHANGES_REQUIRED
+- `summary`: one-sentence
+- `findings[]`: each with severity, file, line, description, current_code, fixed_code, explanation
+- `fabrication_check`: passed + concerns
+
+## When to use
+- After an implementer (codex-rescue, codex-cli implementer, etc.) ships a diff
+- Inside the `code-implement-and-review.yaml` composition (stage 2)
+- Standalone: operator wants a single review pass on a PR diff before merge
+
+## When NOT to use
+- For PRD/SDD/Sprint planning review — use Flatline Protocol
+- For style/lint feedback — use the project's linter
+- For UI/UX feel — use artisan/feel-iterate
+```
+
+#### `reviewing-files` (secondary)
+
+Same shape but takes file paths instead of a diff. Use case: review a specific module without a diff context (e.g., "audit auth.ts before we ship").
+
+### `scripts/codex-review-api.sh`
+
+Lean wrapper, ~100 lines. Sources 3 vendored libs. Single backend (codex CLI). No fallback chains in V1.
+
+```bash
+#!/usr/bin/env bash
+# codex-review-api.sh <command> [args]
+# Commands: review-diff, review-files
+# Exit codes: 0=approved 1=changes_required 2=input_error 3=api_failure 4=auth 5=format
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONSTRUCT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROMPTS_DIR="$CONSTRUCT_ROOT/prompts"
+SCHEMA_PATH="$CONSTRUCT_ROOT/schemas/codex-review-finding.schema.json"
+
+source "$SCRIPT_DIR/lib/lib-security.sh"     # auth + redaction
+source "$SCRIPT_DIR/lib/lib-content.sh"      # token budgeting + priority
+source "$SCRIPT_DIR/lib/lib-codex-exec.sh"   # codex CLI execution
+
+# Defaults
+CODEX_REVIEW_MODEL="${CODEX_REVIEW_MODEL:-gpt-5.3-codex}"
+CODEX_REVIEW_TIMEOUT="${CODEX_REVIEW_TIMEOUT:-300}"
+CODEX_REVIEW_MAX_ITERATIONS="${CODEX_REVIEW_MAX_ITERATIONS:-3}"
+CODEX_REVIEW_MAX_TOKENS="${CODEX_REVIEW_MAX_TOKENS:-30000}"
+
+# Parse args: --iteration N, --previous <findings.json>, --output <file>
+# (See main() below)
+
+main() {
+  # 1. Validate inputs (diff/file path, OPENAI_API_KEY)
+  ensure_codex_auth || { error "OPENAI_API_KEY not set"; exit 4; }
+
+  # 2. Inherit auto-approval pattern from gpt-review-api.sh:lines 264-269
+  #    If iter > MAX_ITERATIONS, return auto-approved verdict without invoking model
+  if [[ "$iter" -gt "$CODEX_REVIEW_MAX_ITERATIONS" ]]; then
+    printf '{"verdict":"APPROVED","summary":"Auto-approved after %s iterations","auto_approved":true,"iteration":%s}\n' \
+      "$CODEX_REVIEW_MAX_ITERATIONS" "$iter"
+    exit 0
+  fi
+
+  # 3. Build prompt
+  if [[ "$iter" -eq 1 ]]; then
+    sp=$(cat "$PROMPTS_DIR/code-review.md")
+  else
+    [[ -n "$previous_findings_file" ]] || { error "Re-review requires --previous"; exit 2; }
+    # Awk-based safe template substitution (vision-002 pattern)
+    sp=$(awk -v iter="$iter" -v findings="$(cat "$previous_findings_file")" \
+      '{gsub(/\{\{ITERATION\}\}/, iter); gsub(/\{\{PREVIOUS_FINDINGS\}\}/, findings); print}' \
+      "$PROMPTS_DIR/re-review.md")
+  fi
+
+  # 4. Token budget the diff content (priority-based truncation if needed)
+  raw=$(cat "$diff_path")
+  prepared=$(prepare_content "$raw" "$CODEX_REVIEW_MAX_TOKENS")
+
+  # 5. Execute codex CLI
+  workspace=$(setup_review_workspace "")
+  out=$(mktemp "${workspace}/out-$$.XXXXXX")
+  full_prompt=$(printf '%s\n\n---\n\n## CONTENT TO REVIEW:\n\n%s\n\n---\n\nRespond with valid JSON only.' "$sp" "$prepared")
+
+  codex_exec_single "$full_prompt" "$CODEX_REVIEW_MODEL" "$out" "$workspace" "$CODEX_REVIEW_TIMEOUT"
+
+  # 6. Parse + redact + emit
+  raw_response=$(cat "$out")
+  cleanup_workspace "$workspace"
+  resp=$(parse_codex_output "$raw_response")
+  resp=$(echo "$resp" | jq --arg i "$iter" '. + {iteration: ($i | tonumber)}')
+  resp=$(redact_secrets "$resp" "json")
+
+  # 7. Optional: validate against schema (jq + ajv if available)
+  # ajv validate -s "$SCHEMA_PATH" -d <(echo "$resp") || warn "Schema validation failed"
+
+  echo "$resp"
+
+  # Exit code maps verdict
+  verdict=$(echo "$resp" | jq -r '.verdict')
+  case "$verdict" in
+    APPROVED) exit 0 ;;
+    CHANGES_REQUIRED) exit 1 ;;
+    *) exit 5 ;;
+  esac
+}
+
+main "$@"
+```
+
+Key inheritance from gpt-review-api.sh:
+
+- **Auto-approval at API level** (lines 264-269 of original) — `iter > MAX` returns approved without invoking model. Composition just increments iter; cap enforcement is INSIDE the script. Cleaner than composition-level cap logic.
+- **Awk-based safe template substitution** (line 90 of original) — `{{ITERATION}}` and `{{PREVIOUS_FINDINGS}}` substituted via awk so shell metacharacters in findings don't break the prompt. Vision-002 pattern.
+- **`prepare_content` for token budget** — git-diff-aware splitting + priority sort + truncation summary. P0 (security, .claude/) first, P3 (docs/tests) last. Inherits the entire 4-tier discipline from lib-content.sh.
+- **`parse_codex_output` chain** — direct JSON → markdown fenced → greedy regex → Python3 `raw_decode` fallback. The Python3 fallback is critical for outputs that wrap JSON in prose with arbitrary nesting.
+- **`redact_secrets` on response** — jq-based key-preserving redaction. Strips OpenAI/Anthropic/GitHub/AWS/JWT patterns from the response BEFORE it's emitted.
+
+### `prompts/re-review.md` — convergence prompt
+
+The re-review prompt is the LOAD-BEARING convergence asset. Adapting bonfire's verbatim with light edits:
+
+**Substitutions**: `{{ITERATION}}`, `{{PREVIOUS_FINDINGS}}` (awk-safe).
+
+**Invariants from the original** (preserve verbatim):
+
+1. "**DO NOT find new nitpicks** — You already had your chance on the first review."
+2. "**DO NOT raise the bar** — If something was acceptable before, it's acceptable now."
+3. "**New concerns ONLY if truly blocking** — The fix broke something critical, not 'I noticed something else.'"
+4. "**APPROVE** if previous issues are reasonably fixed, even if not perfect."
+5. "**NO DECISION_NEEDED on re-review** — Design questions should have been raised on first review." (Aligns with our binary-verdict schema.)
+6. "**Claude has more context than you.** If Claude's explanation is reasonable, accept it."
+7. "**Default to APPROVED if the fixes are reasonable. Don't require perfection.**"
+8. Closing: "**VERIFY. DON'T REINVENT. CONVERGE.**"
+
+**Edits for the new construct**:
+- Remove "5.2" model reference (we use 5.3-codex default)
+- Remove DECISION_NEEDED reference from response format (binary verdict)
+- Remove `blocking_issues` reference (code-only)
+- Tighten to diff-only context (strip PRD/SDD/Sprint generality)
+
+The convergence DISCIPLINE is what makes the iteration cap work without needing composition-level intervention. Without these prompt invariants, models drift into finding new issues on iteration 2+, and the loop never converges. **This prompt is the construct's most important asset — treat as canon, change with care.**
+
+### `prompts/code-review.md` (the lean reviewer prompt)
+
+Adapted from bonfire's gpt-review code-review prompt with these changes:
+- Strip flatline-specific routing language
+- Strip references to deprecated /gpt-review commands
+- Tighten the WHAT TO IGNORE section (lean = aggressive on scope)
+- Add explicit boundary statement: "This is diff-scoped code review. PRD/SDD review = different prompt; not your job here."
+
+Single canonical version. No phase variants (the original had prd/sdd/sprint/code/re-review). For codex-review, only `code-review.md` and `re-review.md`.
+
+### `schemas/codex-review-finding.schema.json` (locally-owned)
+
+Aligned with the existing `gpt-review-response.schema.json` (draft-07, permissive) for ecosystem consistency. Major differences from the deprecated schema: no `SKIPPED`/`DECISION_NEEDED` verdicts (code review is binary — fixes, not discussions), no `blocking_issues` (code-only construct), no `new_blocking_concerns` on re-review (the convergence prompt explicitly forbids new concerns unless TRULY blocking).
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://0xhoneyjar.github.io/construct-codex-review/schemas/codex-review-finding.schema.json",
+  "title": "Codex Review Finding",
+  "description": "Structured output contract for codex-review reviewer skills. Diff-scoped code review only.",
+  "type": "object",
+  "required": ["verdict"],
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "enum": ["APPROVED", "CHANGES_REQUIRED"],
+      "description": "Code review verdict. Binary by design — bugs get fixed, not discussed."
+    },
+    "summary": {
+      "type": "string",
+      "description": "One sentence assessment"
+    },
+    "findings": {
+      "type": "array",
+      "description": "Code review findings (each with line-anchored fix)",
+      "items": {
+        "type": "object",
+        "required": ["severity", "file", "description", "fixed_code"],
+        "properties": {
+          "severity": { "type": "string", "enum": ["critical", "major"] },
+          "file": { "type": "string" },
+          "line": { "type": "integer" },
+          "description": { "type": "string" },
+          "current_code": { "type": "string" },
+          "fixed_code": { "type": "string" },
+          "explanation": { "type": "string" }
+        }
+      }
+    },
+    "fabrication_check": {
+      "type": "object",
+      "description": "Fabrication detection (hardcoded values, stubbed functions, faked results)",
+      "properties": {
+        "passed": { "type": "boolean" },
+        "concerns": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "previous_issues_status": {
+      "type": "array",
+      "description": "Per-issue status on re-review (iteration > 1)",
+      "items": {
+        "type": "object",
+        "required": ["original_issue", "status"],
+        "properties": {
+          "original_issue": { "type": "string" },
+          "status": { "type": "string", "enum": ["fixed", "rejected_with_valid_reason", "not_fixed"] },
+          "notes": { "type": "string" }
+        }
+      }
+    },
+    "iteration": { "type": "integer", "description": "Review iteration number" },
+    "auto_approved": { "type": "boolean", "description": "True when iteration > MAX_ITERATIONS triggered API-level auto-approval" },
+    "note": { "type": "string", "description": "Additional notes appended by the API script" }
+  }
+}
+```
+
+**Permissive by design** (no `additionalProperties: false`). The wrapper script appends `iteration`, `auto_approved`, `note`, and other meta-fields after the model returns; strict mode would reject these. Strict validation can run on the model's RAW output (before wrapper enrichment) if needed.
+
+Public `$id` URL via GitHub Pages on the construct repo. Follows the contracts-as-bridges pattern at the construct level — schema lives WITH the construct (cohesive impl), referenced via `$id` by consumers.
+
+---
+
+## Composition design
+
+### YAML
+
+`loa-compositions/compositions/delivery/code-implement-and-review.yaml`:
+
+```yaml
+schema_version: "1.0"
+kind: workflow
+name: code-implement-and-review
+description: >
+  Implement code changes, then run adversarial code review against the
+  diff. Iterate until reviewer approves OR max 3 iterations reached.
+
+intent: >
+  "Operator delegates a coding task. Implementer ships a diff. Reviewer
+   runs FAGAN over it, returns line-anchored findings with fixes.
+   Implementer applies fixes. Reviewer re-reads, converges. Operator gets
+   reviewed code, not raw output."
+
+backend: headless-tmux
+
+hivemind_labels:
+  product_area: "Engineering — composable code review for compositions"
+  workstream: delivery
+  priority: high
+  jtbd:
+    category: personal
+    description: "Reassure Me This Is Safe — implementer output gets a strict gate before reaching prod"
+  source: team-internal
+
+depends_on:
+  constructs:
+    - codex-rescue        # Anthropic's codex MCP — primary implementer
+    - codex-review        # the new lean reviewer (FAGAN)
+  tools:
+    - codex-cli           # both stages depend on codex CLI being installed
+
+inputs:
+  - type: Intent
+    name: task
+    description: What the operator wants implemented
+    required: true
+  - type: Artifact
+    name: scope
+    description: Files / modules to limit changes to (avoid scope creep)
+    required: false
+  - type: Operator-Model
+    name: operator_context
+    required: false
+
+iterate:
+  - [1, 2]                 # implement ↔ review until approved or cap
+
+chain:
+  - stage: 1
+    name: implement
+    construct: codex-rescue
+    skill: implement
+    persona: CODEX-RESCUE
+    mode: persistent
+    reads: [Intent, Artifact, Verdict]   # Verdict from previous review iteration
+    writes: [Artifact, Signal]           # Diff + trajectory
+    role: primary
+    iterates_with: 2
+    thinking_effort: high
+    notes: >
+      First iteration: implement against the operator's task within scope.
+      Subsequent iterations: read the previous review Verdict, apply
+      every finding's fixed_code, re-emit Diff. Don't introduce new
+      changes outside of fix scope unless the fix requires them.
+
+  - stage: 2
+    name: review
+    construct: codex-review
+    skill: reviewing-diffs
+    persona: FAGAN
+    mode: fresh                          # fresh context per iteration — no memory of previous reviews
+    reads: [Artifact]                    # the diff
+    writes: [Verdict, Signal]
+    role: craft-gate
+    iterates_with: 1
+    thinking_effort: high
+    notes: >
+      Stage 1 emits Diff; this stage runs codex-review-api.sh review-diff
+      against it. Returns structured JSON Verdict (APPROVED |
+      CHANGES_REQUIRED + findings[]). On APPROVED, composition completes.
+      On CHANGES_REQUIRED, loop back to stage 1 with findings as context.
+      Iteration cap: 3 total reviews. After cap: emit Verdict with note
+      "iteration-cap-reached" and surface to operator.
+
+outputs:
+  - type: Artifact
+    destination: <repo>/<changed-files>
+    description: The implemented + reviewed code changes
+    hivemind_labels:
+      artifact_type: product-spec
+      learning_status: strongly-validated
+  - type: Verdict
+    destination: .run/compose/<run_id>/codex-review-trail.jsonl
+    description: Per-iteration review verdicts + findings
+    schema: https://0xhoneyjar.github.io/construct-codex-review/schemas/codex-review-finding.schema.json
+  - type: Signal
+    destination: .run/compose/<run_id>/orchestrator.jsonl
+    description: Orchestrator trajectory (stage transitions, iteration counts)
+
+compose_with:
+  - codex-rescue
+  - codex-review
+
+composes_symmetrically_with:
+  - codex-rescue ↔ codex-review   # implement ↔ review — load-bearing pair
+
+invocation_examples:
+  - operator_utterance: "implement the perf pass and review it"
+    resolves_to: full chain stages 1-2 with iteration loop
+  - operator_utterance: "review this diff"
+    resolves_to: stage 2 only with operator-supplied Diff Artifact
+  - operator_utterance: "skip review, just implement"
+    resolves_to: stage 1 only (operator opts out of gate — surface as warning)
+
+when_to_use: >
+  - Implementer just shipped code (perf pass, refactor, feature)
+  - Pre-merge gate on a PR diff
+  - Any composition where "implement then verify" is the shape
+  - NOT for PRD/SDD/Sprint review (use Flatline Protocol)
+  - NOT for UI feel iteration (use feel-iterate)
+  - NOT for architecture audits (use audit-feel or other audit-pair compositions)
+
+known_limitations:
+  - "Iteration cap of 3 is advisory; on culturetech-loose surfaces operator halts dictate progress; on defi-strict the cap enforces. See surface_class."
+  - "Reviewer has no memory of previous reviews (mode: fresh per iteration). Convergence relies on the re-review prompt's discipline. If reviewer keeps finding NEW issues post-iteration-1, that's a prompt drift bug to file."
+  - "Implementer (codex-rescue) requires the Anthropic codex MCP plugin installed. For environments without the plugin, swap with a CLI implementer (use the same codex CLI primitive directly)."
+
+surface_class:
+  default: unspecified
+  enum: [culturetech-loose, defi-strict, mixed, unspecified]
+  affects_in_this_composition:
+    - iteration cap — advisory on culturetech-loose, enforced on defi-strict
+    - severity threshold — major-only on culturetech-loose, all findings on defi-strict
+
+thinking_effort:
+  default: high
+  rationale: "Both stages are multi-step synthesis (implement = production code; review = bug-finding + fix-authoring)."
+
+version: "1.0.0"
+authored_at: "2026-04-26"
+authored_by: kickoff session 1 — codex-review
+```
+
+---
+
+## Blast radius
+
+| Artifact | Change | Risk | Repo |
+|---|---|---|---|
+| `construct-codex-review/` | NEW REPO (entire) | Low — isolated | new |
+| `loa-constructs/registry.yaml` | MODIFIED — add codex-review entry | Low — append-only | loa-constructs |
+| `loa-compositions/compositions/delivery/code-implement-and-review.yaml` | NEW | Low — isolated | loa-compositions |
+| `loa-compositions/docs/SHAPES.md` | OPTIONAL: document implement-review pair as observed pattern | Low | loa-compositions |
+| `loa-constructs/.claude/scripts/lib-codex-exec.sh` | UNCHANGED — vendored into construct repo with version-pin attribution | Zero | loa-constructs |
+| Existing /gpt-review scripts in loa-constructs | UNCHANGED — stay soft-retired | Zero | loa-constructs |
+| Flatline ecosystem | UNCHANGED — different responsibility | Zero | loa-constructs |
+
+**No deletions.** No breaking changes. Existing flatline / gpt-review remain as-is.
+
+---
+
+## Build sequence (Barth — V1 ship now)
+
+### V1 — Ship Now
+
+1. **Create repo `construct-codex-review`** on 0xHoneyJar org. Public, MIT.
+2. **Author `construct.yaml`** following construct-the-easel shape (schema_version 3, slug, version 0.1.0, skills + identity + persona refs).
+3. **Author `identity/persona.yaml` + `identity/expertise.yaml`** (FAGAN placeholder; operator can rename).
+4. **Author `prompts/code-review.md`** (lean SWE focus; strip flatline-specific routing; tighten WHAT TO IGNORE).
+5. **Author `prompts/re-review.md`** (convergence-toward-approval prompt).
+6. **Author `schemas/codex-review-finding.schema.json`** (verdict, findings[], fabrication_check, previous_issues_status).
+7. **Vendor 3 libs** from `loa-constructs/.claude/scripts/` into `scripts/lib/`: `lib-codex-exec.sh`, `lib-security.sh`, `lib-content.sh`. Pin to a specific commit SHA. Write `VENDOR.md` with attribution + adaptations log. Adapt `lib-security.sh` to drop the `flatline_protocol.secret_scanning.patterns` config lookup (or rename to `codex_review.secret_patterns`).
+8. **Author `scripts/codex-review-api.sh`** (~100 lines) — sources the 3 vendored libs, single backend (codex CLI only, no curl fallback in V1), inherits auto-approval pattern from gpt-review-api.sh:264-269, awk-safe template substitution for re-review prompt, validates response against schema.
+9. **Author `skills/reviewing-diffs/SKILL.md` + `index.yaml`** — primary skill.
+10. **Author `skills/reviewing-files/SKILL.md` + `index.yaml`** — secondary skill.
+11. **Author bats tests** — only assertions that reflect actual behavior. Start with happy-path + 1-2 error cases. NO aspirational tests.
+12. **Register in `loa-constructs/registry.yaml`** — add codex-review entry under `constructs:`.
+13. **Author `loa-compositions/compositions/delivery/code-implement-and-review.yaml`** — pair codex-rescue + codex-review with iterate [[1, 2]].
+14. **Run the composition end-to-end** on a real diff (henlo-monorepo would be the natural test bed — last night's perf pass left a clear "this should have had a review gate" gap).
+15. **Verify the gate fires meaningfully** — run on intentionally buggy code, confirm CHANGES_REQUIRED returned with actionable findings.
+
+### V2 — After Feedback
+
+- **CLI implementer alternative**: an implementer that uses codex exec directly (no MCP plugin dep) for environments without codex-rescue
+- **Pre-dispatch validation**: wire the construct's schema into compose-run.sh so malformed Verdict streams fail fast
+- **Hivemind log entry** if the construct earns its place via real usage
+- **MCP wrapper** for the construct (per `mcp-wraps-cli-pattern`)
+
+### Cut from V1
+
+- **Hooks** — no PostToolUse, no Stop hook, no auto-fire. Explicit invocation only. (Lesson from PR #523.)
+- **Multi-persona expansion** — codex-review stays single-persona. Flatline-style multi-persona is a different construct, not a layer on this one.
+- **Phase-aware prompts** (prd/sdd/sprint variants) — single code-review.md only. Other phases = Flatline territory.
+- **Toggle commands** (/toggle-codex-review) — opt-in is via composition selection, not a global toggle.
+
+---
+
+## Failure modes to avoid (PR #523 archaeology)
+
+1. **No silent always-on hooks**. The original PostToolUse hook fired on every Edit/Write but early-exited because config was null — pure noise in settings.json. Don't repeat.
+2. **Tests must reflect reality**. The original 22 failing bats tests asserted behavior that contradicted the script's own design note. New tests are happy-path-first; assertions match implementation.
+3. **No orphan code**. The original was deprecated because nothing invoked it. The new construct MUST have at least one composition consuming it (`code-implement-and-review.yaml`) before merging the construct repo.
+4. **Clear scope from flatline**. The original gpt-review overlapped with flatline's territory. The new construct's `when_to_use` explicitly defers PRD/SDD/Sprint to Flatline.
+5. **Working defaults**. The original config was NULL in distribution template. The new construct ships with a sensible default config that works out-of-the-box.
+6. **Convergence discipline**. The original re-review prompt drifted into finding new issues on iteration 2+. The new prompt explicitly says "focus ONLY on whether previous issues were fixed."
+
+---
+
+## Verify
+
+```bash
+# After construct repo + composition land:
+cd ~/Documents/GitHub/construct-codex-review
+bun install                           # if it has node deps for tests
+bash scripts/tests/run-all.sh         # bats tests, all green
+
+# Validate schema against draft 2020-12
+ajv validate -s schemas/codex-review-finding.schema.json -d test-fixtures/sample-finding.json
+
+# Smoke test: review a known-buggy diff
+bash scripts/codex-review-api.sh review-diff test-fixtures/buggy.diff
+# Expected: verdict CHANGES_REQUIRED, ≥1 finding with current/fixed code
+
+# Composition end-to-end:
+cd ~/bonfire/loa-compositions
+yq eval '.' compositions/delivery/code-implement-and-review.yaml > /dev/null   # YAML valid
+# Validate against composition.schema.json
+ajv validate -s https://raw.githubusercontent.com/0xHoneyJar/loa-constructs/main/.claude/schemas/composition.schema.json -d compositions/delivery/code-implement-and-review.yaml.json
+
+# Run composition on real diff
+loa compose-run code-implement-and-review --task "fix the off-by-one in foo.ts"
+# Expected: stage 1 implements, stage 2 reviews, iterates if needed, completes with verdict trail
+```
+
+---
+
+## Key references
+
+| Topic | File / URL |
+|---|---|
+| contracts-as-bridges doctrine | `~/hivemind/wiki/concepts/contracts-as-bridges.md` |
+| composition-schema-as-bridge doctrine | `~/hivemind/wiki/concepts/composition-schema-as-bridge.md` |
+| Existing arch spec on schema sync | `loa-constructs/grimoires/loa/specs/arch-composition-schema-sync.md` |
+| Composition schema (the bridge we consume) | `loa-constructs/.claude/schemas/composition.schema.json` |
+| CLI primitive to wrap | `loa-constructs/.claude/scripts/lib-codex-exec.sh` |
+| Construct repo template to follow | `~/Documents/GitHub/construct-the-easel/` |
+| PR #523 deprecation context | commit `e25128ba` in loa-constructs |
+| First-review prompt source (canonical) | `loa-constructs/.../prompts/gpt-review/base/code-review.md` (mirrors bonfire) |
+| Re-review prompt source (canonical) | `loa-constructs/.../prompts/gpt-review/base/re-review.md` (mirrors bonfire) |
+| Schema source (draft-07, permissive) | `loa-constructs/.claude/schemas/gpt-review-response.schema.json` |
+| Vendor source — codex execution | `loa-constructs/.claude/scripts/lib-codex-exec.sh` (cycle-033) |
+| Vendor source — auth + redaction | `loa-constructs/.claude/scripts/lib-security.sh` (cycle-033) |
+| Vendor source — token budget + priority | `loa-constructs/.claude/scripts/lib-content.sh` (PR #235, Bridgebuilder Finding #1 extraction) |
+| Reference wrapper (study, don't fork) | `loa-constructs/.claude/scripts/gpt-review-api.sh` (302 lines, has deprecation warning) |
+| Existing composition example (pattern reference) | `~/bonfire/loa-compositions/compositions/delivery/feel-iterate.yaml` |
+| Bonfire vs loa-constructs sync status | **identical** — `diff` returns empty. Source from loa-constructs. |
+
+---
+
+## Open questions to resolve in build session
+
+1. **Persona name** — FAGAN is placeholder. Operator override?
+2. **Construct repo name** — `construct-codex-review` proposed. Alternative: `construct-codex-reviewer` / `construct-adversarial-review` / something punchier?
+3. **lib-codex-exec.sh: vendor vs source** — vendoring with version pin is cleaner (no runtime path dep); sourcing is simpler (auto-updates with loa-constructs). Lean toward vendor.
+4. **Test-bed**: run the first composition end-to-end against henlo-monorepo? It's the natural test (perf pass left a clear gate-shaped hole). Or use a synthetic test fixture?
+5. **Hivemind log entry** — write a `~/hivemind/wiki/concepts/codex-review-vs-flatline.md` page documenting the responsibility split? (Avoids future confusion.)

--- a/grimoires/loa/specs/arch-composition-schema-sync.md
+++ b/grimoires/loa/specs/arch-composition-schema-sync.md
@@ -1,0 +1,470 @@
+# ARCH + BUILD: Composition Schema Sync (cycle-002 followup)
+
+> **Mode**: ARCH (Ostrom) + craft lens (Alexander minimal)
+> **Date**: 2026-04-25
+> **Authors**: cycle-002 followup convergence (operator + Claude Opus 4.7)
+> **Kickoff**: this is the spec for the dedicated session that fixes composition.schema.json sync drift relative to loa-compositions YAMLs
+
+---
+
+## TL;DR
+
+The cycle-002 followup added four schema-shaped fields to `loa-compositions` YAMLs (`vocabulary_governance`, `surface_class`, `thinking_effort`, `codex_mode`) over PRs #4–#7 plus three new compositions (hibernate-product, ground-and-craft, feel-iterate). **None of those updated `composition.schema.json` in `loa-constructs`.** The schema's `additionalProperties: false` makes today's loa-compositions YAMLs technically schema-invalid; no CI catches the drift because no validation runs against schema in either repo.
+
+**This is a synchronization problem, not an ownership problem.** The earlier framing ("move the schema to loa-compositions") was reconsidered after Phase 1 dig surfaced that:
+- composition.schema.json is one of a coherent **schema family** (prd / sdd / sprint / trajectory / composition) in loa-constructs/.claude/schemas/
+- loa-constructs IS the engine that validates these documents — schemas are engine-side contracts, not registry-owned
+- The friction is "YAML drifted from schema and nothing caught it," not "schema lives in the wrong repo"
+
+**Fix:** keep the schema in `loa-constructs`, bump it to v1.1 with the cycle-002 fields added explicitly, and add CI in `loa-compositions` that fetches the public `$id` URL and validates every YAML on PR.
+
+---
+
+## Invariants (Ostrom)
+
+What MUST NOT CHANGE:
+
+1. **The schema family in `loa-constructs/.claude/schemas/` stays cohesive.** All five canonical doc-type schemas (prd / sdd / sprint / trajectory-entry / composition) live together. No asymmetric extraction.
+2. **Public `$id` URL is the authoritative reference.** `https://loa.dev/schemas/composition.schema.json` is how external consumers (loa-compositions CI, future Herald composition tooling, third-party engines) reach the contract. Don't break the URL.
+3. **`loa-compositions` is a registry of YAMLs, not a schema authority.** It conforms to the upstream contract; it doesn't author it.
+4. **Backward compatibility for existing loa-compositions YAMLs.** PRs #2–#7 shipped 7 compositions already. Schema bump must NOT invalidate any of them (additive changes only).
+5. **Engine reads schema, doesn't own its evolution.** When loa-compositions PRs add new YAML shapes, the schema in loa-constructs catches up via PR; the schema is the consensus contract, not unilateral.
+
+---
+
+## Blast Radius
+
+| Artifact | Change | Risk |
+|---|---|---|
+| `loa-constructs/.claude/schemas/composition.schema.json` | Bump to v1.1, add 4 new top-level / per-stage field shapes | LOW — additive only; existing fields unchanged |
+| `loa-constructs/.claude/schemas/README.md` | Document the v1.1 additions | LOW — docs |
+| `loa-constructs/grimoires/compositions/*.yaml` | (None — internal canonical compositions don't use the new fields yet) | NONE |
+| `loa-compositions/.github/workflows/validate-schema.yml` | NEW — fetches `$id` URL + validates all YAMLs | LOW — pure CI add |
+| `loa-compositions/scripts/validate-yaml.ts` | NEW — local equivalent for `bun run validate` | LOW — new file |
+| `loa-compositions/package.json` | Add `validate` script + `ajv` / `js-yaml` devDeps | LOW — new deps in devDependencies |
+| `loa-compositions/README.md` | Update schema badge from `1.0` → `1.1` and link | COSMETIC |
+| `loa-compositions/compositions/**/*.yaml` (~10 files) | Bump `schema_version: "1.0"` → `"1.1"` field | LOW — one-line change per file |
+| `loa-constructs/grimoires/loa/tracks/session-1-composition-schema-sync-kickoff.md` | NEW — session continuity record | NONE |
+
+**What breaks if wrong:** If schema bump is non-backward-compatible, all 10 loa-compositions YAMLs fail validation immediately on next CI run. Reversibility: revert the schema PR; YAMLs continue working without validation. Low total risk because no production system depends on schema validation today (this PR introduces validation FOR THE FIRST TIME).
+
+---
+
+## Data Architecture
+
+```
+                                  ┌──────────────────────────────┐
+                                  │  loa-constructs (engine)     │
+                                  │  ─────────────────────────   │
+                                  │  .claude/schemas/             │
+                                  │    composition.schema.json    │ ← SOURCE OF TRUTH
+                                  │    (v1.1, additive cycle-002) │
+                                  │                               │
+                                  │  Public $id:                  │
+                                  │  loa.dev/schemas/...          │
+                                  └──────────┬───────────────────┘
+                                             │ HTTPS fetch
+                                             ▼
+                                  ┌──────────────────────────────┐
+                                  │  loa-compositions (registry) │
+                                  │  ─────────────────────────   │
+                                  │  .github/workflows/           │
+                                  │    validate-schema.yml        │ ← CI fetches schema
+                                  │  scripts/                     │
+                                  │    validate-yaml.ts           │ ← local validator
+                                  │  compositions/                │
+                                  │    **/*.yaml (10 files)       │ ← validates against schema on PR
+                                  └──────────────────────────────┘
+```
+
+**Three-tier model preserved:**
+- Tier 1: `construct-*` repos — surface area for each construct
+- Tier 2: `loa-constructs` — Constructs Network: registry + engine + schema family
+- Tier 3: `loa-compositions` — registry of composition YAMLs that conform to the schema family
+
+---
+
+## Schema v1.1 — Field Additions
+
+Four cycle-002 followup fields to add to `composition.schema.json`:
+
+### 1. `surface_class` (top-level)
+
+```json
+{
+  "surface_class": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Drives gating intensity, codex_mode default, iteration_cap, inline_fix permission. Canonical def in compositions/sorry-for-ur-loss/outage-triage.yaml.",
+    "properties": {
+      "default": { "enum": ["culturetech-loose", "defi-strict", "mixed", "unspecified"] },
+      "enum": { "type": "array", "items": { "type": "string" } },
+      "canonical_definition": { "type": "string" },
+      "inferred_when_unspecified": { "type": "string" },
+      "affects_in_this_composition": { "type": "array", "items": { "type": "string" } },
+      "inference": { "type": "object" },
+      "affects": { "type": "object" },
+      "rationale": { "type": "string" },
+      "invocation": { "type": "object" }
+    }
+  }
+}
+```
+
+### 2. `thinking_effort` (top-level)
+
+```json
+{
+  "thinking_effort": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Per-stage hint for adaptive-thinking-capable runtimes. Canonical def in compositions/delivery/feel-iterate.yaml.",
+    "properties": {
+      "default": { "enum": ["low", "medium", "high", "xhigh", "max"] },
+      "enum": { "type": "array", "items": { "enum": ["low", "medium", "high", "xhigh", "max"] } },
+      "canonical_definition": { "type": "string" },
+      "guide": { "type": "object" },
+      "rationale": { "type": "string" },
+      "runtime_translation": { "type": "object" },
+      "promptable_steering": { "type": "string" },
+      "affects_in_this_composition": { "type": "array", "items": { "type": "string" } }
+    }
+  }
+}
+```
+
+### 3. `vocabulary_governance` (per-stage, on chain[].stage)
+
+```json
+{
+  "vocabulary_governance": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Generation-as-audit-surface discipline for chrome copy stages. Per parallel-agent Hibernation Copy Discipline brief, cycle-002 followup.",
+    "properties": {
+      "taxonomy": { "type": "object" },
+      "line_types": {
+        "type": "object",
+        "properties": {
+          "anchor": { "type": "string" },
+          "flavor": { "type": "string" }
+        }
+      },
+      "no_promises_linter": {
+        "type": "object",
+        "properties": {
+          "regex": { "type": "string" },
+          "action": { "type": "string" },
+          "rationale": { "type": "string" }
+        }
+      },
+      "bank_first_authoring": { "type": "object" },
+      "reference_brief": { "type": "string" }
+    }
+  }
+}
+```
+
+### 4. `codex_mode` (per-stage, on chain[].stage)
+
+```json
+{
+  "codex_mode": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Codex delegation vs pair-program enum on engineering-handoff stages. Canonical in compositions/sorry-for-ur-loss/outage-triage.yaml stage 3.",
+    "properties": {
+      "delegation": { "type": "string" },
+      "pair-program": { "type": "string" },
+      "default": { "enum": ["delegation", "pair-program"] }
+    }
+  }
+}
+```
+
+### 5. `thinking_effort` (per-stage, on chain[].stage — string form)
+
+In addition to the top-level object form, individual stages can carry the simple string tier:
+
+```json
+{
+  "thinking_effort": {
+    "anyOf": [
+      { "enum": ["low", "medium", "high", "xhigh", "max"] },
+      { "type": "object" }
+    ],
+    "description": "Stage-level override (string) or canonical-def object on the composition that owns the family."
+  }
+}
+```
+
+### Plus: stage 1.5 ground-canon shape
+
+The `ground-canon` stage (added v1.6.0 to triage-pause and v1.1.0 to hibernate-product) carries non-standard sub-fields: `when`, `probes` (array), `on_present_and_fresh` (array), `on_present_but_stale` (array), `on_absent` (array). These are gate-specific shapes. Either:
+- (a) Allow them as freeform via reduced strictness on stage objects (`additionalProperties: true` on stage)
+- (b) Define a `stage.gate_shape` sub-schema with the four predicates explicitly
+
+**Recommendation: (b)** for the long-term schema clarity, but (a) is acceptable as a short-term unblock if the explicit shape is too much detail for this PR.
+
+### Schema version field
+
+```json
+{
+  "schema_version": {
+    "type": "string",
+    "enum": ["1.0", "1.1"],
+    "description": "Bump to 1.1 when introducing additive field shapes. v1.0 YAMLs validated against v1.1 schema by relaxing required-field set; v1.1 YAMLs reject under v1.0 validators."
+  }
+}
+```
+
+Existing v1.0 YAMLs in loa-compositions get a one-line bump to `schema_version: "1.1"` in this migration PR.
+
+---
+
+## Build Sequence (next session executes this)
+
+### Step 0 — Branch in both repos
+
+```bash
+cd ~/Documents/GitHub/loa-constructs && git checkout -b schema-v1.1-cycle-002-fields
+cd ~/bonfire/loa-compositions  && git checkout -b add-schema-validation-ci
+```
+
+### Step 1 — Bump composition.schema.json to v1.1 (loa-constructs)
+
+Edit `/Users/zksoju/Documents/GitHub/loa-constructs/.claude/schemas/composition.schema.json`:
+
+1. Change `schema_version.const: "1.0"` to `schema_version.enum: ["1.0", "1.1"]`
+2. Add 5 new top-level / nested property definitions (see "Schema v1.1 — Field Additions" above):
+   - `surface_class` (top-level object)
+   - `thinking_effort` (top-level object + stage-level union)
+   - `vocabulary_governance` (per-stage object)
+   - `codex_mode` (per-stage object)
+   - `ground-canon` stage shape (gate sub-fields)
+3. Update `$id` if needed — keep `https://loa.dev/schemas/composition.schema.json` unchanged
+4. Update `description` to reference v1.1 and cycle-002 followup additions
+
+### Step 2 — Update schemas/README.md (loa-constructs)
+
+Document the v1.1 addition. Reference the canonical compositions where each field lives:
+- `surface_class` → outage-triage.yaml v1.2.0 stage block
+- `thinking_effort` → feel-iterate.yaml v1.1.0 top-level + per-stage
+- `vocabulary_governance` → triage-pause.yaml v1.8.0 + hibernate-product v1.2.0
+- `codex_mode` → outage-triage.yaml v1.1.0 stage 3 + triage-pause v1.5.0 stage 6.5
+
+### Step 3 — Add validation CI in loa-compositions
+
+Create `/Users/zksoju/bonfire/loa-compositions/.github/workflows/validate-schema.yml`:
+
+```yaml
+name: Validate composition YAMLs against schema
+on:
+  pull_request:
+    paths: ['compositions/**/*.yaml']
+  push:
+    branches: [main]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - run: bun install
+      - run: bun run validate:compositions
+```
+
+### Step 4 — Add local validator in loa-compositions
+
+Create `/Users/zksoju/bonfire/loa-compositions/scripts/validate-compositions.ts`:
+
+```typescript
+import { readdir, readFile } from "fs/promises";
+import { join, relative } from "path";
+import yaml from "js-yaml";
+import Ajv from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+
+const SCHEMA_URL = "https://loa.dev/schemas/composition.schema.json";
+const COMPOSITIONS_DIR = "compositions";
+
+async function main() {
+  // Fetch schema (cache to .cache/schemas/ for offline runs)
+  const schemaJson = await fetch(SCHEMA_URL).then(r => r.json());
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schemaJson);
+
+  // Walk compositions/ for YAMLs
+  const files = await walkYaml(COMPOSITIONS_DIR);
+  let failed = 0;
+
+  for (const f of files) {
+    const text = await readFile(f, "utf-8");
+    const doc = yaml.load(text);
+    if (!validate(doc)) {
+      console.error(`✗ ${f}`);
+      for (const err of validate.errors ?? []) {
+        console.error(`    ${err.instancePath} ${err.message}`);
+      }
+      failed++;
+    } else {
+      console.log(`✓ ${f}`);
+    }
+  }
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+async function walkYaml(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...await walkYaml(p));
+    else if (entry.name.endsWith(".yaml")) out.push(p);
+  }
+  return out;
+}
+
+main();
+```
+
+### Step 5 — Add devDeps + npm script (loa-compositions)
+
+Edit `/Users/zksoju/bonfire/loa-compositions/package.json` — add:
+
+```json
+{
+  "scripts": {
+    "validate:compositions": "bun scripts/validate-compositions.ts"
+  },
+  "devDependencies": {
+    "ajv": "^8.12.0",
+    "ajv-formats": "^3.0.0",
+    "js-yaml": "^4.1.0",
+    "@types/js-yaml": "^4.0.9"
+  }
+}
+```
+
+If loa-compositions has no package.json today, create a minimal one:
+
+```json
+{
+  "name": "loa-compositions",
+  "private": true,
+  "type": "module",
+  "scripts": { "validate:compositions": "bun scripts/validate-compositions.ts" },
+  "devDependencies": { /* as above */ }
+}
+```
+
+### Step 6 — Bump schema_version in all YAMLs (loa-compositions)
+
+For each YAML in `compositions/**/*.yaml`:
+
+```yaml
+schema_version: "1.0"   # → change to "1.1"
+```
+
+Files to touch (~10):
+- `compositions/delivery/direct-render.yaml` (no cycle-002 fields; can stay 1.0 if desired)
+- `compositions/delivery/feel-iterate.yaml`
+- `compositions/delivery/ground-and-craft.yaml`
+- `compositions/discovery/audit-feel.yaml` (no cycle-002 fields; can stay 1.0)
+- `compositions/discovery/find-construct.yaml` (no cycle-002 fields; can stay 1.0)
+- `compositions/experimentation/mint-codex.yaml` (no cycle-002 fields; can stay 1.0)
+- `compositions/sorry-for-ur-loss/hibernate-product.yaml`
+- `compositions/sorry-for-ur-loss/outage-triage.yaml`
+- `compositions/sorry-for-ur-loss/triage-pause.yaml`
+
+Bump only the ones using v1.1 fields. Files without new fields stay at v1.0 (backward-compat).
+
+### Step 7 — Update README badges (loa-compositions)
+
+Edit `/Users/zksoju/bonfire/loa-compositions/README.md`:
+
+```markdown
+[![schema](https://img.shields.io/badge/schema-1.1-8B5CF6)](https://github.com/0xHoneyJar/loa-constructs/blob/main/.claude/schemas/composition.schema.json)
+```
+
+### Step 8 — Run validation locally before pushing
+
+```bash
+cd ~/bonfire/loa-compositions
+bun install
+bun run validate:compositions
+# Expect: ✓ all YAMLs pass
+```
+
+### Step 9 — Commit + PR + merge
+
+Two PRs, sequenced:
+
+**PR A (loa-constructs):** "schema: composition.schema.json v1.1 — cycle-002 followup additions"
+
+**PR B (loa-compositions):** "validate: add schema-validation CI + bump v1.1 fields" — depends on PR A merging first (CI fetches the live schema URL).
+
+Operator-authorized direct merge per the cycle-002 precedent (loa-compositions PRs #2–#7).
+
+---
+
+## Verify
+
+After both PRs merge:
+
+```bash
+# Schema validates current YAMLs
+cd ~/bonfire/loa-compositions && bun run validate:compositions  # → all pass
+
+# Schema URL is current
+curl -s https://loa.dev/schemas/composition.schema.json | jq '.properties.schema_version.enum'
+# → ["1.0", "1.1"]
+
+# Future YAML changes that drift from schema get caught in PR CI
+```
+
+---
+
+## Design Rules (Alexander minimal — engineering-heavy work)
+
+- **Schema field naming:** snake_case for all new fields (matches existing `schema_version`, `compose_with`, `composes_symmetrically_with`)
+- **README badge color:** keep `8B5CF6` (matches existing badge)
+- **Error messages from validator:** include file path + JSONPath of failing field + expected vs actual; operator should be able to grep the offending YAML and fix in one read
+- **PR description shape:** include schema diff in fenced block + impact table per the cycle-002 PR precedent (#2–#7)
+
+---
+
+## What NOT to Build (Barth scope discipline)
+
+- **Don't extract schemas to a third repo (`@loa/schemas` package)** — that was Option C from the prior thread. Defer until a third consumer surfaces (Herald construct work, custom orchestrator). This PR is sync-fix only.
+- **Don't add a runtime that interprets `surface_class` / `thinking_effort` to translate to API config** — that's a separate downstream concern. Schema declares; orchestrators interpret. Out of scope.
+- **Don't refactor the schema family structure** (5 schemas in `.claude/schemas/`) — only composition.schema.json gets touched in this PR. Other schemas stay as-is.
+- **Don't move composition.schema.json out of loa-constructs** — that was the original framing; revised after dig.
+- **Don't add validation for stage-level `notes` prose content** (e.g., the bespoke-per-room language). Prose is documentation, not contract. Schema validates structure, not narrative.
+
+---
+
+## Key References
+
+| Topic | Path |
+|---|---|
+| Schema source of truth | `loa-constructs/.claude/schemas/composition.schema.json` |
+| Schema family README | `loa-constructs/.claude/schemas/README.md` |
+| Public $id URL | `https://loa.dev/schemas/composition.schema.json` |
+| Validator script (existing, construct-graph) | `loa-constructs/scripts/validate-composition.ts` (NOT a JSON-schema validator — for ghost-wire detection) |
+| schema-validator.sh tool | `loa-constructs/.claude/scripts/schema-validator.sh` |
+| Compositions registry | `loa-compositions/compositions/**/*.yaml` |
+| Composition tower (sorry-for-ur-loss) | `loa-compositions/compositions/sorry-for-ur-loss/{triage-pause,outage-triage,hibernate-product}.yaml` |
+| Composition tower (delivery) | `loa-compositions/compositions/delivery/{feel-iterate,ground-and-craft,direct-render}.yaml` |
+| Cycle-002 followup PRs | loa-compositions PRs #3, #4, #5, #6, #7 + henlo-monorepo PRs #20, #21, #22 |
+| Operator's mental model memory | `~/.claude/projects/-Users-zksoju-Documents-GitHub-henlo-monorepo/memory/feedback_schema_ownership_registry_owns_its_contract.md` |
+
+---
+
+## Open questions for next session
+
+1. **Should `schema_version` enum lock to `["1.0", "1.1"]` only, or use `pattern` for forward compat (`^1\\.\\d+$`)?** Recommendation: lock to enum; requires explicit bump per addition (clearer audit trail).
+2. **`ground-canon` stage shape — explicit sub-schema or freeform?** Recommendation: explicit (gate_shape sub-schema with the four predicates) — codifies the gate pattern as reusable.
+3. **Should validate-compositions.ts cache the schema fetch?** If yes, write to `.cache/schemas/` with a 24-hour TTL and a `--no-cache` flag. Reasonable polish, not load-bearing.
+4. **CI: GitHub Action vs reusable workflow?** Single-repo for now (simple). Promote to org-level reusable workflow if other repos start consuming the same schema.

--- a/grimoires/loa/tracks/session-1-composition-schema-sync-kickoff.md
+++ b/grimoires/loa/tracks/session-1-composition-schema-sync-kickoff.md
@@ -1,0 +1,64 @@
+---
+session: 1
+date: 2026-04-25
+type: kickoff
+status: planned
+authored_by: cycle-002 followup convergence (operator + Claude Opus 4.7)
+---
+
+# Session 1 — Composition Schema Sync (kickoff)
+
+## Scope
+
+- Bump `loa-constructs/.claude/schemas/composition.schema.json` to v1.1 with cycle-002 followup field additions (`surface_class`, `thinking_effort`, `vocabulary_governance`, `codex_mode`, `ground-canon` gate sub-fields).
+- Add schema-validation CI in `loa-compositions` that fetches the public `$id` URL and validates every YAML on PR.
+- Bump `schema_version: "1.0"` → `"1.1"` in loa-compositions YAMLs that use the new fields.
+- Update README badges in both repos.
+- Two PRs, sequenced (loa-constructs first, loa-compositions second).
+
+## Artifacts
+
+- Architecture + build doc: `grimoires/loa/specs/arch-composition-schema-sync.md` (combined; source of truth)
+- Session track: this file
+
+## Prior session
+
+Cycle-002 followup convergence shipped 7 PRs across loa-compositions (#3–#7) and henlo-monorepo (#20–#22). Schema-shaped fields were added to YAMLs without updating composition.schema.json — that drift is what this session fixes. See `henlo-monorepo:grimoires/loa/tracks/session-3-cycle-002-followup-close.md` for the upstream record.
+
+## Decisions made
+
+- **Schema stays in loa-constructs.** Earlier framing ("move to loa-compositions") was reconsidered after Phase 1 dig surfaced the schema family cohesion (5 schemas in `.claude/schemas/`) and the engine-side validation contract pattern. Friction is sync, not ownership.
+- **Schema version bumps to 1.1** with the four cycle-002 fields added explicitly — preserves `additionalProperties: false` strictness while accepting the new shapes.
+- **Backward compatible.** v1.0 YAMLs continue to validate; v1.1 introduces optional new fields. No existing composition breaks.
+- **CI validates against public `$id` URL** (`https://loa.dev/schemas/composition.schema.json`). No git submodule needed; URL is the contract.
+- **Don't extract to a third repo** (`@loa/schemas` package). Defer until a second/third consumer surfaces. Operator overbloat-pushback discipline holds.
+- **Two PRs, sequenced.** loa-constructs schema bump merges first; loa-compositions CI/validator depends on the live schema URL being current.
+
+## Three-tier mental model (corrected)
+
+| Tier | Repo | Role |
+|---|---|---|
+| 1 | 30+ `construct-*` | Surface area; constructs authored as standalone repos |
+| 2 | `loa-constructs` | Constructs Network — registry + engine + apps + canonical compositions + schema family |
+| 3 | `loa-compositions` | External registry of composition YAMLs that conform to the schema family |
+
+Tier 2 was originally framed as "just an index" — corrected: it's the engine + distribution + canonical reference + schema authority. Schema authoritative-home stays at tier 2. Tier 3 conforms.
+
+## Estimated effort
+
+- Schema bump (loa-constructs PR): ~30 min — single file edit + README update + validation against current YAMLs locally
+- Validator + CI (loa-compositions PR): ~45 min — new script (~80 LOC), CI workflow, package.json update, schema_version bumps in ~10 YAMLs, README badge update
+- Total: ~75 min for a single focused session
+
+## Memory references
+
+- `~/.claude/projects/-Users-zksoju-Documents-GitHub-henlo-monorepo/memory/feedback_schema_ownership_registry_owns_its_contract.md` — original ownership framing (now superseded by this session's revised conclusion)
+- `~/.claude/projects/-Users-zksoju-Documents-GitHub-henlo-monorepo/memory/feedback_thinking_effort_per_stage.md`
+- `~/.claude/projects/-Users-zksoju-Documents-GitHub-henlo-monorepo/memory/feedback_hibernation_copy_discipline.md`
+- `~/.claude/projects/-Users-zksoju-Documents-GitHub-henlo-monorepo/memory/feedback_push_back_on_overbloated_compositions.md`
+
+## Open threads (deferred to future sessions)
+
+- `@loa/schemas` extraction — when a second non-loa-compositions consumer surfaces (Herald construct work, custom orchestrators)
+- Runtime that interprets `surface_class` / `thinking_effort` to translate to API config — separate downstream concern
+- Construct-graph validator integration — `loa-constructs/scripts/validate-composition.ts` (ghost-wire detection) is independent of this PR's JSON-schema validator

--- a/grimoires/loa/tracks/session-2-codex-review-kickoff.md
+++ b/grimoires/loa/tracks/session-2-codex-review-kickoff.md
@@ -1,0 +1,67 @@
+---
+session: 2
+date: 2026-04-26
+type: kickoff
+status: planned
+---
+
+# Session 2 — codex-review construct + composition (kickoff)
+
+## Scope
+
+- Author new construct `construct-codex-review` (separate repo, follows construct-the-easel shape)
+- Author composition `code-implement-and-review.yaml` in loa-compositions/compositions/delivery/
+- Vendor `lib-codex-exec.sh` from loa-constructs into the new construct (version-pinned, attribution)
+- Lean SWE-focused single-persona reviewer (FAGAN placeholder); explicitly NOT overlapping with Flatline
+- Locally-owned schema (`codex-review-finding.schema.json`) — respects contracts-as-bridges by living with the impl
+- Test-bed end-to-end against henlo-monorepo perf pass (last night left a gate-shaped hole)
+
+## Artifacts
+
+- Architecture spec: `grimoires/loa/specs/arch-codex-review.md`
+
+## Prior session
+
+Session 1 (2026-04-25): yesterday's loa-compositions cycle landed `composition.schema.json` v1.0 + 5 compositions normalized. Schema-ownership doctrine settled in `composition-schema-as-bridge.md` — schema stays in loa-constructs, consumed via cross-repo CI.
+
+Last working session (2026-04-26 evening): henlo-monorepo perf pass dispatched via codex-rescue. Worked great as IMPLEMENTER but no adversarial review gate. That's the gap this construct fills.
+
+## Decisions made (informed by /hivemind contracts-as-bridges + PR #523 archaeology)
+
+1. **Schema migration: SKIP** — accept the existing doctrine. composition.schema.json stays in loa-constructs as the BRIDGE (per contracts-as-bridges: "packages are bridges; apps are deployable units"). Operator's "repo owns its shape" instinct applies to the new construct's LOCAL schema (`codex-review-finding.schema.json`) which DOES live with the impl.
+
+2. **Reframe from "resurrect gpt-review" to "build a new lean construct"** — PR #523's deprecation reasoning was honest (orphan, broken tests, silent hooks, flatline absorbed primary value). Resurrection verbatim re-fights settled work. New construct learns from the failure modes.
+
+3. **Responsibility split codified**:
+   - Flatline Protocol = high-stakes adversarial review for PRD/SDD/Sprint planning. Multi-model + multi-persona + scored arbitration.
+   - codex-review (new) = lightweight code review for diffs. Single GPT pass via codex CLI, single persona, structured JSON.
+
+4. **Construct in separate repo** (operator directive) — `construct-codex-review/`, follows construct-the-easel pattern (construct.yaml as source of truth, no manifest.json — that gets generated at install time).
+
+5. **Wrap `lib-codex-exec.sh` (CLI primitive), not codex-rescue (MCP plugin)** — operator framing: "scripts feel more functional we should wrap around core primitives like the headless codex." Vendoring with version pin chosen over sourcing-by-path for deployability.
+
+6. **Composition default convergence cap = 3 iterations** — matches gpt-review's pattern; re-review prompt converges-toward-approval (lesson from drift in the original).
+
+7. **No silently always-on hooks** — explicit invocation only. PostToolUse fire-and-forget was the primary noise generator in the original.
+
+## Open for build session
+
+- Persona name (FAGAN is placeholder — Michael Fagan invented formal code inspection)
+- Construct repo name (`construct-codex-review` proposed)
+- Test-bed: real henlo-monorepo diff vs synthetic fixture for first end-to-end
+- Hivemind page documenting the codex-review-vs-flatline split (worth writing to prevent future confusion)
+- Schema enforcement strictness — permissive (matches existing) vs strict on raw model output (catch drift early)
+
+## v2 deep-dig refinements (2026-04-26 PM)
+
+After reading the actual scripts (lib-codex-exec.sh full 417 lines, gpt-review-api.sh full 302, lib-security.sh, lib-content.sh, re-review.md prompt, gpt-review-hook.sh, schema), the spec was updated:
+
+- **Vendor list precise**: 3 libs (lib-codex-exec.sh, lib-security.sh, lib-content.sh), not 1. Skip lib-curl-fallback.sh, lib-multipass.sh, lib-route-table.sh, normalize-json.sh, all hook infra.
+- **Schema is draft-07 permissive** (not draft 2020-12 strict). Match ecosystem; the wrapper script appends meta-fields after the model returns, which strict mode would reject.
+- **Re-review prompt is the load-bearing convergence asset** — closing line "VERIFY. DON'T REINVENT. CONVERGE." Adopted verbatim with light edits (drop 5.2 reference, drop DECISION_NEEDED, drop blocking_issues, tighten to diff-only).
+- **Auto-approval at API level** is an inherited pattern — gpt-review-api.sh:264-269 returns `{verdict:APPROVED, auto_approved:true}` when iter > MAX_ITERATIONS, without invoking the model. Composition just increments iter; cap enforcement lives in the script.
+- **Bonfire and loa-constructs gpt-review-api.sh are IDENTICAL** — `diff` returns empty. Source from loa-constructs as canonical. No cleanup work needed (operator's instinct was right to defer).
+- **Hooks intentionally REMOVED in v2.0** — `inject-gpt-review-gates.sh` v2.0 comment explicitly says "No more skill/command file injection (fragile and redundant)." LOA team already learned the hook lesson. New construct: NO hooks at any layer.
+- **Token budgeting**: `lib-content.sh` has 4-tier file priority (P0=security, P1=business, P2=config, P3=docs/tests), bytes/3 token estimation, git-diff-aware splitting on `diff --git a/(.+) b/`, optional `.reviewignore` via `review-scope.sh`.
+- **lib-codex-exec.sh has Python3 fallback** for arbitrary-nesting JSON extraction (`raw_decode`) — critical for codex outputs that wrap JSON in prose with deep nesting.
+- **`lib-security.sh` adaptation needed**: drop `flatline_protocol.secret_scanning.patterns[]` config lookup (bonfire-coupled); rename to `codex_review.secret_patterns` OR drop config-driven extras entirely (V1: hardcoded patterns).


### PR DESCRIPTION
Bulk commit of operator WIP per `xcommit all` directive. Skills, composition drafts (now validate clean against v1.2), arch specs (one of which drove #215/#217/#218/#219 this session), and cycle continuity tracks. Excludes local.db.