### PR TITLE
feat(post-v2.40.0): spiral recovery — audit-feel composition + 4 runbooks + egress-filter + telemetry config

### DIFF
--- a/.claude/data/sprint-dag.yaml
+++ b/.claude/data/sprint-dag.yaml
@@ -1,0 +1,506 @@
+# .run/sprint-dag.yaml
+# Machine-readable task dependency graph for the Bounded-Context Substrate initiative.
+# Closes Flatline IMP-002 (beads integration + DAG materialization).
+# Sprint plan §Beads Integration + Machine-Readable Dependency Graph.
+#
+# Schema: each task declares id, sprint, title, depends_on[], blocks[].
+# Consumed by: sprint runner (parallelization), beads CLI (task creation order).
+
+schema_version: 1
+cycle: "cycle/bounded-context-polish"
+generated_at: "2026-05-09"
+
+tasks:
+  # Sprint 0 — Schemas + Tier Config
+  - id: S0-T1
+    sprint: 0
+    title: "Author construct-invocation-v0 schema"
+    priority: high
+    depends_on: []
+    blocks: [S2-T1, S2-T2, S3-T1]
+    layer: CONTRACT
+    status: completed
+
+  - id: S0-T2
+    sprint: 0
+    title: "Author construct-handoff-v0 schema"
+    priority: high
+    depends_on: []
+    blocks: [S2-T1, S2-T2]
+    layer: CONTRACT
+    status: completed
+
+  - id: S0-T3
+    sprint: 0
+    title: "Author legacy-domain-contract schema"
+    priority: medium
+    depends_on: []
+    blocks: [S6-T1, S6-T3]
+    layer: CONTRACT
+    status: completed
+
+  - id: S0-T4
+    sprint: 0
+    title: "Author construct-validation-tiers.yaml"
+    priority: high
+    depends_on: []
+    blocks: [S1-T4, S6-T2]
+    layer: CONTRACT
+    status: completed
+
+  - id: S0-T5
+    sprint: 0
+    title: "Author dry-run-fixture.schema.json"
+    priority: medium
+    depends_on: []
+    blocks: [S2-T4]
+    layer: CONTRACT
+    status: completed
+
+  - id: S0-T6
+    sprint: 0
+    title: "Extend composition.schema.json with context_policy fields"
+    priority: high
+    depends_on: []
+    blocks: [S1-T1, S3-T2, S3-T4]
+    layer: CONTRACT
+    status: completed
+
+  - id: S0-T7
+    sprint: 0
+    title: "Extend construct.schema.json for strict-tier domain requirements"
+    priority: high
+    depends_on: []
+    blocks: [S1-T4, S6-T2]
+    layer: CONTRACT
+    status: completed
+
+  - id: S0-T8
+    sprint: 0
+    title: "Extend stream schemas with domain extension fields"
+    priority: medium
+    depends_on: []
+    blocks: [S1-T2, S4-T5]
+    layer: CONTRACT
+    status: completed
+
+  # Sprint 1 — Validators
+  - id: S1-T1
+    sprint: 1
+    title: "Author lib/compose-stream-graph.sh + .py"
+    priority: high
+    depends_on: [S0-T1, S0-T2, S0-T6]
+    blocks: [S2-T4, S3-T8, S3-T9]
+    layer: CONTRACT
+    status: completed
+
+  - id: S1-T2
+    sprint: 1
+    title: "Author lib/output-gate.sh"
+    priority: high
+    depends_on: [S0-T1, S0-T2, S0-T8]
+    blocks: [S3-T8]
+    layer: CONTRACT
+    status: completed
+
+  - id: S1-T3
+    sprint: 1
+    title: "Author strict-tier prerequisite check"
+    priority: high
+    depends_on: [S0-T4]
+    blocks: [S4-T1, S4-T2]
+    layer: CONTRACT
+    status: completed
+
+  - id: S1-T4
+    sprint: 1
+    title: "Extend construct-validate.sh for tiered enforcement"
+    priority: high
+    depends_on: [S0-T4, S0-T7]
+    blocks: [S6-T2, S6-T3]
+    layer: CONTRACT
+    status: completed
+
+  - id: S1-T5
+    sprint: 1
+    title: "Pre-flight check for audit_signed:true"
+    priority: medium
+    depends_on: [S0-T1]
+    blocks: [S3-T9]
+    layer: CONTRACT
+    status: completed
+
+  - id: S1-T6
+    sprint: 1
+    title: "Test fixtures: 6 failing compositions + 1 golden-path"
+    priority: high
+    depends_on: [S1-T1, S1-T2, S1-T3]
+    blocks: [S3-T9]
+    layer: CONTRACT
+    status: completed
+
+  # Sprint 2 — Envelope Builder + Hash Chain + Dry-Run
+  - id: S2-T1
+    sprint: 2
+    title: "Author lib/envelope-builder.sh"
+    priority: high
+    depends_on: [S0-T1, S0-T2, S1-T1]
+    blocks: [S3-T9, S5-T1]
+    layer: RUNNER
+    status: completed
+
+  - id: S2-T2
+    sprint: 2
+    title: "Author lib/envelope-chain.sh (hash algorithm)"
+    priority: high
+    depends_on: [S0-T1, S0-T2]
+    blocks: [S2-T3, S3-T9, S5-T1]
+    layer: CONTRACT
+    status: completed
+
+  - id: S2-T3
+    sprint: 2
+    title: "Implement composition_id deterministic derivation"
+    priority: high
+    depends_on: [S2-T2]
+    blocks: [S3-T9, S5-T1]
+    layer: CONTRACT
+    status: completed
+
+  - id: S2-T4
+    sprint: 2
+    title: "Author compose-run.sh --dry-run --explain-context"
+    priority: medium
+    depends_on: [S0-T5, S1-T1, S2-T1, S2-T2]
+    blocks: [S3-T9, S5-T6]
+    layer: RUNNER
+    status: completed
+
+  - id: S2-T5
+    sprint: 2
+    title: "Hash chain validation at startup + per-stage + replay"
+    priority: high
+    depends_on: [S2-T2]
+    blocks: [S3-T9]
+    layer: RUNNER
+    status: completed
+
+  - id: S2-T6
+    sprint: 2
+    title: "Test fixtures: tampering sentinel test"
+    priority: high
+    depends_on: [S2-T2, S2-T5]
+    blocks: []
+    layer: RUNNER
+    status: completed
+
+  # Sprint 3 — Stage Executor (Advisory Tier)
+  - id: S3-T1
+    sprint: 3
+    title: "Refactor stage-executor-tmux.sh to argv-array invocation"
+    priority: critical
+    depends_on: [S0-T1, S2-T1]
+    blocks: [S3-T9, S4-T1]
+    layer: RUNNER
+    status: partial
+
+  - id: S3-T2
+    sprint: 3
+    title: "Implement env scrub (env -i + allowed_env_vars allowlist)"
+    priority: high
+    depends_on: [S0-T6]
+    blocks: [S3-T9, S4-T1]
+    layer: RUNNER
+    status: partial
+
+  - id: S3-T3
+    sprint: 3
+    title: "Implement fresh-pty via script -q /dev/null (argv form)"
+    priority: medium
+    depends_on: []
+    blocks: [S3-T9]
+    layer: RUNNER
+    status: partial
+
+  - id: S3-T4
+    sprint: 3
+    title: "Implement advisory-tier filesystem allowlist (LD_PRELOAD / DYLD)"
+    priority: medium
+    depends_on: [S0-T6]
+    blocks: [S3-T9]
+    layer: RUNNER
+    status: partial
+
+  - id: S3-T5
+    sprint: 3
+    title: "Provider memory disable in cheval adapters"
+    priority: high
+    depends_on: []
+    blocks: [S3-T9, S4-T5]
+    layer: RUNNER
+    status: partial
+
+  - id: S3-T6
+    sprint: 3
+    title: "New LLM session ID per stage"
+    priority: medium
+    depends_on: []
+    blocks: [S3-T9]
+    layer: RUNNER
+    status: partial
+
+  - id: S3-T7
+    sprint: 3
+    title: "Path canonicalization via realpath (symlink traversal fix)"
+    priority: high
+    depends_on: []
+    blocks: [S3-T9, S4-T5]
+    layer: RUNNER
+    status: partial
+
+  - id: S3-T8
+    sprint: 3
+    title: "Wire output validator (Sprint 1) into stage executor"
+    priority: high
+    depends_on: [S1-T2, S3-T1]
+    blocks: [S3-T9]
+    layer: RUNNER
+    status: partial
+
+  - id: S3-T9
+    sprint: 3
+    title: "audit-feel golden path end-to-end on advisory tier"
+    priority: high
+    depends_on: [S3-T1, S3-T2, S3-T3, S3-T4, S3-T5, S3-T6, S3-T7, S3-T8]
+    blocks: [S4-T5, S4-T6]
+    layer: RUNNER
+    status: open
+
+  # Sprint 4 — Strict Tier + Adversarial Suite
+  - id: S4-T1
+    sprint: 4
+    title: "Implement bwrap integration for filesystem namespace"
+    priority: high
+    depends_on: [S1-T3, S3-T1]
+    blocks: [S4-T5, S4-T6]
+    layer: RUNNER
+    status: open
+
+  - id: S4-T2
+    sprint: 4
+    title: "Implement Linux network namespace (--unshare-net + proxy bind)"
+    priority: high
+    depends_on: [S1-T3, S4-T3]
+    blocks: [S4-T5, S4-T7]
+    layer: RUNNER
+    status: open
+
+  - id: S4-T3
+    sprint: 4
+    title: "Author lib/egress-filter.py (CONNECT-only proxy)"
+    priority: high
+    depends_on: []
+    blocks: [S4-T2, S4-T4, S4-T5]
+    layer: RUNNER
+    status: completed
+
+  - id: S4-T4
+    sprint: 4
+    title: "Sentinel test: egress-proxy-die failure mode"
+    priority: medium
+    depends_on: [S4-T3]
+    blocks: []
+    layer: RUNNER
+    status: open
+
+  - id: S4-T5
+    sprint: 4
+    title: "12 adversarial test compositions with explicit per-test contracts"
+    priority: critical
+    depends_on: [S3-T9, S4-T1, S4-T3]
+    blocks: [S4-T6]
+    layer: RUNNER
+    status: open
+
+  - id: S4-T6
+    sprint: 4
+    title: "CI matrix with untrusted-code isolation (composition-strict-linux)"
+    priority: high
+    depends_on: [S4-T5]
+    blocks: []
+    layer: RUNNER
+    status: open
+
+  - id: S4-T7
+    sprint: 4
+    title: "Bwrap network design enumeration (DNS, IPv6, loopback, raw protocols)"
+    priority: high
+    depends_on: [S4-T2]
+    blocks: []
+    layer: RUNNER
+    status: open
+
+  - id: S4-T8
+    sprint: 4
+    title: "Author strict-tier-deployment.md runbook"
+    priority: medium
+    depends_on: []
+    blocks: []
+    layer: DOCS
+    status: completed
+
+  # Sprint 5 — Persistent State + Iteration Auditor
+  - id: S5-T1
+    sprint: 5
+    title: "Author lib/persistent-state.sh"
+    priority: high
+    depends_on: [S2-T1, S2-T2, S2-T3]
+    blocks: [S5-T2, S5-T3, S5-T4]
+    layer: RUNNER
+    status: completed
+
+  - id: S5-T2
+    sprint: 5
+    title: "Implement TTL policy (write vs access) with state-poisoning safeguard"
+    priority: high
+    depends_on: [S5-T1]
+    blocks: [S5-T3]
+    layer: RUNNER
+    status: completed
+
+  - id: S5-T3
+    sprint: 5
+    title: "Author compose-state-gc.sh with GC race coordination"
+    priority: medium
+    depends_on: [S5-T1, S5-T2]
+    blocks: [S5-T4]
+    layer: RUNNER
+    status: completed
+
+  - id: S5-T4
+    sprint: 5
+    title: "Sentinel test: gc-vs-running-composition.sh"
+    priority: medium
+    depends_on: [S5-T3]
+    blocks: []
+    layer: RUNNER
+    status: completed
+
+  - id: S5-T5
+    sprint: 5
+    title: "Author compose-iteration-audit.sh Phase 1 (enumerate)"
+    priority: medium
+    depends_on: []
+    blocks: [S5-T6]
+    layer: RUNNER
+    status: completed
+
+  - id: S5-T6
+    sprint: 5
+    title: "Implement compose-run --dry-run --iteration-mode=dual Phase 2"
+    priority: medium
+    depends_on: [S2-T4, S5-T5]
+    blocks: [S5-T7]
+    layer: RUNNER
+    status: completed
+
+  - id: S5-T7
+    sprint: 5
+    title: "Implement opt-in iteration_mode: stream_edge flag"
+    priority: low
+    depends_on: [S5-T6]
+    blocks: []
+    layer: RUNNER
+    status: completed
+
+  - id: S5-T8
+    sprint: 5
+    title: "Iteration validation (max_iterations + terminate_when)"
+    priority: high
+    depends_on: [S1-T1]
+    blocks: []
+    layer: CONTRACT
+    status: completed
+
+  # Sprint 6 — Manifest Migration + Docs
+  - id: S6-T1
+    sprint: 6
+    title: "Author legacy-contract-bootstrap.sh"
+    priority: medium
+    depends_on: [S0-T3, S1-T4]
+    blocks: [S6-T3]
+    layer: RUNNER
+    status: completed
+
+  - id: S6-T2
+    sprint: 6
+    title: "Author full domain block for top-12 packs"
+    priority: high
+    depends_on: [S0-T4, S0-T7, S1-T4]
+    blocks: []
+    layer: DATA
+    status: completed
+
+  - id: S6-T3
+    sprint: 6
+    title: "Generate starter compatibility contracts for legacy packs"
+    priority: medium
+    depends_on: [S6-T1]
+    blocks: []
+    layer: DATA
+    status: completed
+
+  - id: S6-T4
+    sprint: 6
+    title: "Author construct-usage-rank.sh"
+    priority: medium
+    depends_on: []
+    blocks: []
+    layer: RUNNER
+    status: completed
+
+  - id: S6-T5
+    sprint: 6
+    title: "Author grimoires/loa/runbooks/envelope-schema-migration.md"
+    priority: medium
+    depends_on: [S0-T1, S0-T2, S2-T2]
+    blocks: []
+    layer: DOCS
+    status: completed
+
+  - id: S6-T6
+    sprint: 6
+    title: "Update audit-keys-bootstrap.md for composition audit_signed flag"
+    priority: low
+    depends_on: [S1-T5]
+    blocks: []
+    layer: DOCS
+    status: completed
+
+  - id: S6-T7
+    sprint: 6
+    title: "Author grimoires/loa/runbooks/context-policy-guide.md"
+    priority: medium
+    depends_on: [S0-T6]
+    blocks: []
+    layer: DOCS
+    status: completed
+
+  - id: S6-T8
+    sprint: 6
+    title: "Update BUTTERFREEZONE.md with substrate availability"
+    priority: low
+    depends_on: []
+    blocks: []
+    layer: DOCS
+    status: open
+
+# Parallelization hints for sprint runner
+parallelization:
+  - group: sprint_4_5_parallel
+    description: "Sprint 5 can run in parallel with Sprint 4 (independent codebases)"
+    sprints: [4, 5]
+  - group: sprint_6_manifests_parallel
+    description: "Sprint 6 T2 manifest authoring can parallelize across 12 packs"
+    tasks: [S6-T2]
+    parallelism: 4

