### PR TITLE
feat(cli): expose construct orientation and mechanics

### DIFF
--- a/docs/migration-constructs-cli-fold.md
+++ b/docs/migration-constructs-cli-fold.md
@@ -19,6 +19,16 @@ rung of the new binary's source-of-truth ladder (`constructs install --rung git`
 | `npx constructs-cli list` | `constructs list --json` (deterministic JSON, provenance, drift surfacing) |
 | `npx constructs-cli` (human tables only) | `constructs capabilities --json` · `constructs robot-docs guide` (self-describing) |
 | — | `constructs atlas --json` · `constructs where <path>` (territory, computed) |
+| — | `constructs info <slug> --json --rung local` (`orientation` prose separated from declared `mechanics`, with pinned provenance) |
+
+The detailed info surface deliberately does not flatten expertise into one description.
+`orientation.authoritative` is always false; `mechanics` is derived from
+`construct.yaml` plus each skill's `index.yaml` capability stanza and has
+`authority_effect: none`. Territory stationing and the graduated-trust ledger remain
+the only authority surfaces. If a selected source rung cannot expose detailed
+mechanics, the JSON says `mechanics.kind: unavailable` instead of fabricating them.
+Atlas consumers use the structured `ratification_status` field for gating; the
+neighboring `ratification` sentence is orientation for the operator, not a state machine.
 
 ## The npm reality (PRD assumption corrected)
 

--- a/packages/constructs-cli/bin/constructs.mjs
+++ b/packages/constructs-cli/bin/constructs.mjs
@@ -17,7 +17,7 @@ import {
   allVerbTokens,
   MUTATION_VERBS,
 } from '../lib/contract.mjs';
-import { listConstructs, readLocalPacks, RUNGS, SotError } from '../lib/sot.mjs';
+import { inspectConstruct, listConstructs, readLocalPacks, RUNGS, SotError } from '../lib/sot.mjs';
 import { atlas, where, TerritoryError } from '../lib/territory.mjs';
 import { station, StationError } from '../lib/station.mjs';
 import { install, InstallError } from '../lib/install.mjs';
