### PR TITLE
fix(construct-index): construct.yaml is the SoT for skills + commands + persona

### DIFF
--- a/.claude/scripts/construct-index-gen.sh
+++ b/.claude/scripts/construct-index-gen.sh
@@ -369,6 +369,7 @@ process_pack() {
 
     # Check for construct.yaml overlay
     local construct_yaml="$pack_dir/construct.yaml"
+    local construct_yaml_persona="null"
     if [[ -f "$construct_yaml" ]] && command -v yq &>/dev/null; then
         log "    Merging construct.yaml"
 
@@ -393,19 +394,44 @@ process_pack() {
         if [[ "$cy_tags" != "null" ]]; then
             tags_json="$cy_tags"
         fi
+
+        # construct.yaml is the SoT: its skills + COMMANDS + persona pointer ALL win over the (possibly
+        # stale) manifest.json, like every other overlaid field — leaving any of them manifest-sourced
+        # re-introduces the exact staleness this fix defeats (FAGAN F1: gecko otherwise loses 5 of 9
+        # commands from routing). Each list normalizes the three real shapes — a MAP (key=slug/name,
+        # value object OR scalar) · a list of STRINGs · a list of OBJECTs — to [{slug|name, path}]; an
+        # unexpected shape silently keeps the manifest value (no crash, no whole-pack drop — FAGAN F2/F3).
+        local cy_skills cy_commands cy_persona
+        cy_skills=$(yq eval -o=json '.skills // []' "$construct_yaml" 2>/dev/null || echo "[]")
+        if [[ "$cy_skills" != "[]" && "$cy_skills" != "{}" && "$cy_skills" != "null" ]]; then
+            skills_json=$(echo "$cy_skills" | jq -c 'if type=="object" then [to_entries[] | {slug:.key, path:(if (.value|type)=="object" then (.value.path // ("skills/"+.key)) elif (.value|type)=="string" then .value else ("skills/"+.key) end)}] else [.[] | if type=="string" then {slug:., path:("skills/"+.)} else {slug:(.slug // .name), path:(.path // ("skills/"+(.slug // .name)))} end] end' 2>/dev/null || echo "$skills_json")
+        fi
+        cy_commands=$(yq eval -o=json '.commands // []' "$construct_yaml" 2>/dev/null || echo "[]")
+        if [[ "$cy_commands" != "[]" && "$cy_commands" != "{}" && "$cy_commands" != "null" ]]; then
+            commands_json=$(echo "$cy_commands" | jq -c 'if type=="object" then [to_entries[] | {name:.key, path:(if (.value|type)=="object" then (.value.path // ("commands/"+.key+".md")) elif (.value|type)=="string" then .value else ("commands/"+.key+".md") end)}] else [.[] | if type=="string" then {name:., path:("commands/"+.+".md")} else {name:(.name // .slug), path:(.path // ("commands/"+(.name // .slug)+".md"))} end] end' 2>/dev/null || echo "$commands_json")
+        fi
+        # persona: construct.yaml identity.persona is the SoT, but reject a traversal (..) — a pack must
+        # not point the routing index at another pack's persona or an arbitrary file (FAGAN LOW).
+        cy_persona=$(yq eval '.identity.persona // ""' "$construct_yaml" 2>/dev/null || echo "")
+        if [[ -n "$cy_persona" && "$cy_persona" != "null" && "$cy_persona" != *".."* && -f "${pack_dir%/}/$cy_persona" ]]; then
+            construct_yaml_persona="${pack_dir%/}/$cy_persona"
+        fi
     fi
 
-    # Scan for persona file
-    local persona_path="null"
-    for skill_entry in $(echo "$skills_json" | jq -r '.[].slug // empty'); do
-        for candidate in "$SKILLS_DIR/$skill_entry/persona.md" "$SKILLS_DIR/$skill_entry/PERSONA.md" \
-                         "$pack_dir/skills/$skill_entry/persona.md" "$pack_dir/skills/$skill_entry/PERSONA.md"; do
-            if [[ -f "$candidate" ]]; then
-                persona_path="$candidate"
-                break 2
-            fi
+    # Persona: construct.yaml identity.persona is the SoT (resolved in the overlay above); fall back
+    # to a per-skill persona.md file only when construct.yaml did not declare one.
+    local persona_path="$construct_yaml_persona"
+    if [[ "$persona_path" == "null" ]]; then
+        for skill_entry in $(echo "$skills_json" | jq -r '.[].slug // empty'); do
+            for candidate in "$SKILLS_DIR/$skill_entry/persona.md" "$SKILLS_DIR/$skill_entry/PERSONA.md" \
+                             "$pack_dir/skills/$skill_entry/persona.md" "$pack_dir/skills/$skill_entry/PERSONA.md"; do
+                if [[ -f "$candidate" ]]; then
+                    persona_path="$candidate"
+                    break 2
+                fi
+            done
         done
-    done
+    fi
 
     # Determine quick_start (first command name)
     local quick_start="null"

--- a/tests/unit/construct-index-gen.bats
+++ b/tests/unit/construct-index-gen.bats
@@ -247,6 +247,75 @@ gates:
 }
 
 # =============================================================================
+# T4b: construct.yaml SKILLS + identity.persona win over a stale manifest.json
+# (the SoT bug — gecko showed 4/10 skills + null persona because manifest.json
+#  shadowed construct.yaml; construct.yaml is the source-of-truth)
+# =============================================================================
+
+@test "T4b: construct.yaml skills + identity.persona win over manifest.json (SoT)" {
+    create_mock_pack "test-pack" "$FULL_MANIFEST"   # manifest.json declares 2 skills, no persona
+    create_mock_construct_yaml "test-pack" "name: Test Pack
+slug: test-pack
+version: 1.0.0
+skills:
+  - {slug: extra-a, path: skills/extra-a}
+  - {slug: extra-b, path: skills/extra-b}
+  - {slug: extra-c, path: skills/extra-c}
+identity:
+  persona: identity/persona.yaml
+"
+    mkdir -p "$TEST_PACKS_DIR/test-pack/identity"
+    printf 'name: TESTER\n' > "$TEST_PACKS_DIR/test-pack/identity/persona.yaml"
+
+    run "$SCRIPT" --json --output "$TEST_OUTPUT" --quiet
+    [ "$status" -eq 0 ]
+
+    # construct.yaml SKILLS win over the (stale) manifest.json — 3, not 2
+    [ "$(jq '.constructs[0].skills | length' "$TEST_OUTPUT")" -eq 3 ]
+    [ "$(jq -r '.constructs[0].skills[0].slug' "$TEST_OUTPUT")" = "extra-a" ]
+
+    # construct.yaml identity.persona resolves to persona_path (was null)
+    [ "$(jq -r '.constructs[0].persona_path' "$TEST_OUTPUT")" != "null" ]
+    [[ "$(jq -r '.constructs[0].persona_path' "$TEST_OUTPUT")" == *"identity/persona.yaml" ]]
+}
+
+# =============================================================================
+# T4c: construct.yaml COMMANDS win (FAGAN F1) + scalar-valued MAPs don't crash/
+# drop the pack (FAGAN F2/F3) — skills/commands as {key: string-path} maps
+# =============================================================================
+
+@test "T4c: construct.yaml commands win + scalar-valued maps resolve (FAGAN F1/F2/F3)" {
+    create_mock_pack "test-pack" "$FULL_MANIFEST"   # manifest.json: 1 command (test-cmd), 2 skills
+    create_mock_construct_yaml "test-pack" "name: Test Pack
+slug: test-pack
+version: 1.0.0
+skills:
+  alpha: skills/alpha
+  beta: skills/beta
+commands:
+  cmd-x: commands/cmd-x.md
+  cmd-y: commands/cmd-y.md
+  cmd-z: commands/cmd-z.md
+"
+
+    run "$SCRIPT" --json --output "$TEST_OUTPUT" --quiet
+    [ "$status" -eq 0 ]
+
+    # the pack SURVIVES — a scalar-valued map must not crash jq and silently drop the whole construct
+    [ "$(jq '.constructs | length' "$TEST_OUTPUT")" -eq 1 ]
+
+    # construct.yaml COMMANDS win over the stale manifest.json (3, not manifest's 1)
+    [ "$(jq '.constructs[0].commands | length' "$TEST_OUTPUT")" -eq 3 ]
+    [ "$(jq -r '.constructs[0].commands[0].name' "$TEST_OUTPUT")" = "cmd-x" ]
+    [ "$(jq -r '.constructs[0].commands[0].path' "$TEST_OUTPUT")" = "commands/cmd-x.md" ]
+
+    # scalar-valued skills map (key=slug, value=string path) resolves correctly
+    [ "$(jq '.constructs[0].skills | length' "$TEST_OUTPUT")" -eq 2 ]
+    [ "$(jq -r '.constructs[0].skills[0].slug' "$TEST_OUTPUT")" = "alpha" ]
+    [ "$(jq -r '.constructs[0].skills[0].path' "$TEST_OUTPUT")" = "skills/alpha" ]
+}
+
+# =============================================================================
 # T5: Missing construct.yaml — manifest-only fields used
 # =============================================================================
 


### PR DESCRIPTION
GECKO heals the construct routing index. construct-index-gen.sh read skills/commands/persona from a stale manifest.json while name/version/tags already won from construct.yaml — gecko showed 4 skills/4 commands/null persona despite declaring 10/9/persona.yaml. Fix: construct.yaml is SoT for skills+commands+persona (normalizes map/string/object; persona rejects ..). Impact: gecko 4→10 skills, 4→9 commands; +4 skills/+3 commands/+35 persona estate-wide; jq errors 8→0. Tests T4b+T4c. Cross-model FAGAN converged (commands-stale F1 + map-scalar crash F2/F3 fixed). 🤖 Claude Code