### PR TITLE
feat(cycle-053): compose on-ramp FR-1 — chain.items authoring guidance (sprint-69)

### DIFF
--- a/.claude/schemas/runtime/composition.schema.json
+++ b/.claude/schemas/runtime/composition.schema.json
@@ -99,7 +99,21 @@
     "chain": {
       "type": "array",
       "minItems": 1,
-      "items": { "$ref": "#/$defs/Stage" },
+      "items": {
+        "$ref": "#/$defs/Stage",
+        "description": "A pipeline stage. The validation authority is $defs.Stage; the sibling 'properties' below are ANNOTATION-ONLY (description + examples) — they guide authoring at the point of use and impose NO constraint (cycle-053 FR-1, additive, no schema_version bump).",
+        "properties": {
+          "construct": { "description": "Construct slug — whose expertise runs this stage. Required on every stage (enforced by $defs.Stage).", "examples": ["artisan", "the-mint"] },
+          "skill": { "description": "Skill slug within the construct (kebab-case; ':' allows cross-construct refs, '_' and '/' for namespaced skills). The exact pattern is defined in $defs.Stage.", "examples": ["crafting-feel", "codex:rescue"] },
+          "persona": { "description": "Optional persona handle the stage embodies. v1.2 relaxes to a free-form string.", "examples": ["ALEXANDER"] },
+          "mode": { "description": "Execution mode — one of: fresh (new agent), persistent (carries context across iterations), or blocking (a human-gated seam). The enum is defined in $defs.Mode.", "examples": ["blocking"] },
+          "role": { "description": "Stage role — e.g. primary, gate, craft-gate, hard-stop, dispatcher. The gate roles, mode:blocking, and hitl_by_nature each mark a seam. The vocabulary is defined in $defs.Role.", "examples": ["gate"] },
+          "reads": { "description": "Stream types this stage consumes from upstream stages (e.g. an Artifact or Verdict produced earlier in the chain).", "examples": [["Artifact"]] },
+          "writes": { "description": "Stream types this stage produces for downstream stages.", "examples": [["Verdict"]] },
+          "notes": { "description": "What this stage does and why this expert was chosen.", "examples": ["why this expert"] },
+          "hitl_by_nature": { "description": "v1.3: marks a stage the operator inherently performs BY HAND, outside the autonomous agent loop — the third seam class alongside mode:blocking and the gate roles.", "examples": [true] }
+        }
+      },
       "description": "Ordered list of stages. Stage numbers must be 1-indexed and contiguous."
     },
     "outputs": {

--- a/.claude/schemas/runtime/composition.schema.json
+++ b/.claude/schemas/runtime/composition.schema.json
@@ -101,7 +101,7 @@
       "minItems": 1,
       "items": {
         "$ref": "#/$defs/Stage",
-        "description": "A pipeline stage. The validation authority is $defs.Stage; the sibling 'properties' below are ANNOTATION-ONLY (description + examples) — they guide authoring at the point of use and impose NO constraint (cycle-053 FR-1, additive, no schema_version bump).",
+        "description": "A pipeline stage. The validation authority is $defs.Stage; the child schemas under the sibling 'properties' below contain annotations only (description + examples) — they guide authoring at the point of use and impose no constraint.",
         "properties": {
           "construct": { "description": "Construct slug — whose expertise runs this stage. Required on every stage (enforced by $defs.Stage).", "examples": ["artisan", "the-mint"] },
           "skill": { "description": "Skill slug within the construct (kebab-case; ':' allows cross-construct refs, '_' and '/' for namespaced skills). The exact pattern is defined in $defs.Stage.", "examples": ["crafting-feel", "codex:rescue"] },

--- a/tests/composition/validators/golden-error-bad-skill.invalid.yaml
+++ b/tests/composition/validators/golden-error-bad-skill.invalid.yaml
@@ -1,0 +1,19 @@
+# Golden-error fixture — cycle-053 FR-1 (sprint-69).
+# Purpose: prove the schema produces a FIELD-NAMED error (mentions `skill`), not silence,
+# when a stage carries an invalid skill value. This is the #9 "silently strict" footgun
+# the on-ramp hardening closes: `AskUserQuestion` (PascalCase) is rejected by the
+# $defs.Stage.skill pattern ^[a-z0-9][a-z0-9:_/-]*[a-z0-9]$. The fixture is otherwise
+# valid (all required top-level fields present; stage+construct present) so the ONLY
+# validation error points at `skill`.
+#
+# NOT a real composition — lives under tests/ so the CI gate (which globs
+# grimoires/compositions/** or compositions/**) never picks it up.
+schema_version: "1.3"
+kind: workflow
+name: golden-error-bad-skill
+description: "Golden-error fixture: a stage with an invalid uppercase skill must yield a field-named error, not silence."
+intent: "Test fixture for the cycle-053 FR-1 field-named-error acceptance criterion. Not a runnable composition."
+chain:
+  - stage: 1
+    construct: artisan
+    skill: AskUserQuestion


### PR DESCRIPTION
## cycle-053 compose on-ramp hardening — sprint-69 (FR-1 + FR-4 slice)

The **additive, downstream-safe core** of the on-ramp: make `composition.schema.json`'s `chain.items` *guide* authoring without imposing any constraint. Closes the #9 "unguided schema" friction.

### What changed
- **FR-1** — 9 annotation-only guiding `properties` on `chain.items` (`construct`, `skill`, `persona`, `mode`, `role`, `reads`, `writes`, `notes`, `hitl_by_nature`). Each carries **only** `description` + `examples`.
- **Golden-error fixture** — `tests/composition/validators/golden-error-bad-skill.invalid.yaml` proves a malformed stage yields a **field-named** error (`chain/0/skill`), not silence.

### The load-bearing constraint
In JSON-Schema **Draft 2020-12**, sibling keywords next to a `$ref` are **ANDed** with the referenced schema. So each guiding property carries **only** `description`/`examples` — any validation keyword (`type`/`enum`/`pattern`/…) would silently *tighten* the schema. Validation authority stays entirely in `$defs.Stage`.

### Non-breaking — proven, not just argued
**+0 validation-error delta** across the local composition corpus before/after the cut (the invalid-set is byte-identical). `schema_version` enum unchanged (`["1.0","1.1","1.2","1.3"]`) — additive, no bump. Builds cleanly on `#250` (hitl_by_nature / v1.3, already on main).

### Scope
This is the loa-constructs-only, additive slice. Not included (separate sprints): the validator + CI gate + `.known-broken/` baseline (sprint-70), and the cross-repo `construct-compositions` exemplar fix + downstream gate (sprint-71). The FR-4 shape-boundary doc lives in `grimoires/loa/context/compose-as-workflow/shape-boundary.md` (gitignored State Zone, like its siblings).

> Reviewed pre-PR by a 3-voice headless adversarial pass (claude/codex/gemini): consensus **SHIP**; two low-severity wording fixes applied; one open follow-up (a committed regression test asserting the golden-error path) maps to sprint-70 T70.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
