### PR TITLE
fix(atlas): verify territory ratification

### DIFF
--- a/packages/constructs-cli/lib/ratification.mjs
+++ b/packages/constructs-cli/lib/ratification.mjs
@@ -1,0 +1,140 @@
+// Read-only territory ratification proof shared by station writes and atlas reads.
+// Tool location is never authority: every fact is resolved from the region root.
+
+import path from 'node:path';
+import { git, run } from './exec.mjs';
+import { EXIT } from './contract.mjs';
+
+export const TERRITORY_MANIFEST_REL = path.join('grimoires', 'territory.yaml');
+
+export class RatificationInspectionError extends Error {
+  constructor(message, exitCode = EXIT.CALLER_ERROR, { fix = null } = {}) {
+    super(message);
+    this.name = 'RatificationInspectionError';
+    this.exitCode = exitCode;
+    this.fix = fix;
+  }
+}
+
+export async function defaultBranch(regionRoot) {
+  const origin = await run('git', ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], {
+    cwd: regionRoot,
+    allowNonZero: true,
+  });
+  if (origin.exitCode === 0) return origin.stdout.trim().replace(/^origin\//, '');
+  for (const name of ['main', 'master']) {
+    const ref = await run('git', ['show-ref', '--verify', '--quiet', `refs/heads/${name}`], {
+      cwd: regionRoot,
+      allowNonZero: true,
+    });
+    if (ref.exitCode === 0) return name;
+  }
+  return null;
+}
+
+export async function gitFacts(regionRoot, manifestRel = TERRITORY_MANIFEST_REL) {
+  const inRepo = await run('git', ['rev-parse', '--is-inside-work-tree'], {
+    cwd: regionRoot,
+    allowNonZero: true,
+  });
+  if (inRepo.exitCode !== 0 || inRepo.stdout.trim() !== 'true') {
+    throw new RatificationInspectionError(
+      `region at ${regionRoot} is not a git repository — a stationing is a committed manifest edit, so there is nothing here to ratify`,
+      EXIT.CALLER_ERROR,
+      { fix: 'run this from inside the region clone' },
+    );
+  }
+
+  const head = await run('git', ['rev-parse', 'HEAD'], { cwd: regionRoot, allowNonZero: true });
+  if (head.exitCode !== 0) {
+    throw new RatificationInspectionError(
+      `region at ${regionRoot} has no commits yet — commit the territory manifest first`,
+      EXIT.CALLER_ERROR,
+    );
+  }
+
+  const branch = await git(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: regionRoot });
+  const resolvedDefaultBranch = await defaultBranch(regionRoot);
+  const tracked = await run('git', ['ls-files', '--error-unmatch', '--', manifestRel], {
+    cwd: regionRoot,
+    allowNonZero: true,
+  });
+  const dirty = await git(['status', '--porcelain', '--', manifestRel], { cwd: regionRoot });
+
+  let anchor = 'local-only';
+  let containedInRemote = null;
+  const originConfigured = await run('git', ['remote', 'get-url', 'origin'], {
+    cwd: regionRoot,
+    allowNonZero: true,
+  });
+  if (originConfigured.exitCode === 0 && resolvedDefaultBranch !== null) {
+    anchor = `origin/${resolvedDefaultBranch}`;
+    const originRef = `refs/remotes/origin/${resolvedDefaultBranch}`;
+    const hasRef = await run('git', ['show-ref', '--verify', '--quiet', originRef], {
+      cwd: regionRoot,
+      allowNonZero: true,
+    });
+    if (hasRef.exitCode === 0) {
+      const contained = await run('git', ['merge-base', '--is-ancestor', 'HEAD', originRef], {
+        cwd: regionRoot,
+        allowNonZero: true,
+      });
+      containedInRemote = contained.exitCode === 0;
+    } else {
+      containedInRemote = false;
+    }
+  }
+
+  return {
+    head: head.stdout.trim(),
+    branch,
+    default_branch: resolvedDefaultBranch,
+    manifest_tracked: tracked.exitCode === 0,
+    manifest_clean: dirty === '',
+    anchor,
+    contained_in_remote: containedInRemote,
+  };
+}
+
+export function ratificationBlockers(facts) {
+  const blockers = [];
+  if (!facts.manifest_tracked) {
+    blockers.push('the territory manifest is not tracked by git — writability is not ratification');
+  } else if (!facts.manifest_clean) {
+    blockers.push('the territory manifest has uncommitted edits — a worktree-only edit is --dry-run territory, not a ratified act');
+  }
+  if (facts.default_branch === null) {
+    blockers.push('the repository default branch cannot be resolved');
+  } else if (facts.branch !== facts.default_branch) {
+    blockers.push(
+      `HEAD is on ${JSON.stringify(facts.branch)}, but ratification means committed on the default branch (${JSON.stringify(facts.default_branch)})`,
+    );
+  }
+  if (facts.contained_in_remote === false) {
+    blockers.push(
+      `HEAD is not contained in origin/${facts.default_branch} (or that ref has never been fetched) — the manifest edit has not verifiably landed on the region remote default branch`,
+    );
+  }
+  return blockers;
+}
+
+export async function inspectRatification(regionRoot = '.') {
+  const facts = await gitFacts(regionRoot);
+  const blockers = ratificationBlockers(facts);
+  const ratified = blockers.length === 0;
+  return {
+    status: ratified ? 'ratified' : 'unchecked',
+    ratification: ratified
+      ? `ratified — clean tracked territory manifest on ${facts.default_branch}, anchored to ${facts.anchor}`
+      : `unchecked — ${blockers.join('; ')}`,
+    blockers,
+    verification: {
+      head: facts.head,
+      branch: facts.branch,
+      default_branch: facts.default_branch,
+      anchor: facts.anchor,
+      contained_in_remote: facts.contained_in_remote,
+    },
+  };
+}
+