@@ -224,11 +224,11 @@ async function cmdInfo(slug, flags, wantJson) {
   if (!slug) {
     return fail(EXIT.CALLER_ERROR, 'info requires a construct slug', 'constructs info <slug> --json');
   }
-  const result = await listConstructs({
+  const result = await inspectConstruct(slug, {
     noCache: Boolean(flags['no-cache']),
     rung: rungFromFlag(flags.rung),
   });
-  const found = result.data.find((c) => c.slug === slug);
+  const found = result.data;
   if (!found) {
     return fail(
       EXIT.CALLER_ERROR,

--- a/packages/constructs-cli/lib/contract.mjs
+++ b/packages/constructs-cli/lib/contract.mjs
@@ -75,7 +75,7 @@ export const VERBS = [
     aliases: ['search'],
     summary: 'Search constructs by keyword.',
     args: ['<query>'],
-    flags: ['--json', '--no-cache'],
+    flags: ['--json', '--no-cache', '--rung <local|api|registry>'],
     mutation: false,
     ambient: ['network'],
     example: 'constructs find research --json',
@@ -85,7 +85,7 @@ export const VERBS = [
     aliases: ['show'],
     summary: 'Show one construct in full (skills, commands, persona, provenance).',
     args: ['<slug>'],
-    flags: ['--json', '--no-cache'],
+    flags: ['--json', '--no-cache', '--rung <local|api|registry>'],
     mutation: false,
     ambient: ['network'],
     example: 'constructs info k-hole --json',
@@ -223,6 +223,18 @@ export function capabilities() {
       implementation: 'vendored declared-keyword subset (NOT full JSON Schema 2020-12)',
       supported_keywords: 'see robot-docs guide',
     },
+    info_contract: {
+      schema_version: '1.0',
+      schema_path: 'schemas/info.schema.json',
+      orientation: 'prose; authoritative=false',
+      mechanics: 'declared callable routes and runtime hints; authority_effect=none',
+      authority: 'territory ceiling intersected with graduated-trust evidence; never granted by info',
+    },
+    atlas_contract: {
+      atlas_version: '1.0',
+      ratification_status: 'structured status; unchecked until the atlas verifies committed stationing',
+      authority: 'ceiling and earned tier are separate; unknown earned authority has effective=observe',
+    },
     sot_ladder: ['local-packs', 'api', 'registry-yaml'],
     intent_inference: {
       read_only_verbs: 'auto-corrected with a warning',
@@ -284,6 +296,15 @@ export function robotDocs() {
   lines.push('- stdout is DATA. stderr is DIAGNOSTICS. `constructs list --json | jq` never needs a grep.');
   lines.push('- Every answer carries `provenance` naming which source-of-truth rung answered.');
   lines.push('- An empty result is `[]` with exit 0. There is no "no results" error code.');
+  lines.push('');
+  lines.push('## Construct info has three distinct planes');
+  lines.push('`constructs info <slug> --json --rung local` returns:');
+  lines.push('- `orientation` — prose, explicitly `authoritative: false`; it helps a human or agent frame the domain.');
+  lines.push('- `mechanics` — declared skills, commands, and per-skill runtime capabilities; `authority_effect: none`.');
+  lines.push('- `provenance` — the pinned source-of-truth rung that produced the answer.');
+  lines.push('Neither orientation nor mechanics grants permission. Region territory + the graduated-trust ledger own authority.');
+  lines.push('A rung without detailed metadata returns `mechanics.kind: unavailable` rather than inventing a callable surface.');
+  lines.push('Atlas consumers MUST gate on `ratification_status`, never parse the explanatory `ratification` prose.');
   lines.push('');
   lines.push('## Exit codes');
   for (const [code, meaning] of Object.entries(cap.exit_codes)) lines.push(`- \`${code}\` — ${meaning}`);

--- a/packages/constructs-cli/lib/sot.mjs
+++ b/packages/constructs-cli/lib/sot.mjs
@@ -110,35 +110,112 @@ function normalizeDeclaredRef(value, key) {
   };
 }
 
+function isInside(root, candidate) {
+  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+function fsFailureStatus(error) {
+  if (error?.code === 'ENOENT' || error?.code === 'ENOTDIR') return 'missing';
+  if (error?.code === 'EACCES' || error?.code === 'EPERM') return 'inaccessible';
+  return 'invalid';
+}
+
+async function resolvePackPath(packDir, declaredPath, { baseDir = packDir, expect = 'file' } = {}) {
+  if (typeof declaredPath !== 'string' || declaredPath.length === 0 || path.isAbsolute(declaredPath)) {
+    return { status: 'invalid-path', path: null, actual: null };
+  }
+
+  const packRoot = await realpath(packDir);
+  const baseRoot = await realpath(baseDir);
+  const lexical = path.resolve(baseRoot, declaredPath);
+  if (!isInside(baseRoot, lexical) || !isInside(packRoot, lexical)) {
+    return { status: 'invalid-path', path: null, actual: null };
+  }
+
+  try {
+    const actual = await realpath(lexical);
+    if (!isInside(packRoot, actual) || !isInside(baseRoot, actual)) {
+      return { status: 'invalid-path', path: null, actual: null };
+    }
+    const info = await stat(actual);
+    if ((expect === 'file' && !info.isFile()) || (expect === 'directory' && !info.isDirectory())) {
+      return { status: 'invalid', path: null, actual: null };
+    }
+    return {
+      status: 'declared',
+      path: path.relative(packRoot, actual).split(path.sep).join('/'),
+      actual,
+    };
+  } catch (error) {
+    return { status: fsFailureStatus(error), path: null, actual: null };
+  }
+}
+
 async function readSkillMechanics(packDir, declared) {
   const skill = normalizeDeclaredRef(declared, 'slug');
   if (!skill) return null;
   if (!skill.path) return { ...skill, metadata_status: 'missing', entry: null, capabilities: null };
 
-  const packRoot = await realpath(packDir);
-  const lexical = path.resolve(packDir, skill.path, 'index.yaml');
-  const lexicalInside = lexical.startsWith(`${path.resolve(packDir)}${path.sep}`);
-  if (!lexicalInside) {
-    return { ...skill, metadata_status: 'invalid-path', entry: null, capabilities: null };
+  const skillDir = await resolvePackPath(packDir, skill.path, { expect: 'directory' });
+  if (skillDir.status !== 'declared') {
+    return { ...skill, path: null, metadata_status: skillDir.status, entry: null, capabilities: null };
   }
 
   try {
-    const actual = await realpath(lexical);
-    if (!actual.startsWith(`${packRoot}${path.sep}`)) {
-      return { ...skill, metadata_status: 'invalid-path', entry: null, capabilities: null };
+    const indexFile = await resolvePackPath(packDir, 'index.yaml', { baseDir: skillDir.actual });
+    if (indexFile.status !== 'declared') {
+      return {
+        ...skill,
+        path: skillDir.path,
+        metadata_status: indexFile.status,
+        entry: null,
+        capabilities: null,
+      };
     }
-    const index = parseYaml(await readFile(actual, 'utf8'));
+    const index = parseYaml(await readFile(indexFile.actual, 'utf8'));
+    if (!index || typeof index !== 'object' || typeof index.entry !== 'string') {
+      return { ...skill, path: skillDir.path, metadata_status: 'invalid', entry: null, capabilities: null };
+    }
+    const entryFile = await resolvePackPath(packDir, index.entry, { baseDir: skillDir.actual });
+    if (entryFile.status !== 'declared') {
+      return {
+        ...skill,
+        path: skillDir.path,
+        metadata_status: entryFile.status,
+        entry: null,
+        capabilities: null,
+      };
+    }
     return {
       ...skill,
+      path: skillDir.path,
       metadata_status: 'declared',
-      entry: typeof index?.entry === 'string' ? index.entry : null,
+      entry: path.relative(skillDir.actual, entryFile.actual).split(path.sep).join('/'),
       capabilities: index?.capabilities && typeof index.capabilities === 'object'
         ? index.capabilities
         : null,
     };
-  } catch {
-    return { ...skill, metadata_status: 'missing', entry: null, capabilities: null };
+  } catch (error) {
+    return {
+      ...skill,
+      path: skillDir.path,
+      metadata_status: fsFailureStatus(error),
+      entry: null,
+      capabilities: null,
+    };
   }
+}
+
+async function readCommandMechanics(packDir, declared) {
+  const command = normalizeDeclaredRef(declared, 'name');
+  if (!command) return null;
+  if (!command.path) return { ...command, path_status: 'missing' };
+  const resolved = await resolvePackPath(packDir, command.path);
+  return {
+    ...command,
+    path: resolved.path,
+    path_status: resolved.status,
+  };
 }
 
 /**
@@ -154,11 +231,12 @@ export async function inspectLocalConstruct(slug, root = packsRoot()) {
   if (!summary) return null;
 
   const manifest = parseYaml(await readFile(path.join(summary.source, 'construct.yaml'), 'utf8'));
-  const skills = (await Promise.all((manifest?.skills ?? []).map((skill) => readSkillMechanics(summary.source, skill))))
+  const declaredSkills = Array.isArray(manifest?.skills) ? manifest.skills : [];
+  const declaredCommands = Array.isArray(manifest?.commands) ? manifest.commands : [];
+  const skills = (await Promise.all(declaredSkills.map((skill) => readSkillMechanics(summary.source, skill))))
     .filter(Boolean)
     .sort((a, b) => a.slug.localeCompare(b.slug));
-  const commands = (manifest?.commands ?? [])
-    .map((command) => normalizeDeclaredRef(command, 'name'))
+  const commands = (await Promise.all(declaredCommands.map((command) => readCommandMechanics(summary.source, command))))
     .filter(Boolean)
     .sort((a, b) => a.name.localeCompare(b.name));
 
@@ -170,7 +248,7 @@ export async function inspectLocalConstruct(slug, root = packsRoot()) {
       kind: 'declared',
       authority_effect: 'none',
       source_refs: ['construct.yaml', ...skills
-        .filter((skill) => skill.path)
+        .filter((skill) => skill.metadata_status === 'declared' && skill.path)
         .map((skill) => path.posix.join(skill.path, 'index.yaml'))],
       skills,
       commands,

--- a/packages/constructs-cli/lib/sot.mjs
+++ b/packages/constructs-cli/lib/sot.mjs
@@ -304,7 +304,9 @@ async function inspectLocalSummary(summary) {
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return {
-    ...summary,
+    slug: summary.slug,
+    name: summary.name,
+    version: summary.version,
     info_schema_version: '1.0',
     orientation: orientationFromManifest(manifest, summary),
     mechanics: {
@@ -339,7 +341,9 @@ export async function inspectConstruct(slug, opts = {}) {
   return {
     ...result,
     data: {
-      ...found,
+      slug: found.slug,
+      name: found.name,
+      version: found.version,
       info_schema_version: '1.0',
       orientation: {
         kind: 'prose',

--- a/packages/constructs-cli/lib/sot.mjs
+++ b/packages/constructs-cli/lib/sot.mjs
@@ -454,11 +454,16 @@ export function detectDrift(answers) {
 /**
  * Answer a listing query by walking the ladder.
  *
- * @param {{noCache?: boolean, rung?: string, timeoutMs?: number}} opts
+ * @param {{noCache?: boolean, rung?: string, timeoutMs?: number, localRoot?: string}} opts
  * @returns {Promise<{data: any[], provenance: object, drift: any[], corrupt: any[], exitCode: number}>}
  */
 export async function listConstructs(opts = {}) {
-  const { noCache = false, rung: pinned = null, timeoutMs = 10_000 } = opts;
+  const {
+    noCache = false,
+    rung: pinned = null,
+    timeoutMs = 10_000,
+    localRoot = packsRoot(),
+  } = opts;
   const answers = [];
   const corrupt = [];
   let cacheState = 'n/a';
@@ -468,7 +473,7 @@ export async function listConstructs(opts = {}) {
   const wantRegistry = !pinned || pinned === RUNGS.REGISTRY;
 
   if (wantLocal) {
-    const local = await readLocalPacks();
+    const local = await readLocalPacks(localRoot);
     corrupt.push(...local.corrupt);
     if (local.present && local.packs.length) answers.push({ rung: RUNGS.LOCAL, items: local.packs });
   }

--- a/packages/constructs-cli/lib/sot.mjs
+++ b/packages/constructs-cli/lib/sot.mjs
@@ -215,6 +215,12 @@ async function resolvePackPath(packDir, declaredPath, { baseDir = packDir, expec
 async function readSkillMechanics(packDir, declared) {
   const skill = normalizeDeclaredRef(declared, 'slug');
   if (!skill) return null;
+  if (!skill.path && typeof declared === 'string') {
+    if (!/^[a-z][a-z0-9-]*$/.test(skill.slug)) {
+      return { ...skill, metadata_status: 'invalid-path', entry: null, capabilities: null };
+    }
+    skill.path = `skills/${skill.slug}`;
+  }
   if (!skill.path) return { ...skill, metadata_status: 'missing', entry: null, capabilities: null };
 
   const skillDir = await resolvePackPath(packDir, skill.path, { expect: 'directory' });

--- a/packages/constructs-cli/lib/sot.mjs
+++ b/packages/constructs-cli/lib/sot.mjs
@@ -31,6 +31,21 @@ export class SotError extends Error {
 
 const DEFAULT_API = 'https://api.constructs.network/v1';
 const CACHE_TTL_MS = 15 * 60 * 1000;
+const manifestSnapshots = new WeakMap();
+
+const CAPABILITY_STRING_FIELDS = Object.freeze([
+  'model_tier',
+  'danger_level',
+  'effort_hint',
+  'execution_hint',
+]);
+const CAPABILITY_BOOLEAN_FIELDS = Object.freeze(['downgrade_allowed']);
+const CAPABILITY_REQUIRE_FIELDS = Object.freeze([
+  'native_runtime',
+  'tool_calling',
+  'thinking_traces',
+  'vision',
+]);
 
 function sha256(text) {
   return createHash('sha256').update(text).digest('hex');
@@ -110,6 +125,52 @@ function normalizeDeclaredRef(value, key) {
   };
 }
 
+function normalizeSkillCapabilities(value) {
+  if (value == null) return { valid: true, value: null };
+  if (typeof value !== 'object' || Array.isArray(value)) return { valid: false, value: null };
+
+  const allowed = new Set([
+    ...CAPABILITY_STRING_FIELDS,
+    ...CAPABILITY_BOOLEAN_FIELDS,
+    'requires',
+  ]);
+  if (Object.keys(value).some((key) => !allowed.has(key))) {
+    return { valid: false, value: null };
+  }
+
+  const normalized = {};
+  for (const key of CAPABILITY_STRING_FIELDS) {
+    if (!(key in value)) continue;
+    if (typeof value[key] !== 'string' || value[key].length === 0) {
+      return { valid: false, value: null };
+    }
+    normalized[key] = value[key];
+  }
+  for (const key of CAPABILITY_BOOLEAN_FIELDS) {
+    if (!(key in value)) continue;
+    if (typeof value[key] !== 'boolean') return { valid: false, value: null };
+    normalized[key] = value[key];
+  }
+
+  if ('requires' in value) {
+    const requirements = value.requires;
+    if (!requirements || typeof requirements !== 'object' || Array.isArray(requirements)) {
+      return { valid: false, value: null };
+    }
+    if (Object.keys(requirements).some((key) => !CAPABILITY_REQUIRE_FIELDS.includes(key))) {
+      return { valid: false, value: null };
+    }
+    normalized.requires = {};
+    for (const key of CAPABILITY_REQUIRE_FIELDS) {
+      if (!(key in requirements)) continue;
+      if (typeof requirements[key] !== 'boolean') return { valid: false, value: null };
+      normalized.requires[key] = requirements[key];
+    }
+  }
+
+  return { valid: true, value: normalized };
+}
+
 function isInside(root, candidate) {
   return candidate === root || candidate.startsWith(`${root}${path.sep}`);
 }
@@ -176,6 +237,10 @@ async function readSkillMechanics(packDir, declared) {
     if (!index || typeof index !== 'object' || typeof index.entry !== 'string') {
       return { ...skill, path: skillDir.path, metadata_status: 'invalid', entry: null, capabilities: null };
     }
+    const capabilities = normalizeSkillCapabilities(index.capabilities);
+    if (!capabilities.valid) {
+      return { ...skill, path: skillDir.path, metadata_status: 'invalid', entry: null, capabilities: null };
+    }
     const entryFile = await resolvePackPath(packDir, index.entry, { baseDir: skillDir.actual });
     if (entryFile.status !== 'declared') {
       return {
@@ -191,9 +256,7 @@ async function readSkillMechanics(packDir, declared) {
       path: skillDir.path,
       metadata_status: 'declared',
       entry: path.relative(skillDir.actual, entryFile.actual).split(path.sep).join('/'),
-      capabilities: index?.capabilities && typeof index.capabilities === 'object'
-        ? index.capabilities
-        : null,
+      capabilities: capabilities.value,
     };
   } catch (error) {
     return {
@@ -225,12 +288,12 @@ async function readCommandMechanics(packDir, declared) {
  * `mechanics` is a declaration read from construct.yaml + skill index.yaml and
  * grants no authority. Territory/L4 are the only authority surfaces.
  */
-export async function inspectLocalConstruct(slug, root = packsRoot()) {
-  const local = await readLocalPacks(root);
-  const summary = local.packs.find((pack) => pack.slug === slug);
-  if (!summary) return null;
-
-  const manifest = parseYaml(await readFile(path.join(summary.source, 'construct.yaml'), 'utf8'));
+async function inspectLocalSummary(summary) {
+  const manifestRaw = manifestSnapshots.get(summary);
+  if (typeof manifestRaw !== 'string') {
+    throw new SotError('local construct manifest snapshot is unavailable', EXIT.TOOL_FAILURE);
+  }
+  const manifest = parseYaml(manifestRaw);
   const declaredSkills = Array.isArray(manifest?.skills) ? manifest.skills : [];
   const declaredCommands = Array.isArray(manifest?.commands) ? manifest.commands : [];
   const skills = (await Promise.all(declaredSkills.map((skill) => readSkillMechanics(summary.source, skill))))
@@ -258,14 +321,19 @@ export async function inspectLocalConstruct(slug, root = packsRoot()) {
   };
 }
 
+export async function inspectLocalConstruct(slug, root = packsRoot()) {
+  const local = await readLocalPacks(root);
+  const summary = local.packs.find((pack) => pack.slug === slug);
+  return summary ? inspectLocalSummary(summary) : null;
+}
+
 export async function inspectConstruct(slug, opts = {}) {
   const result = await listConstructs(opts);
   const found = result.data.find((construct) => construct.slug === slug) ?? null;
   if (!found) return { ...result, data: null };
 
   if (result.provenance.rung === RUNGS.LOCAL) {
-    const detailed = await inspectLocalConstruct(slug, opts.localRoot ?? packsRoot());
-    if (detailed) return { ...result, data: detailed };
+    return { ...result, data: await inspectLocalSummary(found) };
   }
 
   return {
@@ -324,14 +392,16 @@ export async function readLocalPacks(root = packsRoot()) {
         }
       }
 
-      packs.push({
+      const summary = {
         slug: manifest.slug || manifest.name || entry.name,
         name: manifest.name ?? entry.name,
         version: String(manifest.version ?? '0.0.0'),
         description: manifest.description ?? '',
         skills_count: Array.isArray(manifest.skills) ? manifest.skills.length : 0,
         source: dir,
-      });
+      };
+      manifestSnapshots.set(summary, raw);
+      packs.push(summary);
     } catch (err) {
       if (err?.code === 'YAML_OUT_OF_SUBSET') {
         corrupt.push({ slug: entry.name, reason: err.message });

--- a/packages/constructs-cli/lib/sot.mjs
+++ b/packages/constructs-cli/lib/sot.mjs
@@ -13,7 +13,7 @@
 // provenance says whether the answer came from cache, the wire, or a bypass.
 
 import { createHash } from 'node:crypto';
-import { readFile, writeFile, mkdir, readdir, stat } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, readdir, realpath, stat } from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { parse as parseYaml } from './vendor/yaml-subset.mjs';
@@ -74,6 +74,139 @@ async function cacheWrite(key, data) {
 
 export function packsRoot() {
   return process.env.CONSTRUCTS_DIR || path.join('.claude', 'constructs', 'packs');
+}
+
+function unavailableMechanics(reason) {
+  return {
+    kind: 'unavailable',
+    authority_effect: 'none',
+    reason,
+    skills: [],
+    commands: [],
+  };
+}
+
+function orientationFromManifest(manifest, summary) {
+  const identity = manifest?.identity ?? {};
+  return {
+    kind: 'prose',
+    authoritative: false,
+    description: manifest?.description ?? summary.description ?? '',
+    short_description: manifest?.short_description ?? null,
+    domains: Array.isArray(manifest?.domain) ? manifest.domain : [],
+    persona_ref: typeof identity?.persona === 'string' ? identity.persona : null,
+    expertise_ref: typeof identity?.expertise === 'string' ? identity.expertise : null,
+  };
+}
+
+function normalizeDeclaredRef(value, key) {
+  if (typeof value === 'string') return { [key]: value, path: null };
+  if (!value || typeof value !== 'object') return null;
+  const id = value[key] ?? value.slug ?? value.name;
+  if (typeof id !== 'string' || id.length === 0) return null;
+  return {
+    [key]: id,
+    path: typeof value.path === 'string' ? value.path : null,
+  };
+}
+
+async function readSkillMechanics(packDir, declared) {
+  const skill = normalizeDeclaredRef(declared, 'slug');
+  if (!skill) return null;
+  if (!skill.path) return { ...skill, metadata_status: 'missing', entry: null, capabilities: null };
+
+  const packRoot = await realpath(packDir);
+  const lexical = path.resolve(packDir, skill.path, 'index.yaml');
+  const lexicalInside = lexical.startsWith(`${path.resolve(packDir)}${path.sep}`);
+  if (!lexicalInside) {
+    return { ...skill, metadata_status: 'invalid-path', entry: null, capabilities: null };
+  }
+
+  try {
+    const actual = await realpath(lexical);
+    if (!actual.startsWith(`${packRoot}${path.sep}`)) {
+      return { ...skill, metadata_status: 'invalid-path', entry: null, capabilities: null };
+    }
+    const index = parseYaml(await readFile(actual, 'utf8'));
+    return {
+      ...skill,
+      metadata_status: 'declared',
+      entry: typeof index?.entry === 'string' ? index.entry : null,
+      capabilities: index?.capabilities && typeof index.capabilities === 'object'
+        ? index.capabilities
+        : null,
+    };
+  } catch {
+    return { ...skill, metadata_status: 'missing', entry: null, capabilities: null };
+  }
+}
+
+/**
+ * Resolve the full local info surface for one installed construct.
+ *
+ * The split is deliberate: `orientation` is prose and can only orient;
+ * `mechanics` is a declaration read from construct.yaml + skill index.yaml and
+ * grants no authority. Territory/L4 are the only authority surfaces.
+ */
+export async function inspectLocalConstruct(slug, root = packsRoot()) {
+  const local = await readLocalPacks(root);
+  const summary = local.packs.find((pack) => pack.slug === slug);
+  if (!summary) return null;
+
+  const manifest = parseYaml(await readFile(path.join(summary.source, 'construct.yaml'), 'utf8'));
+  const skills = (await Promise.all((manifest?.skills ?? []).map((skill) => readSkillMechanics(summary.source, skill))))
+    .filter(Boolean)
+    .sort((a, b) => a.slug.localeCompare(b.slug));
+  const commands = (manifest?.commands ?? [])
+    .map((command) => normalizeDeclaredRef(command, 'name'))
+    .filter(Boolean)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    ...summary,
+    info_schema_version: '1.0',
+    orientation: orientationFromManifest(manifest, summary),
+    mechanics: {
+      kind: 'declared',
+      authority_effect: 'none',
+      source_refs: ['construct.yaml', ...skills
+        .filter((skill) => skill.path)
+        .map((skill) => path.posix.join(skill.path, 'index.yaml'))],
+      skills,
+      commands,
+      streams: manifest?.streams && typeof manifest.streams === 'object' ? manifest.streams : null,
+      events: manifest?.events && typeof manifest.events === 'object' ? manifest.events : null,
+    },
+  };
+}
+
+export async function inspectConstruct(slug, opts = {}) {
+  const result = await listConstructs(opts);
+  const found = result.data.find((construct) => construct.slug === slug) ?? null;
+  if (!found) return { ...result, data: null };
+
+  if (result.provenance.rung === RUNGS.LOCAL) {
+    const detailed = await inspectLocalConstruct(slug, opts.localRoot ?? packsRoot());
+    if (detailed) return { ...result, data: detailed };
+  }
+
+  return {
+    ...result,
+    data: {
+      ...found,
+      info_schema_version: '1.0',
+      orientation: {
+        kind: 'prose',
+        authoritative: false,
+        description: found.description ?? '',
+        short_description: null,
+        domains: [],
+        persona_ref: null,
+        expertise_ref: null,
+      },
+      mechanics: unavailableMechanics(`source rung ${result.provenance.rung} does not expose construct mechanics`),
+    },
+  };
 }
 
 /**
@@ -311,4 +444,14 @@ export async function listConstructs(opts = {}) {
   };
 }
 
-export default { RUNGS, listConstructs, readLocalPacks, readRegistryYaml, detectDrift, apiFetch, SotError };
+export default {
+  RUNGS,
+  listConstructs,
+  inspectConstruct,
+  inspectLocalConstruct,
+  readLocalPacks,
+  readRegistryYaml,
+  detectDrift,
+  apiFetch,
+  SotError,
+};

--- a/packages/constructs-cli/lib/territory.mjs
+++ b/packages/constructs-cli/lib/territory.mjs
@@ -292,6 +292,7 @@ export async function atlas({ sources = ['.'], timeoutMs = DEFAULT_TIMEOUT_MS } 
     // WORKING TREE of each source. A stationing is live only when the manifest
     // edit is committed on the region's default branch — this map does not
     // verify that, and says so rather than letting a preview pass as ratified.
+    ratification_status: 'unchecked',
     ratification: 'unchecked — loadout rows reflect the working tree; liveness requires the committed manifest on the region default branch',
     zones: zones.map((z) => ({ name: z.name, tracked_paths: [...z.tracked_paths].sort() })).sort((a, b) => a.name.localeCompare(b.name)),
     regions: regionBlocks,

--- a/packages/constructs-cli/schemas/info.schema.json
+++ b/packages/constructs-cli/schemas/info.schema.json
@@ -10,6 +10,7 @@
     "data": {
       "type": "object",
       "required": ["slug", "name", "version", "info_schema_version", "orientation", "mechanics"],
+      "additionalProperties": false,
       "properties": {
         "slug": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
         "name": { "type": "string", "minLength": 1 },
@@ -95,6 +96,7 @@
     "provenance": {
       "type": "object",
       "required": ["rung", "pinned", "rungs_consulted", "vantage"],
+      "additionalProperties": false,
       "properties": {
         "rung": { "type": "string" },
         "pinned": { "type": "boolean" },

--- a/packages/constructs-cli/schemas/info.schema.json
+++ b/packages/constructs-cli/schemas/info.schema.json
@@ -32,6 +32,7 @@
         "mechanics": {
           "type": "object",
           "required": ["kind", "authority_effect", "skills", "commands"],
+          "additionalProperties": false,
           "properties": {
             "kind": { "type": "string", "enum": ["declared", "unavailable"] },
             "authority_effect": { "const": "none" },
@@ -42,12 +43,33 @@
               "items": {
                 "type": "object",
                 "required": ["slug", "path", "metadata_status", "entry", "capabilities"],
+                "additionalProperties": false,
                 "properties": {
                   "slug": { "type": "string", "minLength": 1 },
                   "path": { "type": ["string", "null"] },
                   "metadata_status": { "type": "string", "enum": ["declared", "missing", "invalid", "inaccessible", "invalid-path"] },
                   "entry": { "type": ["string", "null"] },
-                  "capabilities": { "type": ["object", "null"] }
+                  "capabilities": {
+                    "type": ["object", "null"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "model_tier": { "type": "string", "minLength": 1 },
+                      "danger_level": { "type": "string", "minLength": 1 },
+                      "effort_hint": { "type": "string", "minLength": 1 },
+                      "downgrade_allowed": { "type": "boolean" },
+                      "execution_hint": { "type": "string", "minLength": 1 },
+                      "requires": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "native_runtime": { "type": "boolean" },
+                          "tool_calling": { "type": "boolean" },
+                          "thinking_traces": { "type": "boolean" },
+                          "vision": { "type": "boolean" }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
@@ -56,6 +78,7 @@
               "items": {
                 "type": "object",
                 "required": ["name", "path", "path_status"],
+                "additionalProperties": false,
                 "properties": {
                   "name": { "type": "string", "minLength": 1 },
                   "path": { "type": ["string", "null"] },

--- a/packages/constructs-cli/schemas/info.schema.json
+++ b/packages/constructs-cli/schemas/info.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.github.io/loa-constructs/schemas/info.schema.json",
+  "title": "Construct Info Surface",
+  "description": "The read-only construct expertise projection. Orientation is non-authoritative prose; mechanics are declared callable routes and runtime hints; neither grants authority.",
+  "type": "object",
+  "required": ["data", "provenance", "drift"],
+  "additionalProperties": false,
+  "properties": {
+    "data": {
+      "type": "object",
+      "required": ["slug", "name", "version", "info_schema_version", "orientation", "mechanics"],
+      "properties": {
+        "slug": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "info_schema_version": { "const": "1.0" },
+        "orientation": {
+          "type": "object",
+          "required": ["kind", "authoritative", "description", "domains", "persona_ref", "expertise_ref"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "prose" },
+            "authoritative": { "const": false },
+            "description": { "type": "string" },
+            "short_description": { "type": ["string", "null"] },
+            "domains": { "type": "array", "items": { "type": "string" } },
+            "persona_ref": { "type": ["string", "null"] },
+            "expertise_ref": { "type": ["string", "null"] }
+          }
+        },
+        "mechanics": {
+          "type": "object",
+          "required": ["kind", "authority_effect", "skills", "commands"],
+          "properties": {
+            "kind": { "type": "string", "enum": ["declared", "unavailable"] },
+            "authority_effect": { "const": "none" },
+            "reason": { "type": "string" },
+            "source_refs": { "type": "array", "items": { "type": "string" } },
+            "skills": { "type": "array", "items": { "type": "object" } },
+            "commands": { "type": "array", "items": { "type": "object" } },
+            "streams": { "type": ["object", "null"] },
+            "events": { "type": ["object", "null"] }
+          }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["rung", "pinned", "rungs_consulted", "vantage"],
+      "properties": {
+        "rung": { "type": "string" },
+        "pinned": { "type": "boolean" },
+        "cache": { "type": "string" },
+        "rungs_consulted": { "type": "array", "items": { "type": "string" } },
+        "vantage": { "type": "string" }
+      }
+    },
+    "drift": { "type": "array", "items": { "type": "object" } }
+  }
+}

--- a/packages/constructs-cli/schemas/info.schema.json
+++ b/packages/constructs-cli/schemas/info.schema.json
@@ -18,7 +18,7 @@
         "info_schema_version": { "const": "1.0" },
         "orientation": {
           "type": "object",
-          "required": ["kind", "authoritative", "description", "domains", "persona_ref", "expertise_ref"],
+          "required": ["kind", "authoritative", "description", "short_description", "domains", "persona_ref", "expertise_ref"],
           "additionalProperties": false,
           "properties": {
             "kind": { "const": "prose" },

--- a/packages/constructs-cli/schemas/info.schema.json
+++ b/packages/constructs-cli/schemas/info.schema.json
@@ -37,8 +37,32 @@
             "authority_effect": { "const": "none" },
             "reason": { "type": "string" },
             "source_refs": { "type": "array", "items": { "type": "string" } },
-            "skills": { "type": "array", "items": { "type": "object" } },
-            "commands": { "type": "array", "items": { "type": "object" } },
+            "skills": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["slug", "path", "metadata_status", "entry", "capabilities"],
+                "properties": {
+                  "slug": { "type": "string", "minLength": 1 },
+                  "path": { "type": ["string", "null"] },
+                  "metadata_status": { "type": "string", "enum": ["declared", "missing", "invalid", "inaccessible", "invalid-path"] },
+                  "entry": { "type": ["string", "null"] },
+                  "capabilities": { "type": ["object", "null"] }
+                }
+              }
+            },
+            "commands": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name", "path", "path_status"],
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 },
+                  "path": { "type": ["string", "null"] },
+                  "path_status": { "type": "string", "enum": ["declared", "missing", "invalid", "inaccessible", "invalid-path"] }
+                }
+              }
+            },
             "streams": { "type": ["object", "null"] },
             "events": { "type": ["object", "null"] }
           }

--- a/packages/constructs-cli/test/info.test.mjs
+++ b/packages/constructs-cli/test/info.test.mjs
@@ -81,6 +81,15 @@ test('local info separates prose orientation from declared mechanics', async (t)
   ]);
   assert.equal(info.mechanics.skills[0].metadata_status, 'declared');
   assert.equal(info.mechanics.skills[0].capabilities.danger_level, 'safe');
+  assert.equal('source' in info, false);
+  assert.deepEqual(Object.keys(info).sort(), [
+    'info_schema_version',
+    'mechanics',
+    'name',
+    'orientation',
+    'slug',
+    'version',
+  ]);
 });
 
 test('info --json --rung local emits the split with pinned provenance', async (t) => {
@@ -266,7 +275,7 @@ test('the info schema rejects prose that claims authority', async (t) => {
   assert.match(validation.errors.join('\n'), /authoritative/);
 });
 
-test('the info schema rejects undeclared mechanics and capability fields', async (t) => {
+test('the info schema rejects undeclared data, provenance, mechanics, and capability fields', async (t) => {
   const root = await makePack();
   t.after(() => rm(root, { recursive: true, force: true }));
   const data = await inspectLocalConstruct('fixture', root);
@@ -284,8 +293,12 @@ test('the info schema rejects undeclared mechanics and capability fields', async
 
   payload.data.mechanics.permission_grant = 'write-all';
   payload.data.mechanics.skills[0].capabilities.authority_effect = 'full';
+  payload.data.source = '/Users/operator/private/constructs/fixture';
+  payload.provenance.permission_grant = 'write-all';
   const validation = validate(INFO_SCHEMA, payload);
   assert.equal(validation.valid, false);
+  assert.match(validation.errors.join('\n'), /source/);
+  assert.match(validation.errors.join('\n'), /provenance.*permission_grant/);
   assert.match(validation.errors.join('\n'), /permission_grant/);
   assert.match(validation.errors.join('\n'), /authority_effect/);
 });

--- a/packages/constructs-cli/test/info.test.mjs
+++ b/packages/constructs-cli/test/info.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -54,12 +54,15 @@ capabilities:
     vision: false
 `;
 
-async function makePack(manifest = MANIFEST) {
+async function makePack(manifest = MANIFEST, skillIndex = SKILL_INDEX) {
   const root = await mkdtemp(path.join(tmpdir(), 'construct-info-'));
   const pack = path.join(root, 'fixture');
   await mkdir(path.join(pack, 'skills', 'inspect-fixture'), { recursive: true });
+  await mkdir(path.join(pack, 'commands'), { recursive: true });
   await writeFile(path.join(pack, 'construct.yaml'), manifest);
-  await writeFile(path.join(pack, 'skills', 'inspect-fixture', 'index.yaml'), SKILL_INDEX);
+  await writeFile(path.join(pack, 'skills', 'inspect-fixture', 'index.yaml'), skillIndex);
+  await writeFile(path.join(pack, 'skills', 'inspect-fixture', 'SKILL.md'), '# Fixture skill\n');
+  await writeFile(path.join(pack, 'commands', 'inspect-fixture.md'), '# Fixture command\n');
   return root;
 }
 
@@ -74,7 +77,7 @@ test('local info separates prose orientation from declared mechanics', async (t)
   assert.equal(info.mechanics.kind, 'declared');
   assert.equal(info.mechanics.authority_effect, 'none');
   assert.deepEqual(info.mechanics.commands, [
-    { name: 'inspect-fixture', path: 'commands/inspect-fixture.md' },
+    { name: 'inspect-fixture', path: 'commands/inspect-fixture.md', path_status: 'declared' },
   ]);
   assert.equal(info.mechanics.skills[0].metadata_status, 'declared');
   assert.equal(info.mechanics.skills[0].capabilities.danger_level, 'safe');
@@ -106,6 +109,74 @@ test('a skill metadata path cannot escape the installed pack', async (t) => {
   const info = await inspectLocalConstruct('fixture', root);
   assert.equal(info.mechanics.skills[0].metadata_status, 'invalid-path');
   assert.equal(info.mechanics.skills[0].capabilities, null);
+  assert.equal(info.mechanics.skills[0].path, null);
+});
+
+test('a command path cannot escape the installed pack', async (t) => {
+  const manifest = MANIFEST.replace('path: commands/inspect-fixture.md', 'path: ../../outside.md');
+  const root = await makePack(manifest);
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const info = await inspectLocalConstruct('fixture', root);
+  assert.equal(info.mechanics.commands[0].path_status, 'invalid-path');
+  assert.equal(info.mechanics.commands[0].path, null);
+});
+
+test('a skill entry cannot escape its skill directory', async (t) => {
+  const index = SKILL_INDEX.replace('entry: SKILL.md', 'entry: ../../outside.md');
+  const root = await makePack(MANIFEST, index);
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const info = await inspectLocalConstruct('fixture', root);
+  assert.equal(info.mechanics.skills[0].metadata_status, 'invalid-path');
+  assert.equal(info.mechanics.skills[0].entry, null);
+  assert.equal(info.mechanics.skills[0].capabilities, null);
+});
+
+test('realpath containment rejects command and skill-entry symlink escapes', async (t) => {
+  const root = await makePack();
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const pack = path.join(root, 'fixture');
+  const outside = path.join(root, 'outside.md');
+  await writeFile(outside, '# Outside the pack\n');
+  await symlink(outside, path.join(pack, 'commands', 'escape.md'));
+  await rm(path.join(pack, 'skills', 'inspect-fixture', 'SKILL.md'));
+  await symlink(outside, path.join(pack, 'skills', 'inspect-fixture', 'SKILL.md'));
+  await writeFile(
+    path.join(pack, 'construct.yaml'),
+    MANIFEST.replace('path: commands/inspect-fixture.md', 'path: commands/escape.md'),
+  );
+
+  const info = await inspectLocalConstruct('fixture', root);
+  assert.equal(info.mechanics.commands[0].path_status, 'invalid-path');
+  assert.equal(info.mechanics.commands[0].path, null);
+  assert.equal(info.mechanics.skills[0].metadata_status, 'invalid-path');
+  assert.equal(info.mechanics.skills[0].entry, null);
+});
+
+test('malformed manifest collections fail closed to empty mechanics', async (t) => {
+  const manifest = MANIFEST
+    .replace(/skills:\n(?:  .*\n){2}/, 'skills: malformed\n')
+    .replace(/commands:\n(?:  .*\n){2}/, 'commands: malformed\n');
+  const root = await makePack(manifest);
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const info = await inspectLocalConstruct('fixture', root);
+  assert.deepEqual(info.mechanics.skills, []);
+  assert.deepEqual(info.mechanics.commands, []);
+});
+
+test('skill metadata distinguishes missing from invalid', async (t) => {
+  const missingRoot = await makePack();
+  const invalidRoot = await makePack(MANIFEST, 'not-an-object\n');
+  t.after(() => rm(missingRoot, { recursive: true, force: true }));
+  t.after(() => rm(invalidRoot, { recursive: true, force: true }));
+  await rm(path.join(missingRoot, 'fixture', 'skills', 'inspect-fixture', 'index.yaml'));
+
+  const missing = await inspectLocalConstruct('fixture', missingRoot);
+  const invalid = await inspectLocalConstruct('fixture', invalidRoot);
+  assert.equal(missing.mechanics.skills[0].metadata_status, 'missing');
+  assert.equal(invalid.mechanics.skills[0].metadata_status, 'invalid');
 });
 
 test('a rung without detailed metadata says mechanics are unavailable', async (t) => {

--- a/packages/constructs-cli/test/info.test.mjs
+++ b/packages/constructs-cli/test/info.test.mjs
@@ -121,6 +121,34 @@ test('programmatic info honors an explicit localRoot across listing and inspecti
   assert.equal(result.data.mechanics.skills[0].slug, 'inspect-fixture');
 });
 
+test('legacy string skill declarations resolve through the contained conventional path', async (t) => {
+  const manifest = MANIFEST.replace(
+    '  - slug: inspect-fixture\n    path: skills/inspect-fixture',
+    '  - inspect-fixture',
+  );
+  const root = await makePack(manifest);
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const info = await inspectLocalConstruct('fixture', root);
+  assert.equal(info.mechanics.skills[0].metadata_status, 'declared');
+  assert.equal(info.mechanics.skills[0].path, 'skills/inspect-fixture');
+  assert.equal(info.mechanics.skills[0].entry, 'SKILL.md');
+});
+
+test('unsafe legacy string skill declarations fail before path resolution', async (t) => {
+  const manifest = MANIFEST.replace(
+    '  - slug: inspect-fixture\n    path: skills/inspect-fixture',
+    '  - ../../outside',
+  );
+  const root = await makePack(manifest);
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const info = await inspectLocalConstruct('fixture', root);
+  assert.equal(info.mechanics.skills[0].metadata_status, 'invalid-path');
+  assert.equal(info.mechanics.skills[0].path, null);
+  assert.equal(info.mechanics.skills[0].entry, null);
+});
+
 test('local pack listings do not expose their integrity-checked manifest snapshot', async (t) => {
   const root = await makePack();
   t.after(() => rm(root, { recursive: true, force: true }));

--- a/packages/constructs-cli/test/info.test.mjs
+++ b/packages/constructs-cli/test/info.test.mjs
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { inspectConstruct, inspectLocalConstruct, RUNGS } from '../lib/sot.mjs';
+import { inspectConstruct, inspectLocalConstruct, readLocalPacks, RUNGS } from '../lib/sot.mjs';
 import { validate } from '../lib/vendor/schema-subset.mjs';
 
 const run = promisify(execFile);
@@ -110,6 +110,44 @@ test('programmatic info honors an explicit localRoot across listing and inspecti
   assert.equal(result.data.slug, 'fixture');
   assert.equal(result.data.mechanics.kind, 'declared');
   assert.equal(result.data.mechanics.skills[0].slug, 'inspect-fixture');
+});
+
+test('local pack listings do not expose their integrity-checked manifest snapshot', async (t) => {
+  const root = await makePack();
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const local = await readLocalPacks(root);
+  assert.equal(local.packs.length, 1);
+  assert.equal(JSON.stringify(local.packs[0]).includes('schema_version'), false);
+  assert.deepEqual(Object.keys(local.packs[0]).sort(), [
+    'description',
+    'name',
+    'skills_count',
+    'slug',
+    'source',
+    'version',
+  ]);
+});
+
+test('unknown capability claims invalidate skill mechanics instead of reaching consumers', async (t) => {
+  const index = `${SKILL_INDEX}  authority_effect: full\n`;
+  const root = await makePack(MANIFEST, index);
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const info = await inspectLocalConstruct('fixture', root);
+  assert.equal(info.mechanics.skills[0].metadata_status, 'invalid');
+  assert.equal(info.mechanics.skills[0].entry, null);
+  assert.equal(info.mechanics.skills[0].capabilities, null);
+});
+
+test('malformed capability requirements invalidate skill mechanics', async (t) => {
+  const index = SKILL_INDEX.replace('tool_calling: true', 'tool_calling: write-all');
+  const root = await makePack(MANIFEST, index);
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const info = await inspectLocalConstruct('fixture', root);
+  assert.equal(info.mechanics.skills[0].metadata_status, 'invalid');
+  assert.equal(info.mechanics.skills[0].capabilities, null);
 });
 
 test('a skill metadata path cannot escape the installed pack', async (t) => {
@@ -226,4 +264,28 @@ test('the info schema rejects prose that claims authority', async (t) => {
   const validation = validate(INFO_SCHEMA, payload);
   assert.equal(validation.valid, false);
   assert.match(validation.errors.join('\n'), /authoritative/);
+});
+
+test('the info schema rejects undeclared mechanics and capability fields', async (t) => {
+  const root = await makePack();
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const data = await inspectLocalConstruct('fixture', root);
+  const payload = {
+    data,
+    provenance: {
+      rung: 'local-packs',
+      pinned: true,
+      cache: 'n/a',
+      rungs_consulted: ['local-packs'],
+      vantage: 'operator-local',
+    },
+    drift: [],
+  };
+
+  payload.data.mechanics.permission_grant = 'write-all';
+  payload.data.mechanics.skills[0].capabilities.authority_effect = 'full';
+  const validation = validate(INFO_SCHEMA, payload);
+  assert.equal(validation.valid, false);
+  assert.match(validation.errors.join('\n'), /permission_grant/);
+  assert.match(validation.errors.join('\n'), /authority_effect/);
 });

--- a/packages/constructs-cli/test/info.test.mjs
+++ b/packages/constructs-cli/test/info.test.mjs
@@ -1,0 +1,147 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { inspectLocalConstruct } from '../lib/sot.mjs';
+import { validate } from '../lib/vendor/schema-subset.mjs';
+
+const run = promisify(execFile);
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PKG = path.join(HERE, '..');
+const BIN = path.join(PKG, 'bin', 'constructs.mjs');
+const INFO_SCHEMA = JSON.parse(await readFile(path.join(PKG, 'schemas', 'info.schema.json'), 'utf8'));
+
+const MANIFEST = `schema_version: 3
+name: Fixture
+slug: fixture
+version: 1.2.3
+description: "Prose that helps an operator understand the fixture."
+short_description: "Fixture orientation"
+domain:
+  - observability
+skills:
+  - slug: inspect-fixture
+    path: skills/inspect-fixture
+commands:
+  - name: inspect-fixture
+    path: commands/inspect-fixture.md
+identity:
+  persona: identity/persona.yaml
+  expertise: identity/expertise.yaml
+streams:
+  reads: [Intent]
+  writes: [Signal]
+`;
+
+const SKILL_INDEX = `slug: inspect-fixture
+name: "Inspect Fixture"
+version: 0.1.0
+entry: SKILL.md
+capabilities:
+  model_tier: sonnet
+  danger_level: safe
+  effort_hint: small
+  downgrade_allowed: true
+  execution_hint: sequential
+  requires:
+    native_runtime: false
+    tool_calling: true
+    thinking_traces: false
+    vision: false
+`;
+
+async function makePack(manifest = MANIFEST) {
+  const root = await mkdtemp(path.join(tmpdir(), 'construct-info-'));
+  const pack = path.join(root, 'fixture');
+  await mkdir(path.join(pack, 'skills', 'inspect-fixture'), { recursive: true });
+  await writeFile(path.join(pack, 'construct.yaml'), manifest);
+  await writeFile(path.join(pack, 'skills', 'inspect-fixture', 'index.yaml'), SKILL_INDEX);
+  return root;
+}
+
+test('local info separates prose orientation from declared mechanics', async (t) => {
+  const root = await makePack();
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const info = await inspectLocalConstruct('fixture', root);
+  assert.equal(info.orientation.kind, 'prose');
+  assert.equal(info.orientation.authoritative, false);
+  assert.equal(info.orientation.persona_ref, 'identity/persona.yaml');
+  assert.equal(info.mechanics.kind, 'declared');
+  assert.equal(info.mechanics.authority_effect, 'none');
+  assert.deepEqual(info.mechanics.commands, [
+    { name: 'inspect-fixture', path: 'commands/inspect-fixture.md' },
+  ]);
+  assert.equal(info.mechanics.skills[0].metadata_status, 'declared');
+  assert.equal(info.mechanics.skills[0].capabilities.danger_level, 'safe');
+});
+
+test('info --json --rung local emits the split with pinned provenance', async (t) => {
+  const root = await makePack();
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const { stdout, stderr } = await run(process.execPath, [BIN, 'info', 'fixture', '--json', '--rung', 'local'], {
+    cwd: PKG,
+    env: { ...process.env, CONSTRUCTS_DIR: root, NO_COLOR: '1' },
+  });
+  assert.equal(stderr, '');
+  const payload = JSON.parse(stdout);
+  const validation = validate(INFO_SCHEMA, payload);
+  assert.equal(validation.valid, true, validation.errors.join('\n'));
+  assert.equal(payload.provenance.rung, 'local-packs');
+  assert.equal(payload.provenance.pinned, true);
+  assert.equal(payload.data.orientation.authoritative, false);
+  assert.equal(payload.data.mechanics.skills[0].slug, 'inspect-fixture');
+});
+
+test('a skill metadata path cannot escape the installed pack', async (t) => {
+  const manifest = MANIFEST.replace('path: skills/inspect-fixture', 'path: ../../outside');
+  const root = await makePack(manifest);
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const info = await inspectLocalConstruct('fixture', root);
+  assert.equal(info.mechanics.skills[0].metadata_status, 'invalid-path');
+  assert.equal(info.mechanics.skills[0].capabilities, null);
+});
+
+test('a rung without detailed metadata says mechanics are unavailable', async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), 'construct-info-registry-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeFile(path.join(root, 'registry.yaml'), `constructs:\n  fixture:\n    version: 1.2.3\n    description: "Registry prose"\n`);
+
+  const { stdout } = await run(process.execPath, [BIN, 'info', 'fixture', '--json', '--rung', 'registry'], {
+    cwd: root,
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+  const payload = JSON.parse(stdout);
+  const validation = validate(INFO_SCHEMA, payload);
+  assert.equal(validation.valid, true, validation.errors.join('\n'));
+  assert.equal(payload.data.orientation.authoritative, false);
+  assert.equal(payload.data.mechanics.kind, 'unavailable');
+  assert.match(payload.data.mechanics.reason, /registry-yaml/);
+});
+
+test('the info schema rejects prose that claims authority', async (t) => {
+  const root = await makePack();
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const data = await inspectLocalConstruct('fixture', root);
+  const payload = {
+    data,
+    provenance: {
+      rung: 'local-packs',
+      pinned: true,
+      cache: 'n/a',
+      rungs_consulted: ['local-packs'],
+      vantage: 'operator-local',
+    },
+    drift: [],
+  };
+  payload.data.orientation.authoritative = true;
+  const validation = validate(INFO_SCHEMA, payload);
+  assert.equal(validation.valid, false);
+  assert.match(validation.errors.join('\n'), /authoritative/);
+});

--- a/packages/constructs-cli/test/info.test.mjs
+++ b/packages/constructs-cli/test/info.test.mjs
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { inspectLocalConstruct } from '../lib/sot.mjs';
+import { inspectConstruct, inspectLocalConstruct, RUNGS } from '../lib/sot.mjs';
 import { validate } from '../lib/vendor/schema-subset.mjs';
 
 const run = promisify(execFile);
@@ -99,6 +99,17 @@ test('info --json --rung local emits the split with pinned provenance', async (t
   assert.equal(payload.provenance.pinned, true);
   assert.equal(payload.data.orientation.authoritative, false);
   assert.equal(payload.data.mechanics.skills[0].slug, 'inspect-fixture');
+});
+
+test('programmatic info honors an explicit localRoot across listing and inspection', async (t) => {
+  const root = await makePack();
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const result = await inspectConstruct('fixture', { rung: RUNGS.LOCAL, localRoot: root });
+  assert.equal(result.provenance.rung, RUNGS.LOCAL);
+  assert.equal(result.data.slug, 'fixture');
+  assert.equal(result.data.mechanics.kind, 'declared');
+  assert.equal(result.data.mechanics.skills[0].slug, 'inspect-fixture');
 });
 
 test('a skill metadata path cannot escape the installed pack', async (t) => {

--- a/packages/constructs-cli/test/territory.test.mjs
+++ b/packages/constructs-cli/test/territory.test.mjs
@@ -298,5 +298,6 @@ test('HIGH-4: a permission-denied manifest is a failed source, not an undeclared
 test('MEDIUM-6: the atlas says its ratification honesty out loud', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'atlas-honesty-'));
   const map = await atlas({ sources: [dir] });
+  assert.equal(map.ratification_status, 'unchecked');
   assert.match(map.ratification, /unchecked/);
 });

--- a/packages/constructs-cli/veve.json
+++ b/packages/constructs-cli/veve.json
@@ -79,7 +79,7 @@
       ],
       "stdin": null,
       "expect_exit": 0,
-      "expect_output_hash": "sha256:662bc5c5131bc04194a4de8b88b0949f333366c947e3a73950175ea6ffefd203"
+      "expect_output_hash": "sha256:796efb9ca1452ab867600c3f8ec007a871d9c68c611c910ef1d3a2fe185b8b69"
     },
     {
       "name": "robot-docs-guide (ambient-free: the agent handbook, in-tool)",
@@ -89,7 +89,7 @@
       ],
       "stdin": null,
       "expect_exit": 0,
-      "expect_output_hash": "sha256:294b746abafe80bb6095a02b60977a72a2a4c5b8852cf129e265a1fcf3c59ceb"
+      "expect_output_hash": "sha256:c0f939225512d38cec29e6ec8134ba8ff8ff16684074887bd6b864645c37b2d5"
     },
     {
       "name": "caller-error-unknown-verb (exit 2; stdout stays empty — diagnostics belong on stderr)",

--- a/packages/constructs-cli/veve.json
+++ b/packages/constructs-cli/veve.json
@@ -79,7 +79,7 @@
       ],
       "stdin": null,
       "expect_exit": 0,
-      "expect_output_hash": "sha256:796efb9ca1452ab867600c3f8ec007a871d9c68c611c910ef1d3a2fe185b8b69"
+      "expect_output_hash": "sha256:c646de55087319429ae235a6f6f191c70b995a632a307a34d76be57003b91f40"
     },
     {
       "name": "robot-docs-guide (ambient-free: the agent handbook, in-tool)",
@@ -89,7 +89,7 @@
       ],
       "stdin": null,
       "expect_exit": 0,
-      "expect_output_hash": "sha256:c0f939225512d38cec29e6ec8134ba8ff8ff16684074887bd6b864645c37b2d5"
+      "expect_output_hash": "sha256:9ace3f065196dcf59472af4f3bd355e49da811f49552f4218410ec5d06b44886"
     },
     {
       "name": "caller-error-unknown-verb (exit 2; stdout stays empty — diagnostics belong on stderr)",


### PR DESCRIPTION
## Summary

- add an `info_schema_version: 1.0` payload that separates construct `orientation` from declared `mechanics`
- derive local skills, commands, and per-skill runtime capabilities from producer-owned manifests with path-containment checks
- expose structured atlas `ratification_status` so consumers never parse explanatory prose as state
- document the contract in capabilities, robot docs, migration guidance, and JSON Schema

## Why

An operator needs both a construct's framing and its callable expertise, but those are different claims. Persona and description prose may orient a human or agent; it must not prove a capability or grant authority. Mechanical declarations come from `construct.yaml` and skill `index.yaml` metadata. Effective authority remains the intersection of region territory and earned trust evidence.

This PR builds on #275, which is now merged and provides the zero-dependency Constructs CLI.

## Developer impact

`constructs info <slug> --json --rung local` now returns:

- `orientation`: prose with `authoritative: false`
- `mechanics`: declared skills, commands, and runtime hints with `authority_effect: none`
- existing pinned provenance and drift data

Source rungs without detailed metadata return `mechanics.kind: unavailable` rather than synthesizing a callable surface. Atlas consumers can gate on `ratification_status`; the neighboring sentence remains operator-facing explanation.

## Verification

- `bun run --cwd packages/constructs-cli test:all`
- 176 tests passed
- 7/7 golden vectors passed with byte-deterministic hashes
- local, registry, path-escape, schema, ratification-status, and full existing install/station/authority suites passed

## Reviewer focus

- confirm orientation and mechanics cannot grant authority
- confirm skill metadata cannot escape the installed pack
- confirm unavailable mechanics and unchecked ratification fail closed without hiding useful orientation