### PR TITLE
fix(compose-run): auto-detect missing /dev/tty and skip iterate prompts

### DIFF
--- a/.claude/scripts/compose-run.sh
+++ b/.claude/scripts/compose-run.sh
@@ -101,6 +101,23 @@ done
 [[ -n "$COMPOSITION_NAME" ]] || { usage >&2; die 1 "composition name required"; }
 
 # ---------------------------------------------------------------------------
+# TTY auto-detection (bug fix 2026-04-27)
+# ---------------------------------------------------------------------------
+# Iterate-loop's `read -r answer </dev/tty` fails silently when invoked from a
+# non-interactive parent (background shell, headless CI, scheduled remote
+# runs, the loom CLI dispatching compose-run from a subprocess, etc.) — the
+# read returns empty and the loop exits after pass 1. Auto-detect here so the
+# operator doesn't need to remember --no-interactive everywhere.
+# Explicit --no-interactive still wins; auto-detection only DOWNGRADES from
+# interactive→non-interactive, never the reverse.
+if (( INTERACTIVE )); then
+  if [[ ! -e /dev/tty ]] || ! ( : </dev/tty ) 2>/dev/null; then
+    INTERACTIVE=0
+    echo "[compose-run] no readable /dev/tty — auto-disabling iterate-loop prompts" >&2
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 # Tool dependencies
 # ---------------------------------------------------------------------------
 command -v yq >/dev/null 2>&1 || die 1 "yq (v4+) required"


### PR DESCRIPTION
## Summary

Surfaced from real-use bug — operator hit it dispatching compose-run from the `loom` CLI (subprocess, no tty). The iterate-loop's `read -r answer </dev/tty` failed silently, returning empty, and the loop bailed after pass 1 even when more iterations were wanted.

## Fix

Probe `/dev/tty` readability at startup; downgrade `INTERACTIVE=0` if unavailable. Explicit `--no-interactive` still wins; auto-detection only downgrades interactive→non-interactive, never reverse.

```bash
if (( INTERACTIVE )); then
  if [[ ! -e /dev/tty ]] || ! ( : </dev/tty ) 2>/dev/null; then
    INTERACTIVE=0
    echo "[compose-run] no readable /dev/tty — auto-disabling iterate-loop prompts" >&2
  fi
fi
```

The redirect runs in a **subshell** so any failure can't kill the parent under `set -euo pipefail`. Earlier attempt using `exec 3</dev/tty` + `exec 3<&-` killed the shell when fd 3 was never opened, even with `|| true`.

## Test plan

- [x] Non-tty parent: auto-disable line prints, dry-run completes normally
- [x] `--no-interactive`: silent, dry-run completes (no auto-disable line)
- [x] `feel-image` (iterate pairs present): non-tty parent lists iterate pairs in dry-run without bailing

## Related (NOT in this PR)

**Bug 1**: `claude -p` subprocess in `stage-executor-tmux.sh` doesn't pass `--allowedTools`, so stages can't write Artifacts (only think). This is a design question — what's the right tools-mapping policy per stage's declared `writes` stream? Filed as separate issue for cycle-006 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)