--- a/.claude/data/telemetry/compose-runs.schema.json
+++ b/.claude/data/telemetry/compose-runs.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "loa.telemetry.compose-run.v1",
+  "title": "Composition Run Telemetry Record",
+  "description": "One JSONL record per compose-run.sh invocation. Stored at .run/telemetry/compose-runs.jsonl. Retention: 90 days per sprint.md §Telemetry.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "ts",
+    "run_id",
+    "composition_id",
+    "composition_path",
+    "outcome",
+    "stage_count",
+    "duration_ms"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "loa.telemetry.compose-run.v1",
+      "description": "Schema version sentinel for forward compatibility."
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp of run completion."
+    },
+    "run_id": {
+      "type": "string",
+      "pattern": "^run_[0-9]{4}_[0-9]{2}_[0-9]{2}_[0-9A-Za-z_-]+$",
+      "description": "Unique run identifier."
+    },
+    "composition_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9_-]+@sha256:[0-9a-f]{12,64}$",
+      "description": "Deterministic composition ID (basename@sha256:prefix). SDD §3.1 IMP-001."
+    },
+    "composition_path": {
+      "type": "string",
+      "description": "Relative path to composition YAML from repo root."
+    },
+    "outcome": {
+      "type": "string",
+      "enum": ["success", "failure", "partial", "aborted", "validation_error"],
+      "description": "Terminal outcome of the full composition run."
+    },
+    "stage_count": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of stages in the composition."
+    },
+    "stages_completed": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Stages that reached handoff status=success."
+    },
+    "duration_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Wall-clock duration of the full run in milliseconds."
+    },
+    "isolation_tiers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["strict", "advisory"]
+      },
+      "description": "Per-stage isolation tiers (index 0 = stage 1)."
+    },
+    "iteration_mode": {
+      "type": ["string", "null"],
+      "enum": ["persistent_leak", "stream_edge", null],
+      "description": "Iteration mode used (null if no iterate: blocks)."
+    },
+    "persistent_state_used": {
+      "type": "boolean",
+      "description": "True if any stage used mode: persistent."
+    },
+    "audit_signed": {
+      "type": "boolean",
+      "description": "True if audit_signed: true was set on the composition."
+    },
+    "error_code": {
+      "type": ["string", "null"],
+      "description": "Structured error code on non-success outcome, e.g. [STREAM-NO-PRODUCER]."
+    },
+    "error_stage": {
+      "type": ["integer", "null"],
+      "minimum": 1,
+      "description": "Stage number where the first error occurred."
+    },
+    "git_sha": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "HEAD commit SHA at run time for provenance."
+    }
+  }
+}

--- a/.claude/data/telemetry/retention-policy.yaml
+++ b/.claude/data/telemetry/retention-policy.yaml
@@ -1,0 +1,63 @@
+# .run/telemetry/retention-policy.yaml
+# Schema-validated telemetry retention policy for the bounded-context substrate.
+# Enforced by compose-telemetry-gc.sh (runs weekly via cron).
+# Sprint plan §Telemetry Schema + Retention (closes Flatline IMP-005).
+#
+# Each entry specifies:
+#   path_glob      — glob pattern relative to .run/telemetry/
+#   retention_days — maximum age before deletion
+#   schema         — JSON Schema for validating records before archival
+#   description    — human-readable purpose note
+
+schema_version: 1
+
+streams:
+
+  - id: compose_runs
+    path_glob: "compose-runs.jsonl"
+    retention_days: 90
+    schema: ".claude/data/telemetry/compose-runs.schema.json"
+    description: >
+      One record per compose-run.sh invocation. Used to track adoption of
+      advisory vs strict tier, iteration mode usage, and failure rates.
+      90-day window covers one full quarterly review cycle.
+
+  - id: iteration_modes
+    path_glob: "iteration-modes.jsonl"
+    retention_days: 365
+    schema: null
+    description: >
+      Per-composition iteration mode telemetry emitted by compose-iteration-audit.sh.
+      Long-tail signal (365 days) used for the default-flip decision: when 100%
+      of catalogued compositions pass L1+L2 dual-run, the default switches from
+      persistent_leak to stream_edge. This decision requires at least one full
+      cycle (3 months) of dual-run data.
+
+  - id: pack_tiers
+    path_glob: "pack-tiers.jsonl"
+    retention_days: 365
+    schema: null
+    description: >
+      Tier distribution per pack, emitted by construct-validate.sh on each
+      validation run. Used to track migration progress (advisory → compatibility
+      → strict) and surface packs that have stalled mid-migration.
+
+  - id: egress_logs
+    path_glob: "compose/*/stage-*/egress.jsonl"
+    retention_days: 30
+    schema: null
+    description: >
+      Per-stage egress proxy event log. 30-day window matches the L3
+      scheduled-cycle max_cycle_seconds heuristic. Rotated by
+      compose-telemetry-gc.sh. Not schema-validated (egress log is
+      unstructured operational data).
+
+# GC configuration
+gc:
+  # compose-telemetry-gc.sh runs weekly (cron: 0 2 * * 0)
+  schedule_cron: "0 2 * * 0"
+  # Dry-run mode: log what would be deleted but do not delete.
+  dry_run: false
+  # Minimum age before a file is eligible for GC, regardless of retention_days.
+  # Prevents accidental deletion of very recent files if a clock skew occurs.
+  minimum_age_hours: 48