--- a/packages/constructs-cli/lib/station.mjs
+++ b/packages/constructs-cli/lib/station.mjs
@@ -18,9 +18,14 @@ import { readFile, writeFile, mkdir, rename, rm, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { readManifest } from './territory.mjs';
-import { git, run } from './exec.mjs';
+import { run } from './exec.mjs';
 import { validate as validateSchema } from './vendor/schema-subset.mjs';
 import { EXIT } from './contract.mjs';
+import {
+  gitFacts as inspectGitFacts,
+  ratificationBlockers,
+  TERRITORY_MANIFEST_REL,
+} from './ratification.mjs';
 
 export class StationError extends Error {
   constructor(message, exitCode = EXIT.REFUSED, { details = [], fix = null } = {}) {
@@ -118,112 +123,13 @@ export function assertMounted(probe, regionRoot) {
 
 // ── git facts ─────────────────────────────────────────────────────────────────
 
-async function defaultBranch(regionRoot) {
-  // The remote's HEAD is the truth when a remote exists.
-  const origin = await run('git', ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], {
-    cwd: regionRoot,
-    allowNonZero: true,
-  });
-  if (origin.exitCode === 0) return origin.stdout.trim().replace(/^origin\//, '');
-  // No remote: main, then master — the documented local fallback.
-  for (const name of ['main', 'master']) {
-    const ref = await run('git', ['show-ref', '--verify', '--quiet', `refs/heads/${name}`], {
-      cwd: regionRoot,
-      allowNonZero: true,
-    });
-    if (ref.exitCode === 0) return name;
-  }
-  return null;
-}
-
-async function gitFacts(regionRoot, manifestRel) {
-  const inRepo = await run('git', ['rev-parse', '--is-inside-work-tree'], { cwd: regionRoot, allowNonZero: true });
-  if (inRepo.exitCode !== 0 || inRepo.stdout.trim() !== 'true') {
-    throw new StationError(
-      `region at ${regionRoot} is not a git repository — a stationing is a COMMITTED manifest edit, so there is nothing here to ratify it`,
-      EXIT.CALLER_ERROR,
-      { fix: 'run this from inside the region\'s clone' }
-    );
-  }
-
-  const head = await run('git', ['rev-parse', 'HEAD'], { cwd: regionRoot, allowNonZero: true });
-  if (head.exitCode !== 0) {
-    throw new StationError(`region at ${regionRoot} has no commits yet — commit the territory manifest first`, EXIT.CALLER_ERROR);
-  }
-
-  const branch = await git(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: regionRoot });
-  const def = await defaultBranch(regionRoot);
-  const tracked = await run('git', ['ls-files', '--error-unmatch', '--', manifestRel], { cwd: regionRoot, allowNonZero: true });
-  const dirty = await git(['status', '--porcelain', '--', manifestRel], { cwd: regionRoot });
-
-  // HIGH-1 (review pass 1): a local commit alone never exercises the region's
-  // git permissions. When an origin remote is CONFIGURED, HEAD must be contained
-  // in the last-fetched origin/<default> for the act to count as ratified —
-  // and a configured origin whose default-branch ref is unfetched FAILS CLOSED
-  // rather than downgrading to local-only (review pass 2). Only a repo with no
-  // origin at all is local-only mode. Containment is judged against the
-  // last-fetched state: a stale ref can only under-approve (conservative),
-  // except across a remote force-push rewrite — that residual is accepted and
-  // named here; live `git ls-remote` verification is the v2 affordance.
-  let anchor = 'local-only';
-  let containedInRemote = null;
-  const originConfigured = await run('git', ['remote', 'get-url', 'origin'], { cwd: regionRoot, allowNonZero: true });
-  if (originConfigured.exitCode === 0 && def !== null) {
-    anchor = `origin/${def}`;
-    const originRef = `refs/remotes/origin/${def}`;
-    const hasRef = await run('git', ['show-ref', '--verify', '--quiet', originRef], { cwd: regionRoot, allowNonZero: true });
-    if (hasRef.exitCode === 0) {
-      const contained = await run('git', ['merge-base', '--is-ancestor', 'HEAD', originRef], { cwd: regionRoot, allowNonZero: true });
-      containedInRemote = contained.exitCode === 0;
-    } else {
-      containedInRemote = false; // configured origin, unverifiable state: fail closed
-    }
-  }
-
-  return {
-    head: head.stdout.trim(),
-    branch,
-    default_branch: def,
-    manifest_tracked: tracked.exitCode === 0,
-    manifest_clean: dirty === '',
-    anchor,
-    contained_in_remote: containedInRemote,
-  };
-}
-
-/**
- * The ratification predicate, in ONE place: every reason this act is not (yet)
- * a committed, remote-landed manifest edit. Empty array = ratified. It is
- * re-run IN FULL immediately before the write (HIGH-2, review pass 1) — a
- * partial recheck is how a same-commit branch switch slips through.
- */
-function ratificationBlockers(facts) {
-  const blockers = [];
-  if (!facts.manifest_tracked) {
-    blockers.push('the territory manifest is not tracked by git — writability is not ratification');
-  } else if (!facts.manifest_clean) {
-    blockers.push('the territory manifest has uncommitted edits — a worktree-only edit is --dry-run territory, not a ratified act');
-  }
-  if (facts.branch !== facts.default_branch) {
-    blockers.push(
-      `HEAD is on ${JSON.stringify(facts.branch)}, but ratification means committed on the default branch (${JSON.stringify(facts.default_branch)})`
-    );
-  }
-  if (facts.contained_in_remote === false) {
-    blockers.push(
-      `HEAD is not contained in origin/${facts.default_branch} (or that ref has never been fetched) — the manifest edit has not verifiably landed on the region's remote default branch. Push or merge it, fetch, then record`
-    );
-  }
-  return blockers;
-}
-
 // ── T2.6 · the authorization snapshot ─────────────────────────────────────────
 //
 // Snapshot the FULL input set at validation — manifest hash, HEAD, resolved default
 // branch, L4 ledger tip — and re-verify ALL of them immediately before the write.
 // Manifest-hash-only rechecking left HEAD/branch/ledger racing (FL-SPRINT HIGH).
 
-const MANIFEST_REL = path.join('grimoires', 'territory.yaml');
+const MANIFEST_REL = TERRITORY_MANIFEST_REL;
 const LEDGER_REL = path.join('.run', 'trust-ledger.jsonl');
 
 export async function snapshotAuthInputs(regionRoot = '.', { manifestRaw = null } = {}) {
@@ -238,7 +144,12 @@ export async function snapshotAuthInputs(regionRoot = '.', { manifestRaw = null 
   } catch {
     // no ledger yet — 'absent' is itself part of the snapshot
   }
-  const facts = await gitFacts(regionRoot, MANIFEST_REL);
+  let facts;
+  try {
+    facts = await inspectGitFacts(regionRoot, MANIFEST_REL);
+  } catch (error) {
+    throw new StationError(error.message, error.exitCode ?? EXIT.CALLER_ERROR, { fix: error.fix ?? null });
+  }
   return {
     manifest_hash: `sha256:${sha256(manifestBytes)}`,
     head: facts.head,

--- a/packages/constructs-cli/lib/territory.mjs
+++ b/packages/constructs-cli/lib/territory.mjs
@@ -17,6 +17,7 @@ import { validate } from './vendor/schema-subset.mjs';
 import { match, overlaps, specificity, GlobError } from './vendor/glob.mjs';
 import { readLocalPacks, packsRoot } from './sot.mjs';
 import { EXIT } from './contract.mjs';
+import { inspectRatification } from './ratification.mjs';
 
 export const ATLAS_VERSION = '1.0';
 export const MAX_SOURCES = 32;
@@ -227,7 +228,26 @@ export async function atlas({ sources = ['.'], timeoutMs = DEFAULT_TIMEOUT_MS } 
         timer = setTimeout(() => reject(new Error(`source timed out after ${timeoutMs}ms`)), timeoutMs);
       });
       try {
-        return { src, manifest: await Promise.race([readManifest(src), deadline]) };
+        const load = async () => {
+          const manifest = await readManifest(src);
+          if (!manifest) return { src, manifest, ratification: null };
+          try {
+            const ratification = await inspectRatification(src);
+            return { src, manifest, ratification };
+          } catch (error) {
+            return {
+              src,
+              manifest,
+              ratification: {
+                status: 'unchecked',
+                ratification: `unchecked — ratification could not be verified: ${error?.message ?? error}`,
+                blockers: [error?.message ?? String(error)],
+                verification: null,
+              },
+            };
+          }
+        };
+        return await Promise.race([load(), deadline]);
       } catch (err) {
         return { src, error: err?.message ?? String(err) };
       } finally {
@@ -241,7 +261,7 @@ export async function atlas({ sources = ['.'], timeoutMs = DEFAULT_TIMEOUT_MS } 
       failed.push({ source: r.src, error: r.error });
       continue;
     }
-    if (r.manifest) regions.push(r.manifest);
+    if (r.manifest) regions.push({ ...r.manifest, _ratification: r.ratification });
   }
 
   const zones = await readZones(sources[0] ?? '.');
@@ -278,8 +298,14 @@ export async function atlas({ sources = ['.'], timeoutMs = DEFAULT_TIMEOUT_MS } 
         }))
         .sort((a, b) => a.construct.localeCompare(b.construct)),
       trust: r.trust ?? null,
+      ratification_status: r._ratification?.status ?? 'unchecked',
+      ratification: r._ratification?.ratification ?? 'unchecked — ratification was not inspected',
+      ratification_verification: r._ratification?.verification ?? null,
     }))
     .sort((a, b) => a.region.localeCompare(b.region));
