### PR TITLE
fix(registry): register fagan (closes #263)

### DIFF
--- a/apps/api/.cache/registry.yaml
+++ b/apps/api/.cache/registry.yaml
@@ -26,6 +26,12 @@ constructs:
     category: analytics
     author: 0xHoneyJar
 
+  fagan:
+    git_url: https://github.com/0xHoneyJar/construct-fagan.git
+    description: "Strict adversarial code review — cross-model council, structured findings, convergence loop (formerly codex-review)"
+    category: code-review
+    author: 0xHoneyJar
+
   gecko:
     git_url: https://github.com/0xHoneyJar/construct-gecko.git
     description: "Ecosystem intelligence — patrol, observe, diagnose, report"

--- a/registry.yaml
+++ b/registry.yaml
@@ -26,6 +26,12 @@ constructs:
     category: analytics
     author: 0xHoneyJar
 
+  fagan:
+    git_url: https://github.com/0xHoneyJar/construct-fagan.git
+    description: "Strict adversarial code review — cross-model council, structured findings, convergence loop (formerly codex-review)"
+    category: code-review
+    author: 0xHoneyJar
+
   gecko:
     git_url: https://github.com/0xHoneyJar/construct-gecko.git
     description: "Ecosystem intelligence — patrol, observe, diagnose, report"


### PR DESCRIPTION
Closes #263.

## What

Six-line data entry in `registry.yaml`: registers `fagan` (19th construct), alphabetically between beehive and gecko.

```yaml
fagan:
  git_url: https://github.com/0xHoneyJar/construct-fagan.git
  description: "Strict adversarial code review, cross-model council, structured findings, convergence loop (formerly codex-review)"
  category: code-review
  author: 0xHoneyJar
```

## Why

Live compositions (`code-implement-and-review`, `fix-sprint`, `architecture-migration`) declare `depends_on.constructs: [fagan]` after the ghost strip in construct-compositions#21, but the registry never carried the slug. Every resolution pushed agents around the governed path (the arneson-unregistered friction class).

## Notes

- The registry schema is `{git_url, description, category, author}` only; no `legacy_slug` field exists, so the codex-review lineage (rename landed under bd-ii1m) is carried in the description per the issue's conditional. Adding a lineage field would be a schema change and stays out of a data PR.
- `category: code-review` is new vocabulary, consistent with the field's de-facto free-form use (`game-design`, `web3`, `smart-contracts` already exist outside any enum). Observed in passing: the Zod `skillCategorySchema` enum in `packages/shared/src/validation.ts:57` and registry.yaml's category vocabulary have fully diverged; that drift belongs with #240/#224, not here.
- Repo is public; org-internal, so `registry-sources.yaml` (external sources) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