--- a/.claude/scripts/lib/egress-filter.py
+++ b/.claude/scripts/lib/egress-filter.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""
+lib/egress-filter.py — Sprint 4 (S4-T3) — userspace egress filter / CONNECT proxy
+SDD §2.3, FR-4.1 network egress allowlist.
+
+CONNECT-only HTTPS proxy with host:port allowlist.
+- Does NOT MITM (no CA trust required, no cert manipulation).
+- Enforces allowlist via the CONNECT request line.
+- Logs every attempted connection to egress.jsonl.
+- Fail-closed: proxy death causes stage SIGKILL (monitored by stage executor).
+- Advisory-tier scope: HTTP_PROXY-aware code only; raw sockets / DNS / UDP
+  not covered (explicit advisory-tier limitation per SDD §2.3).
+
+Usage:
+    egress-filter.py --port <port> --allowlist-file <path> \
+                     [--log-file <path>] [--timeout <seconds>]
+
+    egress-filter.py --port 0 --allowlist-json '[{"host":"api.anthropic.com","port":443}]'
+
+Allowlist file (YAML or JSON):
+    allowed_egress:
+      - host: api.anthropic.com
+        port: 443
+      - host: api.openai.com
+        port: 443
+
+Exit codes:
+    0  clean shutdown
+    1  configuration error (bad allowlist, port conflict)
+    2  usage error
+    78 EX_CONFIG (missing required arguments)
+
+Error codes emitted to egress.jsonl:
+    [EGRESS-DENIED]      Host:port not in allowlist
+    [EGRESS-PROXY-DOWN]  Proxy died; stage executor should SIGKILL stage subprocess
+    [EGRESS-LOG-ERROR]   Could not write to log file (degraded mode; continues)
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import select
+import signal
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------------
+
+class EgressAllowlist:
+    """Host:port allowlist with O(1) lookup."""
+
+    def __init__(self, entries: list[dict]) -> None:
+        self._allowed: set[tuple[str, int]] = set()
+        for entry in entries:
+            host = str(entry.get("host", "")).strip().lower()
+            port_raw = entry.get("port", 0)
+            try:
+                port = int(port_raw)
+            except (TypeError, ValueError):
+                raise ValueError(f"Invalid port {port_raw!r} in allowlist entry {entry!r}")
+            if not host:
+                raise ValueError(f"Empty host in allowlist entry {entry!r}")
+            self._allowed.add((host, port))
+
+    def permits(self, host: str, port: int) -> bool:
+        return (host.strip().lower(), port) in self._allowed
+
+    def __repr__(self) -> str:
+        return f"EgressAllowlist({sorted(self._allowed)})"
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+class EgressLogger:
+    """Thread-safe JSONL logger for egress events."""
+
+    def __init__(self, log_path: Optional[str]) -> None:
+        self._path = log_path
+        self._lock = threading.Lock()
+
+    def _emit(self, record: dict) -> None:
+        record.setdefault("ts", datetime.datetime.utcnow().isoformat() + "Z")
+        line = json.dumps(record, separators=(",", ":")) + "\n"
+        with self._lock:
+            if self._path:
+                try:
+                    with open(self._path, "a") as fh:
+                        fh.write(line)
+                except OSError as exc:
+                    print(f"[egress-filter] [EGRESS-LOG-ERROR] {exc}", file=sys.stderr)
+            else:
+                print(line.rstrip(), file=sys.stderr)
+
+    def permitted(self, host: str, port: int, client_addr: tuple) -> None:
+        self._emit({
+            "event": "egress.permitted",
+            "host": host,
+            "port": port,
+            "client": f"{client_addr[0]}:{client_addr[1]}",
+        })
+
+    def denied(self, host: str, port: int, client_addr: tuple) -> None:
+        self._emit({
+            "event": "egress.denied",
+            "error_code": "[EGRESS-DENIED]",
+            "host": host,
+            "port": port,
+            "client": f"{client_addr[0]}:{client_addr[1]}",
+        })
+
+    def error(self, msg: str, **kw) -> None:
+        self._emit({"event": "egress.error", "message": msg, **kw})
+
+    def shutdown(self, reason: str) -> None:
+        self._emit({"event": "egress.shutdown", "reason": reason})
+
+
+# ---------------------------------------------------------------------------
+# CONNECT-only proxy handler
+# ---------------------------------------------------------------------------
+
+_BUFSIZE = 65536
+_CONNECT_TIMEOUT = 10  # seconds to connect to upstream
+
+
+def _tunnel(src: socket.socket, dst: socket.socket, stop_event: threading.Event) -> None:
+    """Bidirectional byte relay between two sockets."""
+    src.setblocking(False)
+    dst.setblocking(False)
+    try:
+        while not stop_event.is_set():
+            readable, _, exceptional = select.select([src, dst], [], [src, dst], 1.0)
+            if exceptional:
+                break
+            for sock in readable:
+                other = dst if sock is src else src
+                try:
+                    data = sock.recv(_BUFSIZE)
+                    if not data:
+                        return
+                    other.sendall(data)
+                except OSError:
+                    return
+    finally:
+        for s in (src, dst):
+            try:
+                s.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+
+
+def _handle_connection(
+    client_sock: socket.socket,
+    client_addr: tuple,
+    allowlist: EgressAllowlist,
+    logger: EgressLogger,
+    timeout: int,
+) -> None:
+    """Handle a single client connection — CONNECT method only."""
+    client_sock.settimeout(timeout)
+    upstream: Optional[socket.socket] = None
+    stop_event = threading.Event()
+
+    try:
+        # Read the first request line (CONNECT host:port HTTP/1.x)
+        buf = b""
+        while b"\r\n\r\n" not in buf and len(buf) < 4096:
+            chunk = client_sock.recv(256)
+            if not chunk:
+                return
+            buf += chunk
+
+        request_line = buf.split(b"\r\n")[0].decode("latin-1", errors="replace")
+        parts = request_line.split()
+
+        if len(parts) < 3 or parts[0].upper() != "CONNECT":
+            # Non-CONNECT methods are not supported (advisory-tier HTTPS only).
+            client_sock.sendall(
+                b"HTTP/1.1 405 Method Not Allowed\r\n"
+                b"Content-Length: 0\r\n\r\n"
+            )
+            logger.error("non-CONNECT request rejected", method=parts[0] if parts else "?")
+            return
+
+        authority = parts[1]  # host:port
+        if ":" not in authority:
+            client_sock.sendall(
+                b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n"
+            )
+            logger.error("malformed CONNECT authority", authority=authority)
+            return
+
+        host, port_str = authority.rsplit(":", 1)
+        try:
+            port = int(port_str)
+        except ValueError:
+            client_sock.sendall(
+                b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n"
+            )
+            logger.error("non-numeric port in CONNECT", authority=authority)
+            return
+
+        if not allowlist.permits(host, port):
+            logger.denied(host, port, client_addr)
+            client_sock.sendall(
+                b"HTTP/1.1 403 Forbidden\r\n"
+                b"X-Egress-Filter: [EGRESS-DENIED]\r\n"
+                b"Content-Length: 0\r\n\r\n"
+            )
+            return
+
+        # Permitted — open upstream connection
+        logger.permitted(host, port, client_addr)
+        upstream = socket.create_connection((host, port), timeout=_CONNECT_TIMEOUT)
+        client_sock.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        client_sock.settimeout(None)
+        upstream.settimeout(None)
+
+        # Relay bytes in both directions
+        t = threading.Thread(target=_tunnel, args=(client_sock, upstream, stop_event), daemon=True)
+        t.start()
+        _tunnel(upstream, client_sock, stop_event)
+        stop_event.set()
+        t.join(timeout=5)
+
+    except OSError as exc:
+        logger.error(f"connection error: {exc}")
+    finally:
+        stop_event.set()
+        for s in (client_sock, upstream):
+            if s is not None:
+                try:
+                    s.close()
+                except OSError:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Main server loop
+# ---------------------------------------------------------------------------
+
+class EgressFilterServer:
+    """TCP server that accepts connections and spawns handler threads."""
+
+    def __init__(
+        self,
+        port: int,
+        allowlist: EgressAllowlist,
+        logger: EgressLogger,
+        timeout: int = 30,
+    ) -> None:
+        self._allowlist = allowlist
+        self._logger = logger
+        self._timeout = timeout
+        self._server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server_sock.bind(("127.0.0.1", port))
+        self._server_sock.listen(128)
+        self._bound_port = self._server_sock.getsockname()[1]
+        self._running = True
+
+    @property
+    def port(self) -> int:
+        return self._bound_port
+
+    def run(self) -> None:
+        print(f"[egress-filter] listening on 127.0.0.1:{self._bound_port}", file=sys.stderr, flush=True)
+        # Write the bound port to stdout for the stage executor to read
+        print(self._bound_port, flush=True)
+
+        self._server_sock.settimeout(1.0)
+        while self._running:
+            try:
+                client_sock, client_addr = self._server_sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            t = threading.Thread(
+                target=_handle_connection,
+                args=(client_sock, client_addr, self._allowlist, self._logger, self._timeout),
+                daemon=True,
+            )
+            t.start()
+
+    def stop(self, reason: str = "shutdown") -> None:
+        self._running = False
+        self._logger.shutdown(reason)
+        try:
+            self._server_sock.close()
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Allowlist loading
+# ---------------------------------------------------------------------------
+
+def _load_allowlist_file(path: str) -> list[dict]:
+    import pathlib
+    content = pathlib.Path(path).read_text()
+    # Try JSON first, then YAML
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        try:
+            import yaml  # type: ignore[import-untyped]
+            data = yaml.safe_load(content)
+        except ImportError:
+            raise RuntimeError(
+                "[egress-filter] pyyaml required for YAML allowlist files. "
+                "Install: pip install pyyaml"
+            )
+    if isinstance(data, dict) and "allowed_egress" in data:
+        return data["allowed_egress"] or []
+    if isinstance(data, list):
+        return data
+    raise ValueError(f"Unexpected allowlist format in {path!r}. "
+                     "Expected list or {{allowed_egress: [...]}}.")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="CONNECT-only egress filter proxy (SDD §2.3)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--port", type=int, default=0,
+                        help="Listen port (0 = OS-assigned; bound port printed to stdout)")
+    parser.add_argument("--allowlist-file", metavar="PATH",
+                        help="YAML/JSON file with host:port allowlist")
+    parser.add_argument("--allowlist-json", metavar="JSON",
+                        help="Inline JSON allowlist array or {allowed_egress:[...]} object")
+    parser.add_argument("--log-file", metavar="PATH",
+                        help="Egress event log (JSONL). Defaults to stderr.")
+    parser.add_argument("--timeout", type=int, default=30,
+                        help="Per-connection tunnel idle timeout seconds (default: 30)")
+    parser.add_argument("--allow-none", action="store_true",
+                        help="Start with empty allowlist (deny-all mode); useful for testing")
+
+    args = parser.parse_args(argv)
+
+    # Build allowlist entries
+    entries: list[dict] = []
+    if args.allowlist_file:
+        try:
+            entries.extend(_load_allowlist_file(args.allowlist_file))
+        except Exception as exc:
+            print(f"[egress-filter] ERROR loading allowlist file: {exc}", file=sys.stderr)
+            return 1
+    if args.allowlist_json:
+        try:
+            raw = json.loads(args.allowlist_json)
+            if isinstance(raw, dict) and "allowed_egress" in raw:
+                entries.extend(raw["allowed_egress"] or [])
+            elif isinstance(raw, list):
+                entries.extend(raw)
+            else:
+                print("[egress-filter] ERROR: --allowlist-json must be a list or "
+                      "{allowed_egress: [...]}", file=sys.stderr)
+                return 1
+        except json.JSONDecodeError as exc:
+            print(f"[egress-filter] ERROR parsing --allowlist-json: {exc}", file=sys.stderr)
+            return 1
+
+    if not entries and not args.allow_none:
+        print(
+            "[egress-filter] ERROR: no allowlist provided. "
+            "Use --allowlist-file, --allowlist-json, or --allow-none for deny-all mode.",
+            file=sys.stderr,
+        )
+        return 78  # EX_CONFIG
+
+    try:
+        allowlist = EgressAllowlist(entries)
+    except ValueError as exc:
+        print(f"[egress-filter] ERROR building allowlist: {exc}", file=sys.stderr)
+        return 1
+
+    logger = EgressLogger(args.log_file)
+    server = EgressFilterServer(
+        port=args.port,
+        allowlist=allowlist,
+        logger=logger,
+        timeout=args.timeout,
+    )
+
+    def _handle_signal(signum: int, _frame) -> None:
+        server.stop(f"signal-{signum}")
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    try:
+        server.run()
+    except KeyboardInterrupt:
+        server.stop("keyboard-interrupt")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/BUTTERFREEZONE.md
+++ b/BUTTERFREEZONE.md
@@ -61,20 +61,20 @@ graph TD
     api[api]
     apps[apps]
     audits[audits]
+    compositions[compositions]
+    cycles[cycles]
     docs[docs]
     evals[evals]
     grimoires[grimoires]
-    lib[lib]
-    packages[packages]
     Root[Project Root]
     Root --> api
     Root --> apps
     Root --> audits
+    Root --> compositions
+    Root --> cycles
     Root --> docs
     Root --> evals
     Root --> grimoires
-    Root --> lib
-    Root --> packages
 ```
 Directory structure:
 ```
@@ -86,6 +86,16 @@ Directory structure:
 ./apps/api
 ./apps/docs
 ./audits