+
+  const ratified = regionBlocks.length > 0
+    && regionBlocks.every((region) => region.ratification_status === 'ratified');
 
   return {
     atlas_version: ATLAS_VERSION,
@@ -288,12 +314,17 @@ export async function atlas({ sources = ['.'], timeoutMs = DEFAULT_TIMEOUT_MS } 
       'This is this machine\'s honest view of the estate — the same altitude as `loa census`, not a claim of shared truth. Sources are local paths; a source this machine cannot see is reported, never silently omitted.',
     partial: failed.length > 0,
     failed_sources: failed,
-    // Honesty marker (MEDIUM-6, review pass 1): loadout rows here reflect the
-    // WORKING TREE of each source. A stationing is live only when the manifest
-    // edit is committed on the region's default branch — this map does not
-    // verify that, and says so rather than letting a preview pass as ratified.
-    ratification_status: 'unchecked',
-    ratification: 'unchecked — loadout rows reflect the working tree; liveness requires the committed manifest on the region default branch',
+    // The same fail-closed predicate guards station writes and atlas reads.
+    // Tool source and region authority stay separate: each source is inspected
+    // from its own root, and the aggregate is ratified only when every declared
+    // region is clean, tracked, on its default branch, and remotely anchored
+    // whenever an origin is configured.
+    ratification_status: ratified ? 'ratified' : 'unchecked',
+    ratification: ratified
+      ? `ratified — ${regionBlocks.length} declared region manifest(s) passed default-branch verification`
+      : regionBlocks.length === 0
+        ? 'unchecked — no declared region manifest was available to verify'
+        : 'unchecked — one or more declared region manifests did not pass default-branch verification',
     zones: zones.map((z) => ({ name: z.name, tracked_paths: [...z.tracked_paths].sort() })).sort((a, b) => a.name.localeCompare(b.name)),
     regions: regionBlocks,
     conflicts: detectConflicts(regions),

--- a/packages/constructs-cli/test/territory.test.mjs
+++ b/packages/constructs-cli/test/territory.test.mjs
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { validateManifest, detectConflicts, atlas, where, TerritoryError, MAX_SOURCES } from '../lib/territory.mjs';
+import { run } from '../lib/exec.mjs';
 
 const VALID = {
   schema_version: '1.0',
@@ -122,6 +123,23 @@ async function fixtureRegion(name, manifest) {
   await mkdir(path.join(root, 'grimoires'), { recursive: true });
   await writeFile(path.join(root, 'grimoires', 'territory.yaml'), manifest, 'utf8');
   return root;
+}
+
+async function gitIn(dir, args) {
+  const result = await run('git', args, { cwd: dir, allowNonZero: true });
+  if (result.exitCode !== 0) throw new Error(`git ${args.join(' ')} failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+async function commitRegion(root) {
+  await gitIn(root, ['init', '-q']);
+  await gitIn(root, ['symbolic-ref', 'HEAD', 'refs/heads/main']);
+  await gitIn(root, ['add', 'grimoires/territory.yaml']);
+  await gitIn(root, [
+    '-c', 'user.email=fixture@test',
+    '-c', 'user.name=fixture',
+    'commit', '-q', '-m', 'fixture: territory',
+  ]);
 }
 
 test('atlas: is deterministic — the same estate produces byte-identical JSON', async () => {
@@ -300,4 +318,35 @@ test('MEDIUM-6: the atlas says its ratification honesty out loud', async () => {
   const map = await atlas({ sources: [dir] });
   assert.equal(map.ratification_status, 'unchecked');
   assert.match(map.ratification, /unchecked/);
+});
+
+test('atlas ratification uses the station gate against each region root', async () => {
+  const root = await fixtureRegion(
+    'ratified',
+    `schema_version: "1.0"
+region: alpha
+outcomes:
+  - id: one
+    description: the first outcome
+scopes:
+  - apps/**
+loadout: []
+`,
+  );
+  await commitRegion(root);
+  const remote = await mkdtemp(path.join(tmpdir(), 'territory-remote-'));
+  await gitIn(remote, ['init', '--bare', '-q']);
+  await gitIn(root, ['remote', 'add', 'origin', remote]);
+  await gitIn(root, ['push', '-q', '-u', 'origin', 'main']);
+
+  const ratified = await atlas({ sources: [root] });
+  assert.equal(ratified.ratification_status, 'ratified');
+  assert.equal(ratified.regions[0].ratification_status, 'ratified');
+  assert.equal(ratified.regions[0].ratification_verification.anchor, 'origin/main');
+
+  await gitIn(root, ['checkout', '-q', '-b', 'feature/not-ratified']);
+  const feature = await atlas({ sources: [root] });
+  assert.equal(feature.ratification_status, 'unchecked');
+  assert.equal(feature.regions[0].ratification_status, 'unchecked');
+  assert.match(feature.regions[0].ratification, /HEAD is on/);
 });


### PR DESCRIPTION
## Outcome

Makes `constructs atlas` prove territory ratification with the same fail-closed predicate used by `station`, instead of hardcoding every atlas as `unchecked`. This unblocks the Freeside operator surface `--require-ok` gate while keeping each region root as the authority boundary.

## Changes

- extract shared read-only git/default-branch ratification inspection
- preserve the station mutation gate and error contract
- report per-region verification plus an aggregate atlas status
- keep unreadable or unverified sources fail-closed as `unchecked`

## Verification

- `bun run --cwd packages/constructs-cli test:all` — 177/177 tests, 7/7 deterministic vectors
- merged Freeside consumer + this CLI + installed Beacon/The Arcade packs: `render --json --require-ok` — `status: ok`, territory `ratified`

## E2E defect

The merged consumer correctly rejected the prior producer because `atlas()` hardcoded `ratification_status: unchecked`; the success path was unreachable by construction.