### PR TITLE
fix(schema): persona docstring example cites the eradicated phantom CODEX-RESCUE

### DIFF
--- a/.claude/schemas/runtime/composition.schema.json
+++ b/.claude/schemas/runtime/composition.schema.json
@@ -394,7 +394,7 @@
         "persona": {
           "type": "string",
           "minLength": 1,
-          "description": "Optional persona handle. v1.0/v1.1 convention: uppercase (e.g. 'ALEXANDER', 'MINT'). v1.2 relaxes to free-form string — registry has lowercase ('codex'), hyphenated ('CODEX-RESCUE'), and prose-tagged values."
+          "description": "Optional persona handle. v1.0/v1.1 convention: uppercase (e.g. 'ALEXANDER', 'MINT'). v1.2 relaxes to free-form string — registry has lowercase ('codex'), hyphenated ('SCAR-SENTINEL'), and prose-tagged values."
         },
         "mode": { "$ref": "#/$defs/Mode" },
         "domain": {


### PR DESCRIPTION
Estate ghost sweep (post construct-compositions#21) is clean except this docstring: the persona-handle schema cites `'CODEX-RESCUE'` as an observed hyphenated value. That persona was a phantom (no identity file anywhere; construct-compositions#20) and is now stripped estate-wide. Swapped for `SCAR-SENTINEL`, a real hyphenated persona in the current census. Related: #263 (fagan unregistered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)