+./compositions
+./cycles
+./cycles/cycle-309722a219
+./cycles/cycle-309725186c
+./cycles/cycle-309728dd1b
+./cycles/cycle-309806767c
+./cycles/cycle-30980925d5
+./cycles/cycle-309811b105
+./cycles/cycle-30990251ff
+./cycles/cycle-31047133ca
 ./docs
 ./docs/architecture
 ./docs/archive
@@ -98,16 +108,6 @@ Directory structure:
 ./docs/tutorials
 ./evals
 ./evals/baselines
-./evals/fixtures
-./evals/graders
-./evals/harness
-./evals/results
-./evals/suites
-./evals/tasks
-./evals/tests
-./grimoires
-./grimoires/artisan
-./grimoires/beacon
 ```
 
 ## Interfaces
@@ -182,19 +182,21 @@ Directory structure:
 | `api/` | 3 | API endpoints | \u2014 |
 | `apps/` | 15719 | Uapps | \u2014 |
 | `audits/` | 1 | Uaudits | \u2014 |
+| `compositions/` | 1 | Ucompositions | \u2014 |
+| `cycles/` | 45 | Documentation | \u2014 |
 | `docs/` | 49 | Documentation | \u2014 |
 | `evals/` | 122 | Benchmarking and regression framework for the Loa agent development system. Ensures framework changes don't degrade agent behavior through | [evals/README.md](evals/README.md) |
-| `grimoires/` | 1030 | Home to all grimoire directories for the Loa | [grimoires/README.md](grimoires/README.md) |
+| `grimoires/` | 1036 | Home to all grimoire directories for the Loa | [grimoires/README.md](grimoires/README.md) |
 | `lib/` | 1 | Source code | \u2014 |
 | `packages/` | 1176 | Upackages | \u2014 |
 | `scripts/` | 36 | Utility scripts | \u2014 |
-| `tests/` | 550 | Test suites | \u2014 |
+| `tests/` | 553 | Test suites | \u2014 |
 | `tools/` | 3 | Utools | \u2014 |
 
 ## Verification
 <!-- provenance: CODE-FACTUAL -->
 - Trust Level: **L2 — CI Verified**
-- 553 test files across 1 suite
+- 556 test files across 1 suite
 - CI/CD: GitHub Actions (14 workflows)
 - Linting: ESLint configured
 - Security: SECURITY.md present
@@ -239,16 +241,16 @@ Available commands:
 - `npm run test` — turbo
 - `npm run test:coverage` — turbo
 <!-- ground-truth-meta
-head_sha: d9a9ad3bc118b7897670e6df9a4c30f610491785
-generated_at: 2026-05-09T01:56:42Z
+head_sha: f3cecde3826e5894ec180d9ddd3992d3a994b96a
+generated_at: 2026-05-09T16:25:16Z
 generator: butterfreezone-gen v1.0.0
 sections:
   agent_context: f6cbbb733fad20b570081293245b10a69209411de598e86bc2c6d86fbda2df10
   capabilities: 4b62d222e5aaf2083317bf600ba3f019afeb0698d303f2bf7509a2cec59b11b9
-  architecture: e1d2eacbde1cc866202d876e3f650a1432a8b43987e3d32ca8cc4cdba9e0d026
+  architecture: 6daad447e2220a822052437eab179dc79b17413a123636bd0b070035d5823e32
   interfaces: b50b0e09bda2d8f39e3b0d7e0914a966457386f37d823677a3a7d490881d24bc
-  module_map: 30de6d94a041b75076d71532c71d80dd78cdf095dcdb16fcecd24b941c299c7d
-  verification: c574241585a536659944219c050e39c51798aecb17df1e1edff9ec3bd80b069f
+  module_map: 86db6f5d7aaac62475e10da48868688d840200542125238db6dedb745f013a86
+  verification: 96d9d021ae37b016d9d180cfd3e2660601a18614b38cc2420acfd5ad44e41abd
   agents: ca263d1e05fd123434a21ef574fc8d76b559d22060719640a1f060527ef6a0b6
   ecosystem: 2dc951cf4baf045c490819286fb4c5b11166efc12c58ea26517656b5f1171bde
   culture: f73380f93bb4fadf36ccc10d60fc57555914363fc90e4f15b4dc4eb92bd1640f

--- a/compositions/audit-feel.yaml
+++ b/compositions/audit-feel.yaml
@@ -7,7 +7,11 @@
 # context_policy, isolation_tier, and envelope contract fields from the
 # substrate SDD (Sprint 3 S3-T9 golden-path target).
 #
-# Supersedes: grimoires/compositions/discovery/audit-feel.yaml (doctrine-only)
+# Supersedes: grimoires/compositions/discovery/audit-feel.yaml (doctrine-only,
+#             marked `deprecated: true` in the same change). Resolver picks
+#             this file by namespace+name; the predecessor is retained as a
+#             doctrine breadcrumb (the v1 folklore → v2 doctrine → v3 substrate
+#             evolution trail). LOW-3 disambiguation per BB review 2026-05-09.
 # =====================================================================
 
 schema_version: "1.1"
@@ -56,10 +60,16 @@ chain:
       include_prior_transcript: false
       include_unread_stage_outputs: false
       include_unlisted_grimoires: false
+      # MEDIUM-2 fix (BB review 2026-05-09): orchestrator MUST stage the
+      # operator-supplied target_artifact under runs/{{run_id}}/input/
+      # before stage-1 starts. Do NOT interpolate {{target_artifact}}
+      # directly into a path glob — target_artifact is a typed Artifact
+      # envelope, not a path string. Type-confused interpolation is the
+      # Log4Shell bug shape (CVE-2021-44228). The egress filter bounds
+      # blast radius, but the contract should be explicit at this layer.
       allowed_read_paths:
         - ".claude/constructs/packs/artisan/skills/decomposing-feel/**"
         - "grimoires/loa/runs/{{run_id}}/input/**"
-        - "{{target_artifact}}"
       allowed_write_paths:
         - ".run/compose/{{run_id}}/stage-1/output/**"
       allowed_env_vars:
@@ -152,12 +162,22 @@ chain:
           required: true
 
 # ---- Outputs (composition-level) -----------------------------------
+#
+# LOW-1 fix (BB review 2026-05-09): both stage-2 and stage-3 emit
+# `Verdict` with the same schema_id. The composition-level output
+# binding therefore needs an explicit `source_stage` to disambiguate
+# which producer is canonical. Without it, type-only resolution would
+# match whichever artifact the resolver finds first (Kafka topic-
+# compaction primary-key shape). When loa.stream.EnrichedVerdict.v1
+# exists, prefer renaming stage-3's output type — that is the cleaner
+# self-documenting fix. Until then, source_stage carries the contract.
 
 outputs:
   - type: Verdict
+    source_stage: audit-feel.stage-3
     destination: ".run/feedback-v3.jsonl"
     schema: ".claude/schemas/streams/loa.stream.Verdict.v1.schema.json"
-    description: Final feel-audit verdict with evidence chain
+    description: Final feel-audit verdict with evidence chain (stage-3 enriched)
   - type: Signal
     destination: ".run/construct-trajectory.jsonl"
     description: Invocation trail for all three stages

--- a/compositions/audit-feel.yaml
+++ b/compositions/audit-feel.yaml
@@ -1,0 +1,173 @@
+# compositions/audit-feel.yaml — Golden-path bounded-context composition
+# =====================================================================
+# Surfaces material-quality issues during FEEL sessions using observer's
+# audit depth on top of artisan's feel lens.
+#
+# This is the bounded-context-aware v2 of the composition, incorporating
+# context_policy, isolation_tier, and envelope contract fields from the
+# substrate SDD (Sprint 3 S3-T9 golden-path target).
+#
+# Supersedes: grimoires/compositions/discovery/audit-feel.yaml (doctrine-only)
+# =====================================================================
+
+schema_version: "1.1"
+kind: workflow
+name: audit-feel
+description: >
+  Surface material-quality issues during FEEL sessions using
+  observer critique for audit depth.
+
+intent: >
+  Audit a UI component, interaction pattern, or artifact for craft-feel
+  compliance — produce an evidence-grounded Verdict combining artisan's
+  material decomposition with observer's cross-surface friction map.
+
+# ---- Substrate fields (bounded-context substrate, Sprint 0+) -----
+
+audit_signed: false            # set true to enable cycle-098 Ed25519 chain
+persistent_state_ttl_policy: write  # write (default) | access
+
+# ---- Composition inputs (operator-supplied at run time) -----------
+# Stage 1 reads Artifact (the target file/component under audit) and
+# OperatorModel (the operator's intent + brand context). Both are
+# supplied externally. Without this block, stream-graph validator emits
+# [STREAM-NO-PRODUCER] (closes the validator finding from the spiral
+# recovery cherry-pick, 2026-05-09).
+inputs:
+  - type: Artifact
+    name: target_artifact
+    schema_id: loa.stream.Artifact.v1
+  - type: OperatorModel
+    name: operator_model
+    schema_id: loa.stream.OperatorModel.v1
+
+# ---- Stages -------------------------------------------------------
+
+chain:
+  - stage_id: audit-feel.stage-1
+    stage: 1
+    construct: artisan
+    skill: decomposing-feel
+    reads: [Artifact, OperatorModel]
+    writes: [Signal]
+    role: primary
+
+    context_policy:
+      include_prior_transcript: false
+      include_unread_stage_outputs: false
+      include_unlisted_grimoires: false
+      allowed_read_paths:
+        - ".claude/constructs/packs/artisan/skills/decomposing-feel/**"
+        - "grimoires/loa/runs/{{run_id}}/input/**"
+        - "{{target_artifact}}"
+      allowed_write_paths:
+        - ".run/compose/{{run_id}}/stage-1/output/**"
+      allowed_env_vars:
+        - PATH
+        - HOME
+        - LANG
+        - LC_ALL
+      allow_network: false
+      allowed_egress: []
+      llm_session_strategy: fresh
+      allowed_mcp_tools: []
+      isolation_tier: advisory      # strict requires Linux+bwrap+CAP_NET_ADMIN
+
+    output_contract:
+      writes:
+        - type: Signal
+          schema_id: "loa.stream.Signal.v1"
+          destination: ".run/compose/{{run_id}}/stage-1/output/decomposition.signal.json"
+          required: true
+
+  - stage_id: audit-feel.stage-2
+    stage: 2
+    construct: artisan
+    skill: scoring-experience
+    reads: [Signal]
+    writes: [Verdict]
+    role: primary
+
+    context_policy:
+      include_prior_transcript: false
+      include_unread_stage_outputs: false
+      include_unlisted_grimoires: false
+      allowed_read_paths:
+        - ".claude/constructs/packs/artisan/skills/scoring-experience/**"
+        - ".run/compose/{{run_id}}/stage-1/output/**"
+      allowed_write_paths:
+        - ".run/compose/{{run_id}}/stage-2/output/**"
+      allowed_env_vars:
+        - PATH
+        - HOME
+        - LANG
+        - LC_ALL
+      allow_network: false
+      allowed_egress: []
+      llm_session_strategy: fresh
+      allowed_mcp_tools: []
+      isolation_tier: advisory
+
+    output_contract:
+      writes:
+        - type: Verdict
+          schema_id: "loa.stream.Verdict.v1"
+          destination: ".run/compose/{{run_id}}/stage-2/output/scored.verdict.json"
+          required: true
+
+  - stage_id: audit-feel.stage-3
+    stage: 3
+    construct: observer
+    skill: analyzing-gaps
+    reads: [Verdict, Signal]
+    writes: [Verdict]
+    role: cross-reference
+
+    context_policy:
+      include_prior_transcript: false
+      include_unread_stage_outputs: false
+      include_unlisted_grimoires: false
+      allowed_read_paths:
+        - ".claude/constructs/packs/observer/skills/analyzing-gaps/**"
+        - ".run/compose/{{run_id}}/stage-1/output/**"
+        - ".run/compose/{{run_id}}/stage-2/output/**"
+      allowed_write_paths:
+        - ".run/compose/{{run_id}}/stage-3/output/**"
+      allowed_env_vars:
+        - PATH
+        - HOME
+        - LANG
+        - LC_ALL
+      allow_network: false
+      allowed_egress: []
+      llm_session_strategy: fresh
+      allowed_mcp_tools: []
+      isolation_tier: advisory
+
+    output_contract:
+      writes:
+        - type: Verdict
+          schema_id: "loa.stream.Verdict.v1"
+          destination: ".run/compose/{{run_id}}/stage-3/output/enriched.verdict.json"
+          required: true
+
+# ---- Outputs (composition-level) -----------------------------------
+
+outputs:
+  - type: Verdict
+    destination: ".run/feedback-v3.jsonl"
+    schema: ".claude/schemas/streams/loa.stream.Verdict.v1.schema.json"
+    description: Final feel-audit verdict with evidence chain
+  - type: Signal
+    destination: ".run/construct-trajectory.jsonl"
+    description: Invocation trail for all three stages
+
+# ---- Composition metadata ------------------------------------------
+
+compose_with:
+  - artisan
+  - observer
+
+version: "3.0.0"
+authored_at: "2026-05-09"
+authored_by: "cycle-spiral-20260509 (bounded-context substrate sprint 6)"

--- a/compositions/audit-feel.yaml
+++ b/compositions/audit-feel.yaml
@@ -1,5 +1,22 @@
 # compositions/audit-feel.yaml — Golden-path bounded-context composition
 # =====================================================================
+#
+# ⚠️  ISOLATION TIER: ADVISORY (documentation, not enforcement)
+# ---------------------------------------------------------------------
+# Every stage below sets `isolation_tier: advisory`. In advisory mode
+# `allow_network: false`, `allowed_egress: []`, and the path allowlists
+# are intent declarations — the substrate logs violations but does NOT
+# kernel-enforce them. Constructs are trusted to honor the contract.
+#
+# To get kernel-level enforcement, upgrade stages to `isolation_tier:
+# strict` (requires bwrap + CAP_NET_ADMIN + cheval — see
+# `grimoires/loa/runbooks/strict-tier-deployment.md`). Strict is the
+# correct setting for untrusted-artifact audits running in CI; advisory
+# is the right setting for trusted operator-driven runs where the
+# hint-as-documentation value outweighs the deployment overhead of
+# strict prereqs. F4 banner per BB review 2026-05-09.
+# ---------------------------------------------------------------------
+#
 # Surfaces material-quality issues during FEEL sessions using observer's
 # audit depth on top of artisan's feel lens.
 #

