### PR TITLE
fix(ci): secret-scanning full-scan on push/schedule (un-numb the gate)

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -33,8 +33,12 @@ jobs:
         uses: trufflesecurity/trufflehog@7f4e37db2d928c18ddd7ddf0604f8f7d1f5793ec # v3.93.0
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          # Diff-scan on PRs (base != head); full-tree scan on push/schedule. On non-PR
+          # events both base+head are empty, which triggers TruffleHog's full-scan mode and
+          # avoids the "BASE == HEAD commits are the same" error that failed EVERY push to
+          # main (chronic numb gate — secret-scanning was red on every commit since 06-09).
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
           extra_args: --only-verified
 
       - name: Run GitLeaks


### PR DESCRIPTION
## Problem
`Secret Scanning` (TruffleHog) has been **red on every commit to `main` since 2026-06-09** — `##[error]BASE and HEAD commits are the same. TruffleHog won't scan anything.` The step set `base: github.event.repository.default_branch` + `head: HEAD`, so on **push** (and **schedule**) base==head → exit 1. A required-looking security gate that fails on every push is merge-blind noise — and since admins merge past it, a *real* leak would look identical to the chronic failure.

## Fix
Event-aware base/head on the existing step:
- **pull_request** → base/head = PR base/head sha → diff scan (base ≠ head)
- **push / schedule** → both empty → TruffleHog **full-tree** scan (no base==head error)

Keeps `--only-verified` and `id: trufflehog` (the `Check results` step depends on it).

## Verification
This PR's own `Secret Scanning` check runs as a `pull_request` event (base ≠ head) — green here proves the diff path. Post-merge, the `push` scan runs full-tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