--- a/grimoires/compositions/discovery/audit-feel.yaml
+++ b/grimoires/compositions/discovery/audit-feel.yaml
@@ -1,5 +1,18 @@
-# Composition · feel-audit
+# Composition · feel-audit  [DEPRECATED 2026-05-09 — see redirect below]
 # ================================================================
+# DEPRECATED: superseded by `compositions/audit-feel.yaml` (v3.0.0,
+# bounded-context substrate, schema_version 1.1). The v3 file adds
+# context_policy, isolation_tier, output_contract, persistent_state_ttl_policy,
+# and inputs[] declaration — substrate-runner-ready. This v2 is doctrine-only.
+#
+# DO NOT install or invoke this file. The runner registry resolves
+# `audit-feel` to `compositions/audit-feel.yaml`. This file is retained
+# as a doctrine breadcrumb for the v1 → v2 → v3 evolution trail.
+#
+# Migration: nothing to migrate — operators were never wired against
+# this v2; cycle-005/006 typed-streams work bypassed it.
+# ----------------------------------------------------------------
+#
 # First workflow-kind composition authored per doctrine v4 §15.2.
 # Surfaces material-quality issues during FEEL sessions using
 # observer's audit depth on top of artisan's feel lens.
@@ -9,6 +22,10 @@
 #             (folklore-only, gitignored, prose-shape). This v2 is
 #             checkable + doctrine-conformant + runner-ready.
 # ================================================================
+
+deprecated: true
+deprecated_at: "2026-05-09"
+deprecated_in_favor_of: "compositions/audit-feel.yaml"
 
 schema_version: "1.0"
 kind: workflow                        # doctrine v4 §15.2 (vs. frame-kind)

--- a/grimoires/loa/NOTES.md
+++ b/grimoires/loa/NOTES.md
@@ -1,5 +1,23 @@
 # Loa Project Notes
 
+## Cycle Closure — 2026-05-09 (cycle-construct-bounded-context — DONE)
+
+**Outcome**: substrate v2.40.0 shipped via PR #226 (75989416, 7 sprints, 84/84 tests). Spiral follow-up cycle terminated on `quality_gate_failure` circuit breaker (IMPL_EVIDENCE_MISSING). Manual recovery via PR #228 cherry-picked the 8 valuable artifacts the spiral did produce: audit-feel composition + 4 operator runbooks + sprint-dag + telemetry config + egress-filter (~2,141 lines total). Issue #227 tracks the remaining substrate consumer migration work.
+
+### Spiral failure mode worth remembering
+
+The IMPL_FIX loop wrote 4 stub libs to `lib/{envelope-builder,envelope-chain,output-gate,persistent-state}.sh` to satisfy a sprint-plan path-evidence check that was hallucinated in the first place — the real files existed at `.claude/scripts/lib/*` (the v2.40.0 substrate canonical location, 465+ lines each). The fix-loop should reconcile sprint-plan paths against the filesystem before writing stubs to placate evidence checks. File against the spiraling skill if you hit this pattern again.
+
+### Validator caught real bug in spiral output (autopoietic feedback loop worked)
+
+The spiral's audit-feel.yaml emitted `[STREAM-NO-PRODUCER]` from substrate's own `compose-stream-graph.sh`: missing `inputs:` block + hyphenated `Operator-Model` (canonical is PascalCase `OperatorModel`). 5-line fix during recovery, then validates clean (3 stages, 0 errors), dry-run produces `composition_id=audit-feel.yaml@sha256:e1994339d0d3`. The substrate critiquing its own spiral-generated artifacts is the dynamic the cycle wanted to prove.
+
+### Framework sync state
+
+Local main pre-recovery had 126 unpushed framework commits from a prior `/update-loa` that was never pushed — local main was 126 ahead AND 1 behind origin/main (the 1 behind = PR #226 substrate merge). Resolved by `git checkout -B main origin/main` then re-running `/update-loa`, producing one clean integration commit (130111b1) that pulls cycle-098/099/100 + cycle-102 sprint-1A/B/C + bridgebuilder fixes onto v2.40.0 baseline. Lesson: push immediately after `/update-loa`, don't let local main accumulate framework commits.
+
+---
+
 ## Decision Log — 2026-05-08 (cycle-construct-bounded-context Sprint 1)
 
 ### `[ENVELOPE-CHAIN-BROKEN]` deferred from S1-T1 to Sprint 2 (S2-T2/T5)

--- a/grimoires/loa/runbooks/context-policy-guide.md
+++ b/grimoires/loa/runbooks/context-policy-guide.md
@@ -1,0 +1,222 @@
+# Context Policy Operator Guide
+
+**Sprint 6, S6-T7** — Operator-facing documentation for `context_policy` fields,
+isolation tier choice, and prerequisite check. SDD §3.1, §2.1, FR-1.2, FR-4.
+
+---
+
+## Overview
+
+Every stage in a composition declares a `context_policy` block that governs:
+- What context the stage subprocess can read or write
+- Which environment variables are visible
+- Whether network egress is permitted and to which hosts
+- Which LLM session strategy applies
+- Which MCP tools are available
+- What isolation tier enforces these constraints
+
+The policy is embedded in the invocation envelope at build time and is immutable
+for the duration of that stage. Changing a composition's `context_policy` changes
+its `composition_id`.
+
+---
+
+## context_policy Fields Reference
+
+### Transcript / Context Leakage Controls
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `include_prior_transcript` | bool | `false` | Include operator's prior conversation turns. **Advisory limit**: only controls the envelope declaration; strict tier enforces at subprocess level. |
+| `include_unread_stage_outputs` | bool | `false` | Allow stage to read outputs from prior stages NOT listed in `reads:`. |
+| `include_unlisted_grimoires` | bool | `false` | Allow stage to read any grimoire file, not just those in `allowed_read_paths`. |
+
+All three default to `false`. Set to `true` only when the stage genuinely needs
+ambient context — be explicit about the tradeoff.
+
+### Filesystem Controls
+
+| Field | Type | Description |
+|---|---|---|
+| `allowed_read_paths` | `string[]` | Glob patterns the stage subprocess may read. Evaluated via `realpath` to close symlink traversal (SDD §4.3, Flatline HIGH-3). |
+| `allowed_write_paths` | `string[]` | Glob patterns the stage subprocess may write. Paths outside this list produce `[POLICY-VIOLATION-WRITE]` on strict tier; logged-only on advisory. |
+
+**Template variables**: use `{{run_id}}` and `{{target_artifact}}` for paths that
+vary per run. The envelope builder substitutes these at invocation time.
+
+**Example**:
+```yaml
+allowed_read_paths:
+  - ".claude/constructs/packs/artisan/skills/decomposing-feel/**"
+  - "grimoires/loa/runs/{{run_id}}/input/**"
+  - "{{target_artifact}}"
+allowed_write_paths:
+  - ".run/compose/{{run_id}}/stage-1/output/**"
+```
+
+### Environment Variable Controls
+
+| Field | Type | Description |
+|---|---|---|
+| `allowed_env_vars` | `string[]` | Explicit allowlist. Subprocess invoked with `env -i` + these variables only. |
+
+Minimum safe allowlist for most stages:
+```yaml
+allowed_env_vars:
+  - PATH
+  - HOME
+  - LANG
+  - LC_ALL
+```
+
+Add provider-specific variables (e.g. `ANTHROPIC_API_KEY`) only when the stage
+invokes a model directly rather than via cheval.
+
+### Network Controls
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `allow_network` | bool | `false` | Permit outbound network connections from the stage subprocess. |
+| `allowed_egress` | `{host, port}[]` | `[]` | Host:port pairs permitted when `allow_network: true`. |
+| `network_namespace` | bool | `false` | Linux-only opt-in for kernel-boundary network isolation. Requires `CAP_NET_ADMIN`. |
+
+**Default is deny-all.** When `allow_network: false`, the egress proxy blocks
+all connections. When `allow_network: true` and `allowed_egress` is populated,
+only listed host:port pairs are reachable via HTTP_PROXY.
+
+**Advisory-tier scope**: The HTTP_PROXY mechanism only covers HTTP_PROXY-aware
+code paths. It does NOT cover raw sockets, DNS-over-UDP, SSH, git CLI, or
+TLS-pinned clients. Declare `network_namespace: true` on Linux with
+`CAP_NET_ADMIN` for kernel-boundary enforcement.
+
+```yaml
+allow_network: true
+allowed_egress:
+  - host: api.anthropic.com
+    port: 443
+  - host: api.openai.com
+    port: 443
+```
+
+### LLM Session Controls
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `llm_session_strategy` | `fresh\|continue` | `fresh` | `fresh` starts a new session ID per stage; `continue` reuses the prior stage's session. Use `continue` only when intentional cross-stage context is desired. |
+
+Cheval passes `--session-id "stage-{run_id}-{stage_id}"` when strategy is `fresh`.
+Provider memory disable flags (`--memory-disabled`, `--no-chatgpt-memory`,
+`--no-saved-info`) are applied when `llm_session_strategy: fresh`. See SDD §4.3.
+
+### MCP Tool Controls
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `allowed_mcp_tools` | `string[]` | `[]` | Explicit MCP tool allowlist. Empty = no MCP tools. Passed to cheval as `--allowed-mcp-tools`. |
+
+---
+
+## Isolation Tier Choice
+
+### `isolation_tier: advisory`
+
+- **Platform**: Linux (without bwrap), macOS, Windows
+- **Enforcement**: cooperative constructs only — env scrub + in-process path checks
+- **Does NOT prevent**: foreign binary bypass, direct syscalls, raw socket egress
+- **When to use**: Non-adversarial constructs on developer machines; prototyping
+
+```yaml
+isolation_tier: advisory
+```
+
+### `isolation_tier: strict`
+
+- **Platform**: Linux + bwrap + CAP_NET_ADMIN only
+- **Enforcement**: kernel-boundary filesystem namespace + network namespace + verified provider memory disable
+- **Prerequisite check**: runs at composition validation time, aborts with `[STRICT-TIER-PREREQ-MISSING]` exit 78 if bwrap or CAP_NET_ADMIN missing
+- **When to use**: Compositions handling sensitive context; production CI; untrusted or adversarial construct packs
+
+```yaml
+isolation_tier: strict
+```
+
+**Prerequisite check** runs before any stage executes:
+1. Verifies `bwrap` is installed (`command -v bwrap`)
+2. Verifies `CAP_NET_ADMIN` (`getcap` or effective UID 0)
+3. Verifies cheval adapters support memory-disable flags for all configured providers
+
+Failure exits with code 78 (`EX_CONFIG`). See `grimoires/loa/runbooks/strict-tier-deployment.md`.
+
+---
+
+## Choosing the Right Tier
+
+| Scenario | Recommended tier |
+|---|---|
+| Developer workflow on macOS | `advisory` |
+| CI on standard GitHub-hosted runners | `advisory` |
+| Production CI with sensitive context | `strict` (dedicated self-hosted runner) |
+| Untrusted or third-party construct pack | `strict` |
+| Prototyping a new composition | `advisory`, then migrate to `strict` |
+
+---
+
+## Common Configuration Examples
+
+### Minimal (no network, no MCP, fresh session)
+```yaml
+context_policy:
+  include_prior_transcript: false
+  include_unread_stage_outputs: false
+  include_unlisted_grimoires: false
+  allowed_read_paths:
+    - ".claude/constructs/packs/{{construct}}/skills/{{skill}}/**"
+    - ".run/compose/{{run_id}}/input/**"
+  allowed_write_paths:
+    - ".run/compose/{{run_id}}/{{stage_id}}/output/**"
+  allowed_env_vars: [PATH, HOME, LANG, LC_ALL]
+  allow_network: false
+  allowed_egress: []
+  llm_session_strategy: fresh
+  allowed_mcp_tools: []
+  isolation_tier: advisory
+```
+
+### With API egress (advisory tier)
+```yaml
+context_policy:
+  allow_network: true
+  allowed_egress:
+    - host: api.anthropic.com
+      port: 443
+  isolation_tier: advisory
+```
+
+### Strict tier (Linux CI)
+```yaml
+context_policy:
+  isolation_tier: strict
+  # All other fields apply — strict tier ENFORCES them at kernel boundary
+```
+
+---
+
+## Error Codes
+
+| Code | Trigger |
+|---|---|
+| `[STRICT-TIER-PREREQ-MISSING]` | Strict tier requested but bwrap / CAP_NET_ADMIN absent |
+| `[POLICY-VIOLATION-READ]` | Stage read a path outside `allowed_read_paths` |
+| `[POLICY-VIOLATION-WRITE]` | Stage wrote to a path outside `allowed_write_paths` |
+| `[POLICY-VIOLATION-NETWORK]` | Stage attempted egress to unlisted host:port |
+| `[EGRESS-PROXY-DOWN]` | Egress proxy died mid-stage; stage SIGKILL'd |
+| `[AUDIT-KEYS-NOT-BOOTSTRAPPED]` | `audit_signed: true` but keys not bootstrapped |
+
+---
+
+## See Also
+
+- `grimoires/loa/runbooks/strict-tier-deployment.md` — host hardening for strict tier
+- `grimoires/loa/runbooks/envelope-schema-migration.md` — upgrading envelope schema version
+- `lib/egress-filter.py` — egress proxy implementation (SDD §2.3)
+- `lib/persistent-state.sh` — per-skill state management (SDD §4.5)

--- a/grimoires/loa/runbooks/envelope-schema-migration.md
+++ b/grimoires/loa/runbooks/envelope-schema-migration.md
@@ -1,0 +1,172 @@
+# Envelope Schema Migration Guide
+
+**Sprint 6, S6-T5** — v0 → future v1 migration path per FR-1.4.
+Documents the `audit_emit_signed` opt-in steps.
+
+---
+
+## Overview
+
+The bounded-context substrate ships with envelope schemas at version `v0`:
+- `loa.construct.invocation.v0` — `.claude/schemas/runtime/construct-invocation-v0.schema.json`
+- `loa.construct.handoff.v0` — `.claude/schemas/runtime/construct-handoff-v0.schema.json`
+
+These schemas are **stable for the current cycle**. A future `v1` would be authored
+in `loa-hounfour` (the protocol-level schema repository) once the substrate has
+hardened through at least one full production cycle.
+
+This runbook documents:
+1. How to opt in to audit-grade signing (`audit_emit_signed`) on v0 envelopes
+2. The migration path from v0 to v1 when v1 ships
+3. What to do when `schema_version` validation fails
+
+---
+
+## Opting In to Audit-Grade Signing (v0)
+
+The `audit_emit_signed` integration is an **opt-in** on top of v0 envelopes.
+It does not change the envelope schema — it adds a parallel signed audit chain.
+
+### Prerequisites
+
+1. Bootstrap cycle-098 audit keys (if not already done):
+   ```bash
+   # See grimoires/loa/runbooks/audit-keys-bootstrap.md
+   .claude/scripts/bootstrap-audit-keys.sh
+   ```
+
+2. Verify bootstrap:
+   ```bash
+   .claude/scripts/lib/audit-keys-preflight.sh
+   # Exit 0 = keys ready; Exit 78 = [AUDIT-KEYS-NOT-BOOTSTRAPPED]
+   ```
+
+### Enable in Composition
+
+```yaml
+# compositions/my-composition.yaml
+audit_signed: true   # ← add this field
+```
+
+### What Changes at Runtime
+
+With `audit_signed: true`:
+1. Pre-execution: stream-graph validator calls `audit-keys-preflight.sh`. Abort on
+   exit 78 with `[AUDIT-KEYS-NOT-BOOTSTRAPPED]` before any stage executes.
+2. Per-stage: each invocation and handoff envelope is also emitted via
+   `audit_emit_signed` to `.run/compose/<run_id>/audit.jsonl`.
+3. The signed chain uses Ed25519 signatures per the cycle-098 audit envelope
+   spec (`agent-network-envelope.schema.json` v1.1.0).
+4. Chain replay (`lib/envelope-chain.sh validate`) verifies Ed25519 signatures
+   when signatures are present.
+
+Default is `false`. The golden-path `compositions/audit-feel.yaml` sets
+`audit_signed: false` — enable for sensitive composition runs.
+
+---
+
+## v0 to v1 Migration Path (Future)
+
+When `loa.construct.invocation.v1` ships (expected: after one full hardening cycle):
+
+### Step 1 — Identify Affected Compositions
+
+```bash
+# Find all compositions using v0 schema
+grep -r 'schema_version.*"1\.0"\|"1\.1"' compositions/ --include="*.yaml" -l
+```
+
+Note: the envelope `schema_version` (`loa.construct.invocation.v0`) is distinct
+from the composition file `schema_version` (`"1.0"`, `"1.1"`). The envelope
+schema governs the JSON files at `.run/compose/<run_id>/envelopes/`.
+
+### Step 2 — Run Dry-Run to Identify Breaking Changes
+
+```bash
+# For each composition, run dry-run against the v1 schema
+compose-run.sh compositions/my-composition.yaml \
+    --dry-run \
+    --explain-context \
+    --schema-version v1 \
+    --json | jq '.errors'
+```
+
+### Step 3 — Migrate Composition YAML
+
+v1 envelope schema changes are expected to be additive (new optional fields) plus
+two breaking changes from v0:
+
+| Field | v0 | v1 | Migration |
+|---|---|---|---|
+| `context_policy.isolation_tier` | optional | required | Add `isolation_tier: advisory` to existing stages |
+| `output_contract.writes[].required` | optional | required | Add `required: true` to existing output declarations |
+| `domain.primary` | optional | required on strict | Already enforced by strict-tier validator |
+
+Run the composition's test suite after each change to verify.
+
+### Step 4 — Archive v0 Envelopes (Optional)
+
+Old `.run/compose/` directories with v0 envelopes remain valid for replay and
+audit purposes. The chain validator reads the `schema_version` field and routes
+to the correct validator. No action required.
+
+If you want to clean up old runs:
+```bash
+# Envelopes older than 90 days (telemetry retention)
+find .run/compose/ -name "*.invocation.json" -mtime +90 -delete
+```
+
+---
+
+## Troubleshooting
+
+### `[ENVELOPE-CHAIN-BROKEN]` on Startup
+
+The chain validator detected a hash mismatch. This happens when:
+1. An envelope file was modified after being written.
+2. A disk error corrupted the file.
+3. A manual edit was made to the envelope JSON.
+
+**Diagnose**:
+```bash
+lib/envelope-chain.sh validate --chain-dir .run/compose/<run_id>/envelopes/
+```
+
+**Recover** (if the run is still valid but the chain is suspect):
+```bash
+# Re-validate from git history if envelopes are tracked (they are not by default)
+git fsck --unreachable | grep blob | head -20
+```
+
+**Prevention**: never manually edit envelope JSON files. If you need to replay
+a composition, use `compose-run.sh --replay <run_id>`.
+
+### Schema Version Mismatch Warning
+
+If you see:
+```
+WARN: envelope at stage-2.invocation.json declares schema_version loa.construct.invocation.v0
+but current default is loa.construct.invocation.v1
+```
+
+This is informational — v0 envelopes continue to validate and replay. Set
+`LOA_ENVELOPE_SCHEMA_VERSION=v0` in your environment if you want to suppress
+the warning while migrating.
+
+### `[AUDIT-KEYS-NOT-BOOTSTRAPPED]` exit 78
+
+Composition has `audit_signed: true` but keys are not present. Resolution:
+```bash
+# See the full bootstrap runbook
+cat grimoires/loa/runbooks/audit-keys-bootstrap.md
+```
+
+---
+
+## See Also
+
+- `grimoires/loa/runbooks/audit-keys-bootstrap.md` — key generation + rotation
+- `grimoires/loa/runbooks/context-policy-guide.md` — context_policy field reference
+- `.claude/schemas/runtime/` — live schema files
+- SDD §2.2 (Q#7 envelope reuse vs sibling decision)
+- SDD §3.1 (hash chain algorithm + worked example)

--- a/grimoires/loa/runbooks/persistent-state-migration.md
+++ b/grimoires/loa/runbooks/persistent-state-migration.md
@@ -1,0 +1,249 @@
+# Persistent State Migration Guide
+
+**Sprint plan §State-Key Migration Story** (closes Flatline IMP-006).
+Documents the `compose-state-migrate.sh` workflow for schema_version bumps.
+
+---
+
+## Overview
+
+Persistent state is keyed by six components (SDD §3.3):
+
+```
+.run/compose/persistent/
+  <project_id>/
+    <composition_id>/
+      <construct_slug>/
+        <skill_slug>/
+          <stage_id>/
+            <schema_version>/
+              state.json
+```
+
+When a construct bumps `schema_version`:
+- **Old state is not auto-migrated** — it stays at the old path.
+- **New state initializes fresh** at the new path.
+- **Migration is explicit and operator-driven** via `compose-state-migrate.sh`.
+
+This is intentional: silent auto-migration can corrupt state if the transform
+is wrong. The operator reviews and approves each transform.
+
+---
+
+## When to Migrate
+
+Migrate persistent state when:
+1. A construct bumps its `schema_version` (e.g., `v1` → `v2`) and the payload
+   shape changes.
+2. A composition is renamed (changes `composition_id`) and you want to preserve
+   state across the rename.
+3. You want to transfer state from one project to another (`project_id` change).
+
+You do NOT need to migrate when:
+- The construct is running on fresh state (no prior runs with the old version).
+- The state has already expired past its TTL.
+- The payload change is backwards-compatible and the construct reads both formats.
+
+---
+
+## Migration Workflow
+
+### Step 1 — Inspect Existing State
+
+```bash
+# List all state files for a construct
+lib/persistent-state.sh path \
+    --project-id loa-constructs \
+    --composition-id "audit-feel@sha256:a3f2b1d4e5c6" \
+    --construct-slug artisan \
+    --skill-slug decomposing-feel \
+    --stage-id audit-feel.stage-1 \
+    --schema-version v1
+
+# Read the current payload
+lib/persistent-state.sh get \
+    --project-id loa-constructs \
+    --composition-id "audit-feel@sha256:a3f2b1d4e5c6" \
+    --construct-slug artisan \
+    --skill-slug decomposing-feel \
+    --stage-id audit-feel.stage-1 \
+    --schema-version v1
+```
+
+### Step 2 — Author the Transform
+
+The transform is a `jq` expression that converts the old payload to the new shape.
+
+**Example**: construct bumps from v1 to v2, renaming `material_score` to
+`craft_score` and adding a required `confidence` field:
+
+```bash
+TRANSFORM='.payload | {
+  craft_score: .material_score,
+  confidence: (.confidence // 0.5),
+  last_surface: .last_surface
+}'
+```
+
+Test the transform against the current state before running migration:
+```bash
+lib/persistent-state.sh get \
+    --project-id loa-constructs \
+    --composition-id "audit-feel@sha256:a3f2b1d4e5c6" \
+    --construct-slug artisan \
+    --skill-slug decomposing-feel \
+    --stage-id audit-feel.stage-1 \
+    --schema-version v1 \
+  | jq "$TRANSFORM"
+```
+
+### Step 3 — Run the Migration
+
+```bash
+.claude/scripts/compose-state-migrate.sh \
+    --project-id loa-constructs \
+    --composition-id "audit-feel@sha256:a3f2b1d4e5c6" \
+    --construct-slug artisan \
+    --skill-slug decomposing-feel \
+    --stage-id audit-feel.stage-1 \
+    --from-version v1 \
+    --to-version v2 \
+    --transform "$TRANSFORM"
+```
+
+The migration script:
+1. Reads the source state (acquiring shared flock).
+2. Applies the transform via `jq`.
+3. Validates the result against the new schema (if a schema is registered).
+4. Writes to the new path using atomic-rename (exclusive flock).
+5. Appends a migration log entry to `.run/compose/persistent/migrations.jsonl`.
+6. **Does not delete the old state** — old state is retained until `--finalize`.
+
+### Step 4 — Verify the Migration
+
+```bash
+# Read the new state
+lib/persistent-state.sh get \
+    --project-id loa-constructs \
+    --composition-id "audit-feel@sha256:a3f2b1d4e5c6" \
+    --construct-slug artisan \
+    --skill-slug decomposing-feel \
+    --stage-id audit-feel.stage-1 \
+    --schema-version v2
+
+# Check the migration log
+cat .run/compose/persistent/migrations.jsonl | jq 'select(.construct_slug == "artisan")'
+```
+
+### Step 5 — Finalize (Remove Old State)
+
+Once you've verified the new state is correct:
+
+```bash
+.claude/scripts/compose-state-migrate.sh \
+    --project-id loa-constructs \
+    --composition-id "audit-feel@sha256:a3f2b1d4e5c6" \
+    --construct-slug artisan \
+    --skill-slug decomposing-feel \
+    --stage-id audit-feel.stage-1 \
+    --from-version v1 \
+    --finalize \
+    --remove-old-versions
+```
+
+**Warning**: `--remove-old-versions` is irreversible. Run only after verifying
+the migrated state is correct and the construct has run at least once on v2.
+
+---
+
+## Migration Log Format (`.run/compose/persistent/migrations.jsonl`)
+
+Each migration appends one JSONL record:
+
+```json
+{
+  "ts": "2026-05-09T12:00:00Z",
+  "op": "migrate",
+  "from_path": ".run/compose/persistent/.../v1/state.json",
+  "to_path": ".run/compose/persistent/.../v2/state.json",
+  "from_version": "v1",
+  "to_version": "v2",
+  "source_hash": "sha256:abc123...",
+  "dest_hash": "sha256:def456...",
+  "transform_expr": ".payload | {...}",
+  "finalized": false
+}
+```
+
+When `--finalize` is run, a second record is appended with `"op": "finalize"`.
+
+---
+
+## Bulk Migration
+
+When a construct bumps schema_version and all compositions need migrating:
+
+```bash
+# Find all state files for the construct at the old version
+find .run/compose/persistent/ \
+    -path "*/artisan/decomposing-feel/*/v1/state.json" \
+    -type f
+
+# Run migration for each (or use the --all flag if available)
+.claude/scripts/compose-state-migrate.sh \
+    --construct-slug artisan \
+    --skill-slug decomposing-feel \
+    --from-version v1 \
+    --to-version v2 \
+    --transform "$TRANSFORM" \
+    --all
+```
+
+---
+
+## TTL Implications
+
+During migration:
+- Old state retains its original TTL.
+- New state inherits the old `ttl_seconds` and `ttl_policy`.
+- `last_updated` and `last_accessed` are set to migration time.
+- `ttl_expires` is recomputed from migration time + `ttl_seconds`.
+
+If the old state is near expiry, migrate before the TTL runs out to avoid
+losing the source data.
+
+---
+
+## Troubleshooting
+
+### Migration fails with `[STATE-OWNERSHIP-VIOLATION]`
+
+The migration script runs as the owning construct + skill. If `owning_construct`
+in the state file differs from the `--construct-slug` argument:
+
+```bash
+# Check the owning construct
+cat <state_path> | jq '.ownership'
+```
+
+Use the owning construct's slug in `--construct-slug` to satisfy the ownership check.
+
+### Old state not found
+
+Either the composition_id has changed (slug-at-sha format, stable across runs
+but changes when composition content changes), or the state has already expired.
+
+```bash
+# Find state by construct slug alone
+find .run/compose/persistent/ -name "state.json" \
+  | xargs grep -l '"construct_slug": "artisan"' 2>/dev/null
+```
+
+---
+
+## See Also
+
+- `lib/persistent-state.sh` — state manager API
+- SDD §3.3 (composite key + TTL policy)
+- SDD §4.5 (GC race coordination)
+- `grimoires/loa/runbooks/context-policy-guide.md` — context_policy fields

--- a/grimoires/loa/runbooks/strict-tier-deployment.md
+++ b/grimoires/loa/runbooks/strict-tier-deployment.md
@@ -1,0 +1,239 @@
+# Strict-Tier Deployment Runbook
+
+**Sprint 4, S4-T8** (closes Flatline CRITICAL #3).
+Covers minimum host hardening, CI runner isolation, and capability scope for
+`isolation_tier: strict` compositions.
+
+**TL;DR**: Strict tier requires Linux + `bwrap` + `CAP_NET_ADMIN`. It is explicitly
+NOT recommended on shared multi-tenant hosts. Use dedicated CI runners or
+non-shared developer machines.
+
+---
+
+## What Strict Tier Provides
+
+Strict tier adds kernel-boundary enforcement on top of the advisory tier's
+cooperative controls:
+
+| Control | Advisory | Strict |
+|---|---|---|
+| Filesystem read allowlist | in-process check (cooperative) | `bwrap --ro-bind` (kernel) |
+| Filesystem write allowlist | in-process check (cooperative) | `bwrap --bind` (kernel) |
+| Network egress | HTTP_PROXY env (HTTP-aware code only) | network namespace + CONNECT proxy (kernel) |
+| Process isolation | subprocess only | `bwrap --unshare-pid` |
+| Session isolation | fresh session ID | fresh session ID + verified memory disable |
+| Foreign binary escape | NOT mitigated | blocked by filesystem namespace |
+| Direct syscall escape | NOT mitigated | blocked by `bwrap` PID namespace |
+
+See SDD §6.5b for the full honest threat model.
+
+---
+
+## Prerequisites
+
+### Required Packages
+
+```bash
+# Debian / Ubuntu
+apt-get install -y bubblewrap libcap2-bin
+
+# Fedora / RHEL
+dnf install -y bubblewrap libcap
+
+# Arch
+pacman -S bubblewrap libcap
+```
+
+Verify:
+```bash
+bwrap --version        # should print 0.6.x or later
+getcap $(which bwrap)  # should include cap_net_admin
+```
+
+### Required Capability
+
+`bwrap` needs `CAP_NET_ADMIN` to create network namespaces (`--unshare-net`).
+
+**Option A — Setuid binary** (simpler, less secure):
+```bash
+chmod u+s $(which bwrap)
+```
+
+**Option B — File capability** (recommended):
+```bash
+setcap cap_net_admin+ep $(which bwrap)
+```
+
+**Option C — Run as root** (CI runners where Docker/root is available):
+```bash
+# The prerequisite check accepts effective UID 0 in lieu of CAP_NET_ADMIN
+```
+
+### Verify Prerequisites
+
+The substrate runs this automatically at composition validation time, but you
+can run it manually:
+
+```bash
+.claude/scripts/lib/strict-tier-prereq.sh
+# Exit 0 = all prerequisites met
+# Exit 78 = [STRICT-TIER-PREREQ-MISSING] with specific failure reason
+```
+
+---
+
+## CI Runner Configuration
+
+### Dedicated Self-Hosted Runner (Recommended)
+
+Strict-tier CI (`composition-strict-linux`) must run on a **dedicated** runner —
+not a GitHub-hosted runner (which lacks `CAP_NET_ADMIN`) and not a shared
+multi-tenant host.
+
+**Why dedicated?**
+- `bwrap` with `CAP_NET_ADMIN` on a shared host is a privilege escalation risk.
+- GitHub Actions does not provide `CAP_NET_ADMIN` on hosted runners.
+- The adversarial test suite (S4-T5) executes untrusted construct-like payloads.
+
+**Minimal runner VM spec**:
+- OS: Ubuntu 22.04 LTS (or later)
+- RAM: 4 GB minimum (adversarial tests run concurrent bwrap subprocesses)
+- Disk: 20 GB
+- Network: outbound-only (inbound blocked at host firewall)
+- Packages: `bubblewrap`, `libcap2-bin`, `python3`
+
+**GitHub Actions configuration**:
+```yaml
+# .github/workflows/composition-strict-linux.yml
+jobs:
+  strict-tier-tests:
+    runs-on: [self-hosted, linux, strict-tier]
+    # Gated to repo-maintainer PRs only
+    if: github.event.pull_request.author_association == 'OWNER'
+       || github.event.pull_request.author_association == 'MEMBER'
+       || github.event.pull_request.author_association == 'COLLABORATOR'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify strict-tier prerequisites
+        run: .claude/scripts/lib/strict-tier-prereq.sh
+      - name: Run adversarial suite
+        run: bats tests/composition/adversarial/
+```
+
+Community PRs (non-maintainer): the `composition-strict-linux` job shows as
+skipped/pending. Maintainer approval triggers the job by adding the label
+`safe-to-test-strict-tier`.
+
+---
+
+## Host Hardening Checklist
+
+For the strict-tier runner host (self-hosted VM or developer machine):
+
+### Minimum Hardening
+- [ ] Single-tenant host (no other users or workloads)
+- [ ] `bwrap` capability scoped to the runner user only (`setcap` per-binary)
+- [ ] Outbound network filtered to known allowlisted hosts (CI APIs, package mirrors)
+- [ ] No inbound SSH from public internet
+- [ ] Disk encryption at rest (VM or host level)
+- [ ] Log shipping to centralized SIEM (audit trail for capability use)
+
+### Recommended Hardening
+- [ ] Ephemeral runner VM (new VM per CI job, destroyed after)
+- [ ] Minimal OS install (no desktop environment, no unnecessary services)
+- [ ] `AppArmor` or `SELinux` enforcing mode
+- [ ] `auditd` with capability-use rules (monitors `CAP_NET_ADMIN` invocations)
+- [ ] OOM killer tuned (`vm.overcommit_memory=2`) to prevent memory pressure from killing the stage executor before it can clean up
+
+---
+
+## Developer Machine Setup
+
+If you're running strict-tier compositions locally (Linux only):
+
+```bash
+# 1. Install prerequisites
+sudo apt-get install -y bubblewrap libcap2-bin
+
+# 2. Grant capability to your user's bwrap binary
+sudo setcap cap_net_admin+ep $(which bwrap)
+
+# 3. Verify
+.claude/scripts/lib/strict-tier-prereq.sh && echo "Ready for strict tier"
+
+# 4. Run a strict-tier composition
+compose-run.sh compositions/audit-feel.yaml
+# (uses isolation_tier from each stage's context_policy)
+```
+
+**macOS**: strict tier is NOT supported on macOS. Use `isolation_tier: advisory`.
+The prerequisite check will exit 78 with a specific macOS-not-supported message.
+
+**Windows**: not supported in this cycle. Advisory only.
+
+---
+
+## Capability Scope Justification
+
+`CAP_NET_ADMIN` is required to create network namespaces (`--unshare-net`).
+This is a significant capability — it allows (among other things) modifying
+routing tables and creating virtual network interfaces. The scope is limited to:
+
+1. `bwrap` subprocesses only (scoped via file capability, not process-wide)
+2. Each subprocess's namespace is destroyed when `bwrap` exits
+3. No persistent network configuration changes are made
+
+If `CAP_NET_ADMIN` is not acceptable in your environment, use `isolation_tier: advisory`
+and document the advisory-tier limitations in your security review.
+
+An alternative without `CAP_NET_ADMIN` that achieves network isolation at a
+coarser level is `seccomp` filtering (block `socket()` for non-HTTP traffic).
+This is a NEEDS_DECISION for a future cycle — it covers more network protocols
+than HTTP_PROXY but less than a full network namespace.
+
+---
+
+## Troubleshooting
+
+### `[STRICT-TIER-PREREQ-MISSING]` exit 78
+
+```
+ERROR: composition declares isolation_tier: strict but prerequisites missing:
+  - bwrap: NOT FOUND (install: apt-get install bubblewrap)
+  - CAP_NET_ADMIN: NOT AVAILABLE (run: setcap cap_net_admin+ep $(which bwrap))
+See: grimoires/loa/runbooks/strict-tier-deployment.md
+```
+
+Fix per the checklist above. If bwrap is installed but `getcap` shows no
+capabilities, re-run the `setcap` command.
+
+### `bwrap: creating new user namespace not allowed`
+
+Some Linux kernels disable unprivileged user namespaces (`kernel.unprivileged_userns_clone=0`).
+Check:
+```bash
+sysctl kernel.unprivileged_userns_clone
+```
+If `0`, either enable it (`sudo sysctl -w kernel.unprivileged_userns_clone=1`)
+or use a setuid `bwrap` binary instead.
+
+### `bwrap: bind: Operation not permitted`
+
+Bind-mounting a path that is itself on a read-only filesystem.
+Ensure `allowed_read_paths` and `allowed_write_paths` in the composition resolve
+to writable filesystem mounts on the host.
+
+### Stage process exits immediately under bwrap
+
+Check that the construct skill binary has execute permission and is in one of
+the `--ro-bind` paths. The bwrap sandbox starts with an empty filesystem; only
+explicitly bound paths are visible.
+
+---
+
+## See Also
+
+- `grimoires/loa/runbooks/context-policy-guide.md` — isolation_tier field reference
+- `lib/egress-filter.py` — egress proxy (required for network egress in strict tier)
+- SDD §6.5b — honest threat model, tier definitions
+- SDD §4.3 — stage executor implementation (bwrap argv array construction)


### PR DESCRIPTION
## Summary

Recovers genuine value from an autonomous `/spiral` run that hit a `quality_gate_failure` circuit breaker. Closes 4 cycle deferrals from v2.40.0 (audit-feel composition installation; substantial operator runbooks; egress filter; telemetry schema/retention config). Drops the spiral's 4 hallucinated stub libraries.

The autopoietic feedback loop worked: spiral produced an artifact, the substrate's own validator caught a real bug in it (`[STREAM-NO-PRODUCER]` on the audit-feel composition), recovery fixed it, substrate now accepts it.

## What's new (8 files, 2141 lines)

| Path | Purpose | Closes |
|---|---|---|
| `compositions/audit-feel.yaml` (173 lines) | THE audit-feel composition (substrate's canonical golden path) | S1 AC-1.C, S2 AC-2.A, S3 AC-3.D, S3-T9 |
| `grimoires/loa/runbooks/context-policy-guide.md` (222 lines) | context_policy operator guide | S6-T7 |
| `grimoires/loa/runbooks/envelope-schema-migration.md` (172 lines) | v0→v1 envelope migration path | S6-T5 |
| `grimoires/loa/runbooks/persistent-state-migration.md` (249 lines) | state key migration runbook | IMP-006 |
| `grimoires/loa/runbooks/strict-tier-deployment.md` (239 lines) | CAP_NET_ADMIN deployment doc | S4-T8 |
| `.claude/data/sprint-dag.yaml` (506 lines) | machine-readable task DAG | IMP-002 |
| `.claude/data/telemetry/compose-runs.schema.json` (98 lines) | telemetry schema | IMP-005 |
| `.claude/data/telemetry/retention-policy.yaml` (63 lines) | telemetry retention config | IMP-005 |
| `.claude/scripts/lib/egress-filter.py` (419 lines) | CONNECT-only egress filter proxy per SDD §2.3 | NEW capability |

## What's NOT in this PR (the spiral's hallucinations)

The spiral's IMPL_FIX loop produced 4 stub libraries at `lib/{envelope-builder,envelope-chain,output-gate,persistent-state}.sh` that duplicated the real ones already shipped in v2.40.0 at `.claude/scripts/lib/*`. These were the harness's attempt to satisfy a hallucinated sprint-plan path-evidence check. **Dropped from this PR.**

## Bug fixes during recovery

1. **Stream-name canonicalization** in `compositions/audit-feel.yaml`: spiral wrote `Operator-Model` (hyphenated) but substrate envelope schemas use `OperatorModel` (PascalCase). String-equal matching meant validator emitted `[STREAM-NO-PRODUCER]`. Fixed.
2. **Missing `inputs:` block** in `compositions/audit-feel.yaml`: stage 1 reads `Artifact` and `OperatorModel` but composition didn't declare them as operator-supplied. Added the input declaration.
3. **Misplaced config files**: spiral wrote `.run/sprint-dag.yaml` and `.run/telemetry/retention-policy.yaml` (gitignored ephemeral state). Moved to `.claude/data/` (operator-canonical config zone).
4. **Misplaced lib script**: spiral wrote `lib/egress-filter.py`. Moved to `.claude/scripts/lib/egress-filter.py` (substrate library convention).

## Validator output (after fixes)

```
$ .claude/scripts/lib/compose-stream-graph.sh compositions/audit-feel.yaml
{ "ok": true, "errors_count": 0, "warnings_count": 0, "stages": 3 }

$ .claude/scripts/lib/compose-dry-run.sh compositions/audit-feel.yaml
{ "composition_id": "audit-feel.yaml@sha256:e1994339d0d3",
  "stage_count": 3, "errors_count": 0, "warnings_count": 3 }
# 3 warnings are [ISOLATION-INCOMPLETE] (advisory tier, expected)
```

## Test plan

```bash
# Substrate regression — additive PR, no code changes; tests should pass
bats tests/composition/{hardening,validators,preflight,output-gate,envelopes,runner,state,iteration}/run.bats
.claude/scripts/composition-schema-validate.sh

# Validate audit-feel through every substrate gate
.claude/scripts/lib/compose-stream-graph.sh compositions/audit-feel.yaml
.claude/scripts/lib/compose-dry-run.sh compositions/audit-feel.yaml

# Egress filter loads cleanly
.claude/scripts/lib/egress-filter.py --help
```

## Spiral provenance

- Spiral run: `spiral-20260509-daee48` (cycle-31047133ca)
- Branch: `feat/spiral-spiral-20260509-daee48-cycle-1` (commit `b06e1a19`)
- Wall-clock: 69m27s
- Spend: ~$5-10 (didn't fully bill due to early circuit-break)
- Stopping condition: `quality_gate_failure` (IMPL_EVIDENCE_MISSING after 2 fix iterations)
- 13 files produced; 8 cherry-picked here; 4 hallucinated stubs dropped; 1 path-corrected (egress-filter)

## Issues to file separately

- **Spiral fix-loop bug**: when sprint-plan declares paths that DON'T MATCH substrate reality (e.g. `lib/envelope-builder.sh` when the file is at `.claude/scripts/lib/envelope-builder.sh`), the IMPL_FIX loop should reconcile the plan against the filesystem (recognize the existing file at the canonical location), not write a stub at the hallucinated path. This is what failed cycle-31047133ca.

## References

- Issue #227 — Substrate consumer migration (this PR delivers the docs+composition leg)
- v2.40.0 release: https://github.com/0xHoneyJar/loa-constructs/releases/tag/v2.40.0
- Learnings doc: `grimoires/loa/context/next-cycle-rooms-ddd-bounded-context-learnings.